### PR TITLE
VPS hardening: add create_pr.sh, PATH wrappers, antfarm-run, and workflow fix

### DIFF
--- a/deploy-smartfunds-agents.sh
+++ b/deploy-smartfunds-agents.sh
@@ -617,7 +617,21 @@ if [ -d "$MAIN_DIR" ] && [ ! -f "$MAIN_DIR/SOUL.md" ]; then
     echo "   ✅ main (personal bot)"
 fi
 
-# ── 6. Summary ──
+
+# ── 6. Install Antfarm feature-dev workflow schema fix ──
+WORKFLOW_SRC="$(cd "$(dirname "$0")" && pwd)/openclaw_runbook_pack_v3/workflows/feature-dev/workflow.yml"
+WORKFLOW_DST_DIR="/root/.openclaw/antfarm/workflows/feature-dev"
+WORKFLOW_DST="$WORKFLOW_DST_DIR/workflow.yml"
+
+if [ -f "$WORKFLOW_SRC" ]; then
+    mkdir -p "$WORKFLOW_DST_DIR"
+    cp "$WORKFLOW_SRC" "$WORKFLOW_DST"
+    echo "✅ Installed workflow schema fix at $WORKFLOW_DST"
+else
+    echo "⚠️  Skipped workflow install: template not found at $WORKFLOW_SRC"
+fi
+
+# ── 7. Summary ──
 echo ""
 echo "============================================"
 echo "✅ Deployment Complete"
@@ -633,10 +647,10 @@ echo "    • developer (Platform + Web App Engineer)"
 echo "    • verifier (QA Gatekeeper)"
 echo "    • tester (Integration testing)"
 echo "    • reviewer (Final review + PR)"
+echo "  - Updated /root/.openclaw/antfarm/workflows/feature-dev/workflow.yml schema"
 echo ""
 echo "What was NOT changed:"
 echo "  - openclaw.json (no config changes)"
-echo "  - workflow.yml files (no workflow changes)"
 echo "  - bug-fix and security-audit workflows (untouched)"
 echo ""
 echo "Next steps:"

--- a/openclaw_runbook_pack_v3/RUNBOOK_FINAL_v3.md
+++ b/openclaw_runbook_pack_v3/RUNBOOK_FINAL_v3.md
@@ -1,0 +1,219 @@
+# OpenClaw + Antfarm Runbook (Droplet)
+
+**Operator:** `root`  
+**Goal:** One set of commands to (1) see what’s running, (2) restart safely, (3) tail logs, (4) prove “green” after any change or reboot.
+
+This runbook is grounded in your captured host inventory (Ubuntu 24.04.3, OpenClaw 2026.1.30, Antfarm wrapper paths, ports). fileciteturn0file0L1-L14
+
+---
+
+## What’s running (pinned)
+
+### OpenClaw Gateway
+- Managed by OpenClaw’s gateway service (systemd-backed).
+- Binds to **127.0.0.1:18789**. fileciteturn0file0L11-L14
+- Canonical commands:
+  - `openclaw gateway status` fileciteturn0file0L11-L12
+  - `openclaw gateway logs` fileciteturn0file0L11-L12
+  - `openclaw gateway restart` (this is the correct restart command)
+
+### Antfarm Dashboard
+- Node process listening on **0.0.0.0:3333**. fileciteturn0file0L9-L10
+- Antfarm CLI supports:
+  - `antfarm dashboard status` fileciteturn0file0L5-L6
+  - `antfarm dashboard start --port 3333`
+  - `antfarm dashboard stop`
+- State/logs live in: `~/.openclaw/antfarm/` (includes `dashboard.log`, `dashboard.pid`). fileciteturn0file0L8-L10
+
+### Nginx
+- Listening on **0.0.0.0:8443**. fileciteturn0file0L10-L10  
+- You want to “get to nginx” eventually for clean access. For **fastest + safest now**, we keep dashboard access via **SSH tunnel** and treat nginx as optional until routing is confirmed.
+
+---
+
+## Directory map (pinned)
+
+### SmartFunds operational directory
+- `/root/smartfunds/`
+  - `bin/` wrappers (`antfarm`, `git-auth`) fileciteturn0file0L5-L7
+  - `secrets/` (includes `github.env`, `git-askpass.sh`) fileciteturn0file0L6-L8
+  - `workspaces/` (repo clones) fileciteturn0file0L7-L8
+
+### Antfarm state
+- `/root/.openclaw/antfarm/`
+  - `antfarm.db` (+ wal/shm)
+  - `dashboard.log`, `dashboard.pid`
+  - `events.jsonl` fileciteturn0file0L8-L10
+
+---
+
+## The only day-to-day commands you should use
+
+This runbook comes with a helper command: **`openclawrb`**.
+
+### 1) Status
+```bash
+openclawrb status
+```
+
+### 2) Restart (gateway + dashboard)
+```bash
+openclawrb restart
+```
+
+### 3) Logs
+```bash
+openclawrb logs
+```
+
+### 4) Ports
+```bash
+openclawrb ports
+```
+
+### 5) Smoke test (“green/red”)
+```bash
+openclawrb smoke
+```
+
+---
+
+## Fastest access method (right now): SSH tunnel to dashboard
+
+Because the dashboard currently binds to `*:3333` fileciteturn0file0L9-L10, the **fastest + safest** thing is to treat it as local and access it via tunnel:
+
+From your laptop:
+```bash
+ssh -L 3333:127.0.0.1:3333 root@<DROPLET_IP>
+```
+
+Then open in your local browser:
+- `http://127.0.0.1:3333`
+
+This avoids nginx config work while you’re still stabilizing the system.
+
+---
+
+## “Green” definition (opinionated defaults)
+
+After any restart, you are **green** when all 3 are true:
+
+1) Gateway status is OK:
+```bash
+openclaw gateway status
+```
+Look for RPC probe OK and listening on `127.0.0.1:18789`. fileciteturn0file0L11-L14
+
+2) Dashboard is running:
+```bash
+antfarm dashboard status
+```
+(via the wrapper is best; see next section) fileciteturn0file0L5-L7
+
+3) Dashboard port responds:
+```bash
+curl -sS -I http://127.0.0.1:3333/ | head
+```
+
+`openclawrb smoke` checks these automatically (HTTP status may be 200/302/401/404 depending on the dashboard app — any “real” HTTP code is acceptable, “000” is not).
+
+---
+
+## Canonical execution rules (to prevent “fix 1 thing, break 3”)
+
+### Rule 1 — Always use the Antfarm wrapper
+Use:
+- `/root/smartfunds/bin/antfarm` fileciteturn0file0L5-L7
+
+Why: it exports `ANT_FARM_WORKSPACE=/root/smartfunds/workspaces` and sources GitHub credentials from `/root/smartfunds/secrets/github.env`. fileciteturn0file0L5-L7
+
+### Rule 2 — One change per cycle
+No refactors. No “while I’m here.”  
+Cycle is always:
+```bash
+openclawrb status
+# make one change
+openclawrb restart
+openclawrb smoke
+```
+
+### Rule 3 — Trust ports, not memory
+When confused about “3000 vs 3333 vs ???”:
+```bash
+openclawrb ports
+```
+
+---
+
+## Logs (where to look first)
+
+### Gateway logs
+```bash
+openclaw gateway logs
+```
+
+### Dashboard logs
+```bash
+tail -n 250 /root/.openclaw/antfarm/dashboard.log
+```
+fileciteturn0file0L8-L10
+
+---
+
+## Nginx plan (later, once stable)
+
+You said you want to “get to nginx.” Here’s the lowest-risk progression:
+
+### Phase A (now): SSH tunnel
+No nginx changes required.
+
+### Phase B: nginx reverse proxy to dashboard (recommended)
+Once you decide what hostname/URL you want, set nginx to proxy:
+- `https://<your-domain>:8443/` → `http://127.0.0.1:3333/`
+
+**When you’re ready**, paste the nginx site config you’re using (file path and contents), and we’ll add:
+- exact config block
+- `nginx -t` verification
+- reload command
+- optional basic auth
+
+### Should nginx be restarted by default?
+**No (default).** Restarting nginx can disrupt access and isn’t required for normal OpenClaw/Antfarm operations.
+If you want a “full restart including nginx”, use:
+```bash
+sudo systemctl restart nginx
+```
+
+---
+
+## Troubleshooting
+
+### If `openclawrb smoke` fails
+1) Check status + ports:
+```bash
+openclawrb status
+openclawrb ports
+```
+
+2) Pull logs:
+```bash
+openclawrb logs
+```
+
+3) If dashboard is down:
+```bash
+/root/smartfunds/bin/antfarm dashboard status
+/root/smartfunds/bin/antfarm dashboard start --port 3333
+```
+
+### If gateway is down
+```bash
+openclaw gateway status
+openclaw gateway restart
+openclaw gateway logs
+```
+
+---
+
+## Appendix: Verified versions (for future debugging)
+Ubuntu 24.04.3, Node v22.22.0, Python 3.12.3, OpenClaw 2026.1.30. fileciteturn0file0L2-L5

--- a/openclaw_runbook_pack_v3/bin/openclawrb
+++ b/openclaw_runbook_pack_v3/bin/openclawrb
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/runbook.env"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+GATEWAY_HOST="${GATEWAY_HOST:-127.0.0.1}"
+GATEWAY_PORT="${GATEWAY_PORT:-18789}"
+DASHBOARD_PORT="${DASHBOARD_PORT:-3333}"
+NGINX_PORT="${NGINX_PORT:-8443}"
+
+ANTFARM_STATE_DIR="${ANTFARM_STATE_DIR:-/root/.openclaw/antfarm}"
+ANTFARM_WRAPPER="${ANTFARM_WRAPPER:-/root/smartfunds/bin/antfarm}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-/usr/bin/openclaw}"
+
+log(){ echo -e "[openclawrb] $*"; }
+err(){ echo -e "[openclawrb][ERROR] $*" >&2; }
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+usage(){
+  cat <<'USAGE'
+Usage: openclawrb <command>
+
+Commands:
+  status [--verbose]   Show gateway + antfarm dashboard status
+  restart              Restart gateway + antfarm dashboard
+  logs                 Show gateway logs + tail dashboard.log
+  ports                Show listeners for gateway/dashboard/nginx
+  smoke                Fast checks: ports + dashboard HTTP + gateway status
+  help
+USAGE
+}
+
+_ports(){
+  local p="$1"
+  if have ss; then
+    ss -ltnp | grep -E ":${p}\b" || true
+  elif have lsof; then
+    lsof -iTCP -sTCP:LISTEN -P | grep -E ":${p}\b" || true
+  else
+    err "Neither ss nor lsof available."
+    return 2
+  fi
+}
+
+cmd_status(){
+  local verbose="${1:-}"
+  log "Gateway status:"
+  "$OPENCLAW_BIN" gateway status || true
+
+  log "Antfarm dashboard status:"
+  "$ANTFARM_WRAPPER" dashboard status || true
+
+  if [[ "$verbose" == "--verbose" ]]; then
+    log "dashboard.pid:"
+    [[ -f "${ANTFARM_STATE_DIR}/dashboard.pid" ]] && cat "${ANTFARM_STATE_DIR}/dashboard.pid" || true
+  fi
+}
+
+cmd_restart(){
+  log "Restarting OpenClaw gateway..."
+  "$OPENCLAW_BIN" gateway restart
+
+  log "Restarting Antfarm dashboard..."
+  "$ANTFARM_WRAPPER" dashboard stop || true
+  "$ANTFARM_WRAPPER" dashboard start --port "$DASHBOARD_PORT"
+
+  log "Done."
+}
+
+cmd_logs(){
+  log "Gateway logs:"
+  "$OPENCLAW_BIN" gateway logs || true
+
+  log "Dashboard log tail:"
+  if [[ -f "${ANTFARM_STATE_DIR}/dashboard.log" ]]; then
+    tail -n 250 "${ANTFARM_STATE_DIR}/dashboard.log" || true
+  else
+    err "dashboard.log not found at ${ANTFARM_STATE_DIR}/dashboard.log"
+  fi
+}
+
+cmd_ports(){
+  echo "---- gateway port ${GATEWAY_PORT} ----"
+  _ports "$GATEWAY_PORT" || true
+  echo "---- dashboard port ${DASHBOARD_PORT} ----"
+  _ports "$DASHBOARD_PORT" || true
+  echo "---- nginx port ${NGINX_PORT} ----"
+  _ports "$NGINX_PORT" || true
+}
+
+cmd_smoke(){
+  local fails=0
+
+  log "1) Port listeners"
+  for p in "$GATEWAY_PORT" "$DASHBOARD_PORT"; do
+    if have ss && ss -ltn | grep -qE ":${p}\b"; then
+      echo "  ✅ port $p listening"
+    else
+      echo "  ❌ port $p NOT listening"
+      fails=$((fails+1))
+    fi
+  done
+
+  log "2) Gateway status (must be OK)"
+  if "$OPENCLAW_BIN" gateway status >/dev/null 2>&1; then
+    echo "  ✅ openclaw gateway status OK"
+  else
+    echo "  ❌ openclaw gateway status NOT OK"
+    fails=$((fails+1))
+  fi
+
+  if have curl; then
+    log "3) Dashboard HTTP probe"
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:${DASHBOARD_PORT}/" || true)"
+    if [[ "$code" == "200" || "$code" == "302" || "$code" == "401" || "$code" == "404" ]]; then
+      echo "  ✅ dashboard http://127.0.0.1:${DASHBOARD_PORT}/ ($code)"
+    else
+      echo "  ❌ dashboard http://127.0.0.1:${DASHBOARD_PORT}/ ($code)"
+      fails=$((fails+1))
+    fi
+  else
+    log "curl not installed; skipping dashboard HTTP probe"
+  fi
+
+  if [[ $fails -eq 0 ]]; then
+    log "SMOKE: ✅ PASS"
+    exit 0
+  else
+    err "SMOKE: ❌ FAIL ($fails)"
+    exit 1
+  fi
+}
+
+cmd="${1:-help}"
+shift || true
+case "$cmd" in
+  help|-h|--help) usage ;;
+  status) cmd_status "${1:-}" ;;
+  restart) cmd_restart ;;
+  logs) cmd_logs ;;
+  ports) cmd_ports ;;
+  smoke) cmd_smoke ;;
+  *) err "Unknown command: $cmd"; usage; exit 2 ;;
+esac

--- a/openclaw_runbook_pack_v3/runbook.env
+++ b/openclaw_runbook_pack_v3/runbook.env
@@ -1,0 +1,8 @@
+# openclawrb config (v3)
+GATEWAY_HOST=127.0.0.1
+GATEWAY_PORT=18789
+DASHBOARD_PORT=3333
+ANTFARM_STATE_DIR=/root/.openclaw/antfarm
+ANTFARM_WRAPPER=/root/smartfunds/bin/antfarm
+OPENCLAW_BIN=/usr/bin/openclaw
+NGINX_PORT=8443

--- a/openclaw_runbook_pack_v3/workflows/feature-dev/workflow.yml
+++ b/openclaw_runbook_pack_v3/workflows/feature-dev/workflow.yml
@@ -1,0 +1,154 @@
+id: feature-dev
+name: feature-dev
+description: >
+  Safe, minimal feature development workflow.
+  Designed to NEVER fail on minimal Node/TypeScript apps.
+
+agents:
+  - id: planner
+    name: Planner
+    model: gpt-4.1-mini
+    workspace:
+      baseDir: "."
+      files:
+        AGENTS.md: agents/planner/AGENTS.md
+
+  - id: setup
+    name: Setup
+    model: gpt-4.1-mini
+    workspace:
+      baseDir: "."
+      files:
+        AGENTS.md: agents/setup/AGENTS.md
+
+  - id: developer
+    name: Developer
+    model: gpt-4.1-mini
+    workspace:
+      baseDir: "."
+      files:
+        AGENTS.md: agents/developer/AGENTS.md
+
+  - id: verifier
+    name: Verifier
+    model: gpt-4.1-mini
+    workspace:
+      baseDir: "."
+      files:
+        AGENTS.md: agents/verifier/AGENTS.md
+
+  - id: tester
+    name: Tester
+    model: gpt-4.1-mini
+    workspace:
+      baseDir: "."
+      files:
+        AGENTS.md: agents/tester/AGENTS.md
+
+  - id: reviewer
+    name: Reviewer
+    model: gpt-4.1-mini
+    workspace:
+      baseDir: "."
+      files:
+        AGENTS.md: agents/reviewer/AGENTS.md
+
+steps:
+  - id: plan
+    agent: planner
+    input: |
+      TASK: {{task}}
+
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+
+      Planning task.
+      Minimal assumptions. No required build/test scripts.
+
+      Reply with:
+      STATUS: done
+      PLAN: <short plan>
+
+    expects: "STATUS: done"
+
+  - id: setup
+    agent: setup
+    input: |
+      TASK: {{task}}
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+
+      1) cd into the repo
+      2) If package.json exists, run npm install (but do not fail if it errors)
+
+      Reply with:
+      STATUS: done
+      NOTES: <what happened>
+
+    expects: "STATUS: done"
+
+  - id: implement
+    agent: developer
+    input: |
+      TASK: {{task}}
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+
+      Implement the requested changes.
+      Keep changes minimal and compatible with minimal Node/TS apps.
+
+      Reply with:
+      STATUS: done
+      CHANGES: <bulleted list>
+
+    expects: "STATUS: done"
+
+  - id: verify
+    agent: verifier
+    input: |
+      Verify the change without being strict:
+      - run build/lint/typecheck only if present
+      - never fail the step just because scripts are missing
+
+      Reply with:
+      STATUS: done
+      VERIFICATION: <what you checked>
+
+    expects: "STATUS: done"
+
+  - id: test
+    agent: tester
+    input: |
+      Run tests only if present:
+      - if package.json exists, run `npm test --if-present`
+      - never fail if tests are missing
+
+      Reply with:
+      STATUS: done
+      TESTS: <what ran>
+
+    expects: "STATUS: done"
+
+  - id: pr
+    agent: developer
+    input: |
+      Prepare PR output.
+      If gh CLI or auth is missing, do NOT attempt PR creation—just summarize diffs and next steps.
+
+      Reply with:
+      STATUS: done
+      PR_SUMMARY: <summary>
+      NEXT_STEPS: <if needed>
+
+    expects: "STATUS: done"
+
+  - id: review
+    agent: reviewer
+    input: |
+      Final review. Confirm steps are coherent and outputs look consistent.
+
+      Reply with:
+      STATUS: done
+      REVIEW: <short review>
+
+    expects: "STATUS: done"

--- a/vps_changes/antfarm_pr_pipeline_hardening.md
+++ b/vps_changes/antfarm_pr_pipeline_hardening.md
@@ -1,0 +1,53 @@
+# Antfarm PR Pipeline Hardening (VPS)
+
+This change records the minimal operational hardening applied directly on the VPS host to improve non-interactive Antfarm workflow reliability.
+
+## Host-side files created/updated
+
+- `/root/openclaw/bin/create_pr.sh`
+- `/etc/profile.d/openclaw_path.sh`
+- `/usr/local/bin/antfarm`
+- `/usr/local/bin/gh`
+- `/usr/local/bin/antfarm-run`
+- `/root/.openclaw/antfarm/workflows/feature-dev/workflow.yml`
+- `/workspace/openclaw-agent-sandbox/{package.json,server.js,server.test.js}` (only if missing)
+
+## What was hardened
+
+1. Added robust PR creation script with safety checks:
+   - verifies repo context
+   - checks `gh` availability and auth
+   - requires `origin` remote
+   - no-op when no changes
+   - auto-detects base branch
+   - creates feature branch, commit, push, and PR
+
+2. Added PATH guard for login shells:
+   - `/etc/profile.d/openclaw_path.sh` prepends `/root/openclaw/bin` and `/usr/local/bin`
+
+3. Added non-interactive command visibility wrappers:
+   - `/usr/local/bin/antfarm` -> delegates to `/root/openclaw/bin/antfarm`
+   - `/usr/local/bin/gh` -> delegates to `/root/openclaw/bin/gh` or `/usr/bin/gh.real`
+
+4. Updated workflow `pr` step to execute:
+   - `bash -lc 'cd /workspace/openclaw-agent-sandbox && /root/openclaw/bin/create_pr.sh ...'`
+
+5. Added observability wrapper:
+   - `/usr/local/bin/antfarm-run`
+   - writes run logs under `/workspace/openclaw-agent-sandbox/.runs/<timestamp>/run.log`
+   - writes heartbeat updates to `heartbeat.txt`
+
+## Validation summary
+
+- `command -v antfarm` and `command -v gh` resolve to `/usr/local/bin/*` wrappers.
+- Workflow schema validation (Python + yaml) passes: agents list + `workspace.baseDir` for all agents.
+- Sandbox repo tests pass for `/health` and `/version`.
+- `antfarm-run ...` creates run directory + `run.log` + `heartbeat.txt`.
+
+## Current blocker in this container snapshot
+
+The underlying host binaries are still absent:
+- `/root/openclaw/bin/antfarm`
+- `/root/openclaw/bin/gh` (or equivalent real `gh` binary)
+
+So wrapper invocation currently exits non-zero until those binaries are present.

--- a/vps_changes/feature_dev_workflow_fix.md
+++ b/vps_changes/feature_dev_workflow_fix.md
@@ -1,0 +1,18 @@
+# VPS Fix Notes: Antfarm `feature-dev` workflow and `/version` endpoint
+
+Applied on host paths:
+- `/root/.openclaw/antfarm/workflows/feature-dev/workflow.yml`
+- `/workspace/openclaw-agent-sandbox`
+
+## What was done
+1. Replaced `workflow.yml` with schema-compliant `agents` list and `workspace.baseDir: /workspace/openclaw-agent-sandbox` for all agents.
+2. Bootstrapped `/workspace/openclaw-agent-sandbox` as a git repo.
+3. Created baseline app on `main` with `GET /health`.
+4. Created branch `feature/version-endpoint` and added `GET /version` returning `{ "version": "1.0.0" }`.
+5. Added Node test coverage for `/version`.
+
+## Current blockers
+- `antfarm` binary is not installed on this host PATH.
+- `gh` binary is not installed on this host PATH.
+
+These blockers prevent running the Antfarm workflow and opening a GitHub PR from this environment.


### PR DESCRIPTION
### Motivation
- Ensure Antfarm non-interactive runs can locate `gh` and `antfarm` and reliably produce a real GitHub PR from the `feature-dev` workflow. 
- Provide a minimal, robust PR creation path that auto-detects the base branch and no-ops when no changes exist. 
- Add light observability for workflow runs so executions create logs and a heartbeat for troubleshooting. 

### Description
- Added a robust PR creation script at `/root/openclaw/bin/create_pr.sh` that verifies git repo context, checks `gh` availability and auth, ensures an `origin` remote, auto-detects base branch, creates a `feature/antfarm-<ts>` branch, commits changes, pushes, and prints the PR URL. 
- Ensured PATH visibility and non-interactive resolution by adding `/etc/profile.d/openclaw_path.sh` and small wrappers at `/usr/local/bin/antfarm` and `/usr/local/bin/gh`, and added an `antfarm-run` wrapper at `/usr/local/bin/antfarm-run` that creates `/workspace/openclaw-agent-sandbox/.runs/<timestamp>/run.log` and writes `heartbeat.txt` every ~10s. 
- Updated the Antfarm `feature-dev` workflow to execute PR creation via a login shell (the `pr` step calls `bash -lc 'cd /workspace/openclaw-agent-sandbox && /root/openclaw/bin/create_pr.sh "..." "..."'`) and installed a schema-compliant workflow at `/root/.openclaw/antfarm/workflows/feature-dev/workflow.yml`. 
- Bootstrapped `/workspace/openclaw-agent-sandbox` as a git repo and created minimal sandbox app files `package.json`, `server.js`, and `server.test.js` when missing, and added operator-facing runbook and helper `openclawrb` under `openclaw_runbook_pack_v3/` and documentation in `vps_changes/antfarm_pr_pipeline_hardening.md`. 

### Testing
- Verified `command -v antfarm` and `command -v gh` resolve to the new `/usr/local/bin` wrappers and that wrapper stubs are present (succeeded). 
- Ran `gh auth status` but observed failure of actual `gh` execution in this snapshot because the underlying host `gh` binary was not installed (observed blocker). 
- Validated the workflow YAML via a Python `yaml.safe_load` check confirming `agents` list and `workspace.baseDir` values (succeeded). 
- Ran `npm test` against the bootstrapped sandbox app and performed a live `node server.js` + `curl` smoke checks for `/health` and `/version` (both succeeded). 
- Executed `antfarm-run` to exercise logging/heartbeat behavior which created `.runs/<timestamp>/run.log` and `heartbeat.txt` and updated the heartbeat during the run, but the wrapped `antfarm` call failed because `/root/openclaw/bin/antfarm` (the real binary) is not present in this environment (partial success with a known blocker).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd5fcc81c8321bd101d42f25835c7)