### PR TITLE
feat(doc-factory): add 506(c) doc-factory package and API assembly endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
+    "@smartfunds/doc-factory": "0.1.0",
     "@smartfunds/mission-engine": "0.1.0",
     "@smartfunds/shared": "0.1.0",
     "hono": "^4.6.10"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,14 +1,47 @@
 import { Hono } from "hono";
 import { InvalidTransitionError, MissionNotFoundError, createMission, getMission, getMissionAuditLog, listMissions, transitionMission } from "@smartfunds/mission-engine";
 import { MissionStatus } from "@smartfunds/shared";
+import {
+  MissingDealInputsError,
+  assembleDocuments,
+  getSqliteDocFactoryStore,
+  listTemplates,
+  seedDefaultTemplates
+} from "@smartfunds/doc-factory";
 
 const app = new Hono();
+const docFactoryStore = getSqliteDocFactoryStore();
+
+let templatesSeeded = false;
+
+function ensureTemplatesSeeded(): void {
+  if (!templatesSeeded) {
+    seedDefaultTemplates(docFactoryStore);
+    templatesSeeded = true;
+  }
+}
 
 function isMissionStatus(value: string): value is MissionStatus {
   return Object.values(MissionStatus).includes(value as MissionStatus);
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
 app.get("/health", (c) => c.json({ status: "ok" }));
+
+app.get("/templates", (c) => {
+  ensureTemplatesSeeded();
+
+  const typeParam = c.req.query("type");
+  if (typeParam && typeParam !== "base" && typeParam !== "asset_module") {
+    return c.json({ error: "Invalid type filter" }, 400);
+  }
+
+  const templates = listTemplates(docFactoryStore, typeParam ? { type: typeParam } : undefined);
+  return c.json(templates, 200);
+});
 
 app.post("/missions", async (c) => {
   const body = await c.req.json();
@@ -22,7 +55,7 @@ app.post("/missions", async (c) => {
     });
     return c.json(mission, 201);
   } catch (error) {
-    return c.json({ error: (error as Error).message }, 400);
+    return c.json({ error: getErrorMessage(error) }, 400);
   }
 });
 
@@ -74,7 +107,7 @@ app.post("/missions/:id/transition", async (c) => {
       );
     }
 
-    return c.json({ error: (error as Error).message }, 400);
+    return c.json({ error: getErrorMessage(error) }, 400);
   }
 });
 
@@ -93,7 +126,53 @@ app.get("/missions/:id/audit", (c) => {
       );
     }
 
-    return c.json({ error: (error as Error).message }, 400);
+    return c.json({ error: getErrorMessage(error) }, 400);
+  }
+});
+
+app.post("/missions/:id/assemble", async (c) => {
+  ensureTemplatesSeeded();
+
+  const missionId = c.req.param("id");
+  const mission = getMission(missionId);
+
+  if (!mission) {
+    return c.json({ error: "Mission not found" }, 404);
+  }
+
+  if (mission.status !== MissionStatus.LEGAL_STRUCTURING) {
+    return c.json({ error: "Mission must be in LEGAL_STRUCTURING to assemble documents" }, 409);
+  }
+
+  const body = await c.req.json();
+  const moduleTemplateId = (body as { module_template_id?: string }).module_template_id;
+  const dealInputs = (body as { deal_inputs?: Record<string, string | number> }).deal_inputs;
+
+  if (typeof moduleTemplateId !== "string" || moduleTemplateId.trim().length === 0) {
+    return c.json({ error: "module_template_id is required" }, 400);
+  }
+
+  if (!dealInputs || typeof dealInputs !== "object" || Array.isArray(dealInputs)) {
+    return c.json({ error: "deal_inputs is required" }, 400);
+  }
+
+  try {
+    const result = assembleDocuments({
+      store: docFactoryStore,
+      mission_id: missionId,
+      base_template_id: (body as { base_template_id?: string }).base_template_id,
+      base_template_version: (body as { base_template_version?: string }).base_template_version,
+      module_template_id: moduleTemplateId,
+      module_template_version: (body as { module_template_version?: string }).module_template_version,
+      deal_inputs: dealInputs
+    });
+    return c.json(result, 200);
+  } catch (error) {
+    if (error instanceof MissingDealInputsError) {
+      return c.json({ error: error.message, missing_keys: error.missing_keys }, 400);
+    }
+
+    return c.json({ error: getErrorMessage(error) }, 400);
   }
 });
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,9 +5,18 @@
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "references": [
-    { "path": "../../packages/shared" },
-    { "path": "../../packages/mission-engine" }
+    {
+      "path": "../../packages/shared"
+    },
+    {
+      "path": "../../packages/mission-engine"
+    },
+    {
+      "path": "../../packages/doc-factory"
+    }
   ]
 }

--- a/packages/doc-factory/__tests__/doc-factory.test.ts
+++ b/packages/doc-factory/__tests__/doc-factory.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+import { assembleDocuments, getLatestAssemblyResult } from "../src/assembler.js";
+import { MissingDealInputsError } from "../src/errors.js";
+import { sha256 } from "../src/hash.js";
+import { getTemplate, listTemplates, seedDefaultTemplates } from "../src/registry.js";
+import { createFakeDocFactoryStore } from "../src/store.js";
+
+const CREATED_AT = "2026-01-01T00:00:00.000Z";
+
+function createSeededStore() {
+  const store = createFakeDocFactoryStore();
+  seedDefaultTemplates(store, CREATED_AT);
+  return store;
+}
+
+function buildDealInputs() {
+  return {
+    offering_name: "Fund A",
+    issuer_name: "SmartFunds Issuer LLC",
+    target_raise: 1000000,
+    jurisdiction: "US",
+    minimum_investment: 10000,
+    offering_period: "90 days",
+    artwork_description: "Oil painting",
+    artist_name: "A. Artist",
+    provenance_summary: "Single owner",
+    valuation_method: "Appraisal"
+  };
+}
+
+describe("doc factory", () => {
+  test("T-L1 template lookup returns latest and content_hash matches template_body hash", () => {
+    const store = createSeededStore();
+    const template = getTemplate(store, "base_506c");
+
+    expect(template).not.toBeNull();
+    expect(template?.content_hash).toBe(sha256(template?.template_body ?? ""));
+  });
+
+  test("T-L2 deterministic assembly hashes remain stable across two runs", () => {
+    const store = createSeededStore();
+    const payload = {
+      store,
+      mission_id: "mission-1",
+      module_template_id: "art_module",
+      deal_inputs: buildDealInputs(),
+      created_at: CREATED_AT
+    };
+
+    const first = assembleDocuments(payload);
+    const second = assembleDocuments(payload);
+
+    expect(first.content_hash).toBe(second.content_hash);
+    expect(first.document_set).toEqual(second.document_set);
+  });
+
+  test("T-L3 signature matrix correctness", () => {
+    const store = createSeededStore();
+    const result = assembleDocuments({
+      store,
+      mission_id: "mission-2",
+      module_template_id: "art_module",
+      deal_inputs: buildDealInputs(),
+      created_at: CREATED_AT
+    });
+
+    expect(result.signature_matrix).toEqual([
+      { document_name: "Subscription Agreement", required_signers: ["ISSUER", "INVESTOR"] },
+      { document_name: "Private Placement Memorandum", required_signers: ["INVESTOR"] },
+      { document_name: "Operating Agreement", required_signers: ["ISSUER"] },
+      { document_name: "Accredited Investor Questionnaire", required_signers: ["INVESTOR"] }
+    ]);
+  });
+
+  test("T-L4 template_versions_used includes base and module templates", () => {
+    const store = createSeededStore();
+    const result = assembleDocuments({
+      store,
+      mission_id: "mission-3",
+      module_template_id: "art_module",
+      deal_inputs: buildDealInputs(),
+      created_at: CREATED_AT
+    });
+
+    expect(result.template_versions_used).toHaveLength(2);
+    expect(result.template_versions_used.map((template) => template.id).sort()).toEqual(["art_module", "base_506c"]);
+  });
+
+  test("guardrail MissingDealInputsError returns sorted missing keys", () => {
+    const store = createSeededStore();
+
+    expect(() => {
+      assembleDocuments({
+        store,
+        mission_id: "mission-4",
+        module_template_id: "art_module",
+        deal_inputs: {
+          offering_name: "Fund A"
+        },
+        created_at: CREATED_AT
+      });
+    }).toThrowError(MissingDealInputsError);
+
+    try {
+      assembleDocuments({
+        store,
+        mission_id: "mission-4",
+        module_template_id: "art_module",
+        deal_inputs: {
+          offering_name: "Fund A"
+        },
+        created_at: CREATED_AT
+      });
+    } catch (error) {
+      const typedError = error as MissingDealInputsError;
+      expect(typedError.missing_keys).toEqual([...typedError.missing_keys].sort());
+    }
+  });
+
+  test("guardrail artifact persistence returns latest assembly result", () => {
+    const store = createSeededStore();
+
+    assembleDocuments({
+      store,
+      mission_id: "mission-5",
+      module_template_id: "art_module",
+      deal_inputs: buildDealInputs(),
+      created_at: "2026-01-01T00:00:00.000Z"
+    });
+
+    const newer = assembleDocuments({
+      store,
+      mission_id: "mission-5",
+      module_template_id: "art_module",
+      deal_inputs: {
+        ...buildDealInputs(),
+        offering_name: "Fund B"
+      },
+      created_at: "2026-01-01T00:00:01.000Z"
+    });
+
+    expect(getLatestAssemblyResult(store, "mission-5")).toEqual(newer);
+  });
+
+  test("guardrail listTemplates type filtering", () => {
+    const store = createSeededStore();
+
+    expect(listTemplates(store, { type: "base" }).map((template) => template.id)).toEqual(["base_506c"]);
+    expect(listTemplates(store, { type: "asset_module" }).map((template) => template.id)).toEqual([
+      "art_module",
+      "generic_spv_module",
+      "mineral_royalty_module"
+    ]);
+  });
+});

--- a/packages/doc-factory/__tests__/sqlite.integration.test.ts
+++ b/packages/doc-factory/__tests__/sqlite.integration.test.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+import { assembleDocuments } from "../src/assembler.js";
+import { seedDefaultTemplates } from "../src/registry.js";
+import { getSqliteDocFactoryStore } from "../src/store.js";
+
+const runSqlite = process.env.RUN_SQLITE_INTEGRATION === "1";
+
+const maybeDescribe = runSqlite ? describe : describe.skip;
+
+maybeDescribe("doc-factory sqlite integration", () => {
+  test("persists and assembles using sqlite store", () => {
+    const dbPath = `/tmp/smartfunds-doc-factory-${randomUUID()}.db`;
+
+    try {
+      const store = getSqliteDocFactoryStore(dbPath);
+      seedDefaultTemplates(store, "2026-01-01T00:00:00.000Z");
+
+      const result = assembleDocuments({
+        store,
+        mission_id: "mission-integration",
+        module_template_id: "generic_spv_module",
+        deal_inputs: {
+          offering_name: "Fund A",
+          issuer_name: "Issuer",
+          target_raise: 123,
+          jurisdiction: "US",
+          minimum_investment: 10,
+          offering_period: "30 days",
+          asset_description: "Asset",
+          asset_valuation: "500000"
+        },
+        created_at: "2026-01-01T00:00:00.000Z"
+      });
+
+      expect(result.document_set).toHaveLength(4);
+    } finally {
+      rmSync(dbPath, { force: true });
+    }
+  });
+});

--- a/packages/doc-factory/package.json
+++ b/packages/doc-factory/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@smartfunds/doc-factory",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@smartfunds/shared": "0.1.0"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/doc-factory/src/assembler.ts
+++ b/packages/doc-factory/src/assembler.ts
@@ -1,0 +1,169 @@
+import { buildMissionArtifact, DocFactoryStore } from "./store.js";
+import { MissingDealInputsError } from "./errors.js";
+import { getTemplate, Template } from "./registry.js";
+import { sha256, stableStringify } from "./hash.js";
+
+export type DealInputs = Record<string, string | number>;
+
+export interface TemplateVersionUsed {
+  id: string;
+  version: string;
+  content_hash: string;
+}
+
+export interface AssembledDocument {
+  name: "Subscription Agreement" | "Private Placement Memorandum" | "Operating Agreement" | "Accredited Investor Questionnaire";
+  audience: "ISSUER" | "INVESTOR";
+  content_hash: string;
+}
+
+export interface SignatureRequirement {
+  document_name: AssembledDocument["name"];
+  required_signers: Array<"ISSUER" | "INVESTOR">;
+}
+
+export interface EnforcementRequirement {
+  gate: "ACCREDITATION_GATE" | "SIGNATURE_GATE";
+  stage: "PRE_SUBSCRIPTION";
+}
+
+export interface AssemblyResult {
+  mission_id: string;
+  base_template_id: string;
+  module_template_id: string;
+  document_set: AssembledDocument[];
+  template_versions_used: TemplateVersionUsed[];
+  signature_matrix: SignatureRequirement[];
+  enforcement_requirements: EnforcementRequirement[];
+  content_hash: string;
+  created_at: string;
+}
+
+const ASSEMBLY_ARTIFACT_TYPE = "DOCUMENT_ASSEMBLY_RESULT";
+
+export function assembleDocuments(input: {
+  store: DocFactoryStore;
+  mission_id: string;
+  base_template_id?: string;
+  base_template_version?: string;
+  module_template_id: string;
+  module_template_version?: string;
+  deal_inputs: DealInputs;
+  created_at?: string;
+}): AssemblyResult {
+  const baseTemplate = mustGetTemplate(input.store, input.base_template_id ?? "base_506c", input.base_template_version);
+  const moduleTemplate = mustGetTemplate(input.store, input.module_template_id, input.module_template_version);
+
+  validateDealInputs(baseTemplate, moduleTemplate, input.deal_inputs);
+
+  const template_versions_used: TemplateVersionUsed[] = [
+    toTemplateVersion(baseTemplate),
+    toTemplateVersion(moduleTemplate)
+  ];
+
+  const documentBlueprint: Array<Pick<AssembledDocument, "name" | "audience">> = [
+    { name: "Subscription Agreement", audience: "ISSUER" },
+    { name: "Private Placement Memorandum", audience: "INVESTOR" },
+    { name: "Operating Agreement", audience: "ISSUER" },
+    { name: "Accredited Investor Questionnaire", audience: "INVESTOR" }
+  ];
+
+  const document_set: AssembledDocument[] = documentBlueprint.map((document) => ({
+    ...document,
+    content_hash: buildDocumentHash(document.name, template_versions_used, input.deal_inputs)
+  }));
+
+  const signature_matrix: SignatureRequirement[] = [
+    { document_name: "Subscription Agreement", required_signers: ["ISSUER", "INVESTOR"] },
+    { document_name: "Private Placement Memorandum", required_signers: ["INVESTOR"] },
+    { document_name: "Operating Agreement", required_signers: ["ISSUER"] },
+    { document_name: "Accredited Investor Questionnaire", required_signers: ["INVESTOR"] }
+  ];
+
+  const enforcement_requirements: EnforcementRequirement[] = [
+    { gate: "ACCREDITATION_GATE", stage: "PRE_SUBSCRIPTION" },
+    { gate: "SIGNATURE_GATE", stage: "PRE_SUBSCRIPTION" }
+  ];
+
+  const created_at = input.created_at ?? new Date().toISOString();
+  const artifactLike = {
+    mission_id: input.mission_id,
+    base_template_id: baseTemplate.id,
+    module_template_id: moduleTemplate.id,
+    document_set,
+    template_versions_used,
+    signature_matrix,
+    enforcement_requirements,
+    created_at
+  };
+
+  const content_hash = sha256(stableStringify(artifactLike));
+  const assemblyResult: AssemblyResult = {
+    ...artifactLike,
+    content_hash
+  };
+
+  input.store.insertMissionArtifact(
+    buildMissionArtifact(input.mission_id, ASSEMBLY_ARTIFACT_TYPE, stableStringify(assemblyResult), content_hash, created_at)
+  );
+
+  return assemblyResult;
+}
+
+export function getLatestAssemblyResult(store: DocFactoryStore, mission_id: string): AssemblyResult | null {
+  const artifacts = store.listMissionArtifacts(mission_id, ASSEMBLY_ARTIFACT_TYPE);
+  if (artifacts.length === 0) {
+    return null;
+  }
+
+  const [latest] = [...artifacts].sort((left, right) => {
+    if (left.created_at === right.created_at) {
+      return left.id.localeCompare(right.id);
+    }
+    return left.created_at.localeCompare(right.created_at);
+  }).slice(-1);
+
+  return JSON.parse(latest.artifact_data) as AssemblyResult;
+}
+
+function validateDealInputs(baseTemplate: Template, moduleTemplate: Template, dealInputs: DealInputs): void {
+  const required = new Set([...baseTemplate.placeholders, ...moduleTemplate.placeholders]);
+  const missing = [...required].filter((key) => !Object.hasOwn(dealInputs, key));
+
+  if (missing.length > 0) {
+    throw new MissingDealInputsError(missing);
+  }
+}
+
+function buildDocumentHash(
+  documentName: AssembledDocument["name"],
+  templateVersionsUsed: TemplateVersionUsed[],
+  dealInputs: DealInputs
+): string {
+  const templateRefs = templateVersionsUsed
+    .map((templateVersion) => `${templateVersion.id}@${templateVersion.version}:${templateVersion.content_hash}`)
+    .sort();
+
+  const dealInputLines = Object.keys(dealInputs)
+    .sort()
+    .map((key) => `${key}=${String(dealInputs[key])}`);
+
+  return sha256([documentName, ...templateRefs, ...dealInputLines].join("\n"));
+}
+
+function mustGetTemplate(store: DocFactoryStore, id: string, version?: string): Template {
+  const template = getTemplate(store, id, version);
+  if (!template) {
+    throw new Error(`Template not found: ${id}${version ? `@${version}` : ""}`);
+  }
+
+  return template;
+}
+
+function toTemplateVersion(template: Template): TemplateVersionUsed {
+  return {
+    id: template.id,
+    version: template.version,
+    content_hash: template.content_hash
+  };
+}

--- a/packages/doc-factory/src/errors.ts
+++ b/packages/doc-factory/src/errors.ts
@@ -1,0 +1,10 @@
+export class MissingDealInputsError extends Error {
+  readonly missing_keys: string[];
+
+  constructor(missingKeys: string[]) {
+    const sortedKeys = [...missingKeys].sort();
+    super(`Missing required deal inputs: ${sortedKeys.join(", ")}`);
+    this.name = "MissingDealInputsError";
+    this.missing_keys = sortedKeys;
+  }
+}

--- a/packages/doc-factory/src/hash.ts
+++ b/packages/doc-factory/src/hash.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+
+function normalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalize(entry));
+  }
+
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const keys = Object.keys(source).sort();
+    const result: Record<string, unknown> = {};
+
+    for (const key of keys) {
+      result[key] = normalize(source[key]);
+    }
+
+    return result;
+  }
+
+  return value;
+}
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(normalize(value));
+}
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/packages/doc-factory/src/index.ts
+++ b/packages/doc-factory/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./store.js";
+export * from "./registry.js";
+export * from "./assembler.js";
+export * from "./errors.js";
+export * from "./hash.js";

--- a/packages/doc-factory/src/node-shims.d.ts
+++ b/packages/doc-factory/src/node-shims.d.ts
@@ -1,0 +1,33 @@
+declare module "node:crypto" {
+  export function randomUUID(): string;
+  export function createHash(algorithm: string): {
+    update(value: string): { digest(encoding: "hex"): string };
+    digest(encoding: "hex"): string;
+  };
+}
+
+declare module "node:module" {
+  export function createRequire(url: string): (id: string) => unknown;
+}
+
+declare module "node:sqlite" {
+  export class StatementSync {
+    run(...params: unknown[]): void;
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  }
+
+  export class DatabaseSync {
+    constructor(path: string);
+    exec(sql: string): void;
+    prepare(sql: string): StatementSync;
+  }
+}
+
+declare module "node:fs" {
+  export function rmSync(path: string, opts?: { force?: boolean }): void;
+}
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};

--- a/packages/doc-factory/src/registry.ts
+++ b/packages/doc-factory/src/registry.ts
@@ -1,0 +1,124 @@
+import { sha256 } from "./hash.js";
+import { DocFactoryStore, TemplateRecord, TemplateType } from "./store.js";
+
+export interface Template {
+  id: string;
+  name: string;
+  type: TemplateType;
+  version: string;
+  exemption_type: "506C";
+  placeholders: string[];
+  content_hash: string;
+  created_at: string;
+  template_body: string;
+}
+
+const DEFAULT_TEMPLATES: Array<Omit<Template, "content_hash" | "created_at">> = [
+  {
+    id: "base_506c",
+    name: "Base 506(c) Offering",
+    type: "base",
+    version: "1.0.0",
+    exemption_type: "506C",
+    placeholders: ["offering_name", "issuer_name", "target_raise", "jurisdiction", "minimum_investment", "offering_period"],
+    template_body:
+      "Offering {{offering_name}} by {{issuer_name}} targets {{target_raise}} in {{jurisdiction}} with minimum {{minimum_investment}} over {{offering_period}}."
+  },
+  {
+    id: "art_module",
+    name: "Art Asset Module",
+    type: "asset_module",
+    version: "1.0.0",
+    exemption_type: "506C",
+    placeholders: ["artwork_description", "artist_name", "provenance_summary", "valuation_method"],
+    template_body:
+      "Art module: {{artwork_description}} by {{artist_name}} with provenance {{provenance_summary}} valued via {{valuation_method}}."
+  },
+  {
+    id: "mineral_royalty_module",
+    name: "Mineral Royalty Module",
+    type: "asset_module",
+    version: "1.0.0",
+    exemption_type: "506C",
+    placeholders: ["mineral_type", "property_description", "royalty_percentage", "estimated_reserves"],
+    template_body:
+      "Mineral module: {{mineral_type}} at {{property_description}} royalty {{royalty_percentage}} reserves {{estimated_reserves}}."
+  },
+  {
+    id: "generic_spv_module",
+    name: "Generic SPV Module",
+    type: "asset_module",
+    version: "1.0.0",
+    exemption_type: "506C",
+    placeholders: ["asset_description", "asset_valuation"],
+    template_body: "SPV module: {{asset_description}} valued at {{asset_valuation}}."
+  }
+];
+
+function toTemplate(record: TemplateRecord): Template {
+  return { ...record, placeholders: [...record.placeholders] };
+}
+
+function compareSemver(a: string, b: string): number {
+  const aParts = a.split(".").map((part) => Number.parseInt(part, 10));
+  const bParts = b.split(".").map((part) => Number.parseInt(part, 10));
+
+  for (let index = 0; index < 3; index += 1) {
+    const delta = (aParts[index] ?? 0) - (bParts[index] ?? 0);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+
+  return 0;
+}
+
+export function seedDefaultTemplates(store: DocFactoryStore, createdAt?: string): Template[] {
+  const timestamp = createdAt ?? new Date().toISOString();
+  const seeded: Template[] = [];
+
+  for (const template of DEFAULT_TEMPLATES) {
+    const nextTemplate: Template = {
+      ...template,
+      placeholders: [...template.placeholders],
+      created_at: timestamp,
+      content_hash: sha256(template.template_body)
+    };
+
+    store.upsertTemplate(nextTemplate);
+    seeded.push(nextTemplate);
+  }
+
+  return seeded;
+}
+
+export function getTemplate(store: DocFactoryStore, id: string, version?: string): Template | null {
+  if (version) {
+    const found = store.getTemplate(id, version);
+    return found ? toTemplate(found) : null;
+  }
+
+  const versions = store.listTemplateVersions(id);
+  if (versions.length === 0) {
+    return null;
+  }
+
+  const [latest] = [...versions].sort((left, right) => compareSemver(right.version, left.version));
+  return toTemplate(latest);
+}
+
+export function listTemplates(store: DocFactoryStore, opts?: { type?: TemplateType }): Template[] {
+  const all = store.listTemplates().filter((template) => (opts?.type ? template.type === opts.type : true));
+  const latestById = new Map<string, TemplateRecord>();
+
+  for (const template of all) {
+    const existing = latestById.get(template.id);
+    if (!existing || compareSemver(template.version, existing.version) > 0) {
+      latestById.set(template.id, template);
+    }
+  }
+
+  return [...latestById.values()]
+    .map(toTemplate)
+    .sort((left, right) => left.id.localeCompare(right.id));
+}

--- a/packages/doc-factory/src/store.ts
+++ b/packages/doc-factory/src/store.ts
@@ -1,0 +1,221 @@
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+type NodeSqliteModule = typeof import("node:sqlite");
+type DatabaseSyncInstance = InstanceType<NodeSqliteModule["DatabaseSync"]>;
+
+function loadNodeSqlite(): NodeSqliteModule {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-var-requires
+  return require("node:sqlite") as NodeSqliteModule;
+}
+
+export type TemplateType = "base" | "asset_module";
+
+export interface TemplateRecord {
+  id: string;
+  version: string;
+  name: string;
+  type: TemplateType;
+  exemption_type: "506C";
+  placeholders: string[];
+  template_body: string;
+  content_hash: string;
+  created_at: string;
+}
+
+export interface MissionArtifactRecord {
+  id: string;
+  mission_id: string;
+  artifact_type: string;
+  artifact_data: string;
+  content_hash: string;
+  created_at: string;
+}
+
+export interface DocFactoryStore {
+  upsertTemplate(template: TemplateRecord): void;
+  getTemplate(id: string, version: string): TemplateRecord | null;
+  listTemplateVersions(id: string): TemplateRecord[];
+  listTemplates(): TemplateRecord[];
+  insertMissionArtifact(artifact: MissionArtifactRecord): void;
+  listMissionArtifacts(mission_id: string, artifact_type: string): MissionArtifactRecord[];
+}
+
+export function createFakeDocFactoryStore(): DocFactoryStore {
+  const templates = new Map<string, TemplateRecord>();
+  const artifacts = new Map<string, MissionArtifactRecord>();
+
+  return {
+    upsertTemplate(template) {
+      templates.set(`${template.id}::${template.version}`, { ...template, placeholders: [...template.placeholders] });
+    },
+    getTemplate(id, version) {
+      const found = templates.get(`${id}::${version}`);
+      return found ? { ...found, placeholders: [...found.placeholders] } : null;
+    },
+    listTemplateVersions(id) {
+      return [...templates.values()]
+        .filter((template) => template.id === id)
+        .map((template) => ({ ...template, placeholders: [...template.placeholders] }));
+    },
+    listTemplates() {
+      return [...templates.values()].map((template) => ({ ...template, placeholders: [...template.placeholders] }));
+    },
+    insertMissionArtifact(artifact) {
+      artifacts.set(artifact.id, { ...artifact });
+    },
+    listMissionArtifacts(mission_id, artifact_type) {
+      return [...artifacts.values()]
+        .filter((artifact) => artifact.mission_id === mission_id && artifact.artifact_type === artifact_type)
+        .map((artifact) => ({ ...artifact }));
+    }
+  };
+}
+
+const DEFAULT_DB_PATH = "./smartfunds.db";
+const sqliteStoreRegistry = new Map<string, DocFactoryStore>();
+
+export function getSqliteDocFactoryStore(dbPath?: string): DocFactoryStore {
+  const resolvedPath = dbPath ?? process.env.SMARTFUNDS_DB_PATH ?? DEFAULT_DB_PATH;
+  const existing = sqliteStoreRegistry.get(resolvedPath);
+
+  if (existing) {
+    return existing;
+  }
+
+  const { DatabaseSync } = loadNodeSqlite();
+  const db = new DatabaseSync(resolvedPath);
+  const store = createSqliteDocFactoryStore(db);
+  sqliteStoreRegistry.set(resolvedPath, store);
+  return store;
+}
+
+export function createSqliteDocFactoryStore(db: DatabaseSyncInstance): DocFactoryStore {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS templates(
+      id TEXT NOT NULL,
+      version TEXT NOT NULL,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL CHECK(type IN ('base','asset_module')),
+      exemption_type TEXT NOT NULL CHECK(exemption_type='506C'),
+      placeholders TEXT NOT NULL,
+      template_body TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (id, version)
+    );
+
+    CREATE TABLE IF NOT EXISTS mission_artifacts(
+      id TEXT PRIMARY KEY,
+      mission_id TEXT NOT NULL,
+      artifact_type TEXT NOT NULL,
+      artifact_data TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+
+  return {
+    upsertTemplate(template) {
+      db.prepare(`
+        INSERT INTO templates (id, version, name, type, exemption_type, placeholders, template_body, content_hash, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id, version) DO UPDATE SET
+          name = excluded.name,
+          type = excluded.type,
+          exemption_type = excluded.exemption_type,
+          placeholders = excluded.placeholders,
+          template_body = excluded.template_body,
+          content_hash = excluded.content_hash,
+          created_at = excluded.created_at
+      `).run(
+        template.id,
+        template.version,
+        template.name,
+        template.type,
+        template.exemption_type,
+        JSON.stringify(template.placeholders),
+        template.template_body,
+        template.content_hash,
+        template.created_at
+      );
+    },
+    getTemplate(id, version) {
+      const row = db.prepare("SELECT * FROM templates WHERE id = ? AND version = ?").get(id, version) as
+        | Record<string, unknown>
+        | undefined;
+      return row ? rowToTemplate(row) : null;
+    },
+    listTemplateVersions(id) {
+      const rows = db.prepare("SELECT * FROM templates WHERE id = ?").all(id) as Record<string, unknown>[];
+      return rows.map(rowToTemplate);
+    },
+    listTemplates() {
+      const rows = db.prepare("SELECT * FROM templates").all() as Record<string, unknown>[];
+      return rows.map(rowToTemplate);
+    },
+    insertMissionArtifact(artifact) {
+      db.prepare(`
+        INSERT INTO mission_artifacts (id, mission_id, artifact_type, artifact_data, content_hash, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(
+        artifact.id,
+        artifact.mission_id,
+        artifact.artifact_type,
+        artifact.artifact_data,
+        artifact.content_hash,
+        artifact.created_at
+      );
+    },
+    listMissionArtifacts(mission_id, artifact_type) {
+      const rows = db
+        .prepare("SELECT * FROM mission_artifacts WHERE mission_id = ? AND artifact_type = ? ORDER BY created_at ASC, id ASC")
+        .all(mission_id, artifact_type) as Record<string, unknown>[];
+      return rows.map(rowToArtifact);
+    }
+  };
+}
+
+function rowToTemplate(row: Record<string, unknown>): TemplateRecord {
+  return {
+    id: row.id as string,
+    version: row.version as string,
+    name: row.name as string,
+    type: row.type as TemplateType,
+    exemption_type: row.exemption_type as "506C",
+    placeholders: JSON.parse(row.placeholders as string) as string[],
+    template_body: row.template_body as string,
+    content_hash: row.content_hash as string,
+    created_at: row.created_at as string
+  };
+}
+
+function rowToArtifact(row: Record<string, unknown>): MissionArtifactRecord {
+  return {
+    id: row.id as string,
+    mission_id: row.mission_id as string,
+    artifact_type: row.artifact_type as string,
+    artifact_data: row.artifact_data as string,
+    content_hash: row.content_hash as string,
+    created_at: row.created_at as string
+  };
+}
+
+export function buildMissionArtifact(
+  mission_id: string,
+  artifact_type: string,
+  artifact_data: string,
+  content_hash: string,
+  created_at: string
+): MissionArtifactRecord {
+  return {
+    id: randomUUID(),
+    mission_id,
+    artifact_type,
+    artifact_data,
+    content_hash,
+    created_at
+  };
+}

--- a/packages/doc-factory/tsconfig.json
+++ b/packages/doc-factory/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,17 @@
 {
   "files": [],
   "references": [
-    { "path": "packages/shared" },
-    { "path": "packages/mission-engine" },
-    { "path": "apps/api" }
+    {
+      "path": "packages/shared"
+    },
+    {
+      "path": "packages/mission-engine"
+    },
+    {
+      "path": "packages/doc-factory"
+    },
+    {
+      "path": "apps/api"
+    }
   ]
 }


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable document assembly engine for Phase 1 (506(c) only) to produce legal documents and persist assembly artifacts. 
- Expose a minimal API surface to list seeded templates and assemble mission documents during the `LEGAL_STRUCTURING` stage. 
- Keep the runtime storage boundary flexible with a hermetic fake store for tests and a runtime SQLite-backed store for deployment.

### Description
- Added a new workspace package `packages/doc-factory` implementing stable hashing (`stableStringify`, `sha256`), a seeded template registry, an assembler that builds a deterministic 4-document set, signature matrix and enforcement requirements, and `MissingDealInputsError` guardrail. 
- Implemented a store boundary with `createFakeDocFactoryStore()` for tests and `getSqliteDocFactoryStore()` / `createSqliteDocFactoryStore()` for SQLite-backed persistence and mission artifact storage. 
- Seeded default 506(c) templates (`base_506c`, `art_module`, `mineral_royalty_module`, `generic_spv_module`) with semver-aware latest-selection and type-filtered listing (`listTemplates`). 
- Wired API routes in `apps/api/src/index.ts`: `GET /templates?type=base|asset_module` and `POST /missions/:id/assemble` with mission existence check, `LEGAL_STRUCTURING` status gate, request validation, and mapping of `MissingDealInputsError` to `400`. 
- Updated project references and `apps/api/package.json` to include the new package and added unit tests under `packages/doc-factory/__tests__` (including a gated SQLite integration test).

### Testing
- Ran `npm test --workspace @smartfunds/doc-factory`; unit test suite passed with `7 passed` and the SQLite integration test was skipped by default. 
- Built `@smartfunds/doc-factory` with `npm run build --workspace @smartfunds/doc-factory` successfully. 
- Root-level `npm test` / monorepo build failed due to a pre-existing `packages/mission-engine` test config issue (`packages/mission-engine/vitest.config.ts` missing), which is unrelated to the `doc-factory` changes; the `doc-factory` package tests remain green. 
- The SQLite integration test is gated by `RUN_SQLITE_INTEGRATION=1` and is skipped in default CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962cc24ae88321b530bb506220e8ae)