### PR TITLE
ops: add repo-local path helpers and wrapper scripts

### DIFF
--- a/ops/templates/bin/cdsf
+++ b/ops/templates/bin/cdsf
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /srv/repos/smartfunds-agent-sandbox
+pwd
+git status --short

--- a/ops/templates/openclaw_paths.sh
+++ b/ops/templates/openclaw_paths.sh
@@ -1,0 +1,5 @@
+# SmartFunds canonical repo helpers
+export SMARTFUNDS_REPO="/srv/repos/smartfunds-agent-sandbox"
+cdsf() {
+  cd "${SMARTFUNDS_REPO}"
+}


### PR DESCRIPTION
Adds canonical repo-local PATH helpers and cdsf wrapper script
to align VPS environment with SmartFunds runbook.

No functional application changes.
