### PR TITLE
Sprint 11 — Bootstrap required GitHub governance labels (idempotent)

### DIFF
--- a/control-plane/bootstrap-labels.test.ts
+++ b/control-plane/bootstrap-labels.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureLabels } from './bootstrap-labels';
+
+type MockResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+function mockResponse(payload: unknown, ok = true, status = 200): MockResponse {
+  return {
+    ok,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload)
+  };
+}
+
+describe('bootstrap-labels', () => {
+  it('creates missing labels', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(mockResponse([]))
+      .mockResolvedValue(mockResponse({}));
+
+    const summary = await ensureLabels({
+      repo: 'owner/repo',
+      token: 'token',
+      yes: true,
+      requiredLabels: [
+        { name: 'tier-0', color: 'ededed', description: 'Cosmetic / docs-only' },
+        { name: 'tier-1', color: '0e8a16', description: 'Low risk change' }
+      ],
+      fetchImpl: fetchMock as unknown as typeof fetch
+    });
+
+    expect(summary.created).toEqual(['tier-0', 'tier-1']);
+    expect(summary.updated).toEqual([]);
+    expect(summary.unchanged).toEqual([]);
+
+    const methods = fetchMock.mock.calls.map((call) => call[1]?.method ?? 'GET');
+    expect(methods).toEqual(['GET', 'POST', 'POST']);
+  });
+
+  it('updates existing labels when color or description differ', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse([
+          { name: 'tier-0', color: 'ffffff', description: 'Old description' },
+          { name: 'tier-1', color: '0e8a16', description: 'Low risk change' }
+        ])
+      )
+      .mockResolvedValue(mockResponse({}));
+
+    const summary = await ensureLabels({
+      repo: 'owner/repo',
+      token: 'token',
+      yes: true,
+      requiredLabels: [
+        { name: 'tier-0', color: 'ededed', description: 'Cosmetic / docs-only' },
+        { name: 'tier-1', color: '0e8a16', description: 'Low risk change' }
+      ],
+      fetchImpl: fetchMock as unknown as typeof fetch
+    });
+
+    expect(summary.created).toEqual([]);
+    expect(summary.updated).toEqual(['tier-0']);
+    expect(summary.unchanged).toEqual(['tier-1']);
+
+    const methods = fetchMock.mock.calls.map((call) => call[1]?.method ?? 'GET');
+    expect(methods).toEqual(['GET', 'PATCH']);
+  });
+
+  it('does not mutate labels during dry-run', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      mockResponse([
+        { name: 'tier-0', color: 'ffffff', description: 'Old description' },
+        { name: 'tier-1', color: '0e8a16', description: 'Low risk change' }
+      ])
+    );
+
+    const summary = await ensureLabels({
+      repo: 'owner/repo',
+      token: 'token',
+      yes: true,
+      dryRun: true,
+      requiredLabels: [
+        { name: 'tier-0', color: 'ededed', description: 'Cosmetic / docs-only' },
+        { name: 'tier-1', color: '0e8a16', description: 'Low risk change' }
+      ],
+      fetchImpl: fetchMock as unknown as typeof fetch
+    });
+
+    expect(summary.created).toEqual([]);
+    expect(summary.updated).toEqual(['tier-0']);
+    expect(summary.unchanged).toEqual(['tier-1']);
+
+    const methods = fetchMock.mock.calls.map((call) => call[1]?.method ?? 'GET');
+    expect(methods).toEqual(['GET']);
+  });
+});

--- a/control-plane/bootstrap-labels.ts
+++ b/control-plane/bootstrap-labels.ts
@@ -1,0 +1,293 @@
+import { createInterface } from 'node:readline';
+import { stdin as input, stdout as output } from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+type LabelSpec = {
+  name: string;
+  color: string;
+  description: string;
+};
+
+type ExistingLabel = {
+  name: string;
+  color: string;
+  description: string | null;
+};
+
+type Summary = {
+  created: string[];
+  updated: string[];
+  unchanged: string[];
+};
+
+type EnsureOptions = {
+  repo?: string;
+  token?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+  fetchImpl?: typeof fetch;
+  requiredLabels?: LabelSpec[];
+};
+
+class ExitError extends Error {
+  exitCode: number;
+
+  constructor(message: string, exitCode: number) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+const DEFAULT_REQUIRED_LABELS: LabelSpec[] = [
+  { name: 'tier-0', color: 'ededed', description: 'Cosmetic / docs-only' },
+  { name: 'tier-1', color: '0e8a16', description: 'Low risk change' },
+  { name: 'tier-2', color: 'fbca04', description: 'Medium risk change' },
+  { name: 'tier-3', color: 'b60205', description: 'High risk / control-plane' },
+  { name: 'tier-3-approved', color: '5319e7', description: 'Tier 3 approval recorded' },
+  { name: 'codex', color: '1d76db', description: 'Codex-assisted change' }
+];
+
+const DEFAULT_PER_PAGE = 100;
+
+function normalizeColor(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function normalizeDescription(value: string | null | undefined): string {
+  return (value ?? '').trim();
+}
+
+function parseRepo(value: string): { owner: string; repo: string } {
+  const [owner, repo] = value.split('/');
+  if (!owner || !repo) {
+    throw new Error(`Invalid repo value: ${value}. Expected owner/name.`);
+  }
+  return { owner, repo };
+}
+
+function parseArgs(argv: string[]): { repo?: string; dryRun: boolean; yes: boolean } {
+  let repo: string | undefined;
+  let dryRun = false;
+  let yes = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (arg === '--yes') {
+      yes = true;
+      continue;
+    }
+    if (arg === '--repo') {
+      repo = argv[index + 1];
+      if (!repo) {
+        throw new Error('Missing value for --repo.');
+      }
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--repo=')) {
+      repo = arg.slice('--repo='.length);
+      if (!repo) {
+        throw new Error('Missing value for --repo.');
+      }
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { repo, dryRun, yes };
+}
+
+async function requestJson<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  token: string,
+  options: RequestInit
+): Promise<T> {
+  const response = await fetchImpl(url, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...options.headers
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API error ${response.status}: ${body}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function listLabels(
+  fetchImpl: typeof fetch,
+  owner: string,
+  repo: string,
+  token: string
+): Promise<ExistingLabel[]> {
+  const labels: ExistingLabel[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/labels?per_page=${DEFAULT_PER_PAGE}&page=${page}`;
+    const pageLabels = await requestJson<ExistingLabel[]>(fetchImpl, url, token, { method: 'GET' });
+    labels.push(...pageLabels);
+    if (pageLabels.length < DEFAULT_PER_PAGE) {
+      break;
+    }
+    page += 1;
+  }
+
+  return labels;
+}
+
+async function createLabel(
+  fetchImpl: typeof fetch,
+  owner: string,
+  repo: string,
+  token: string,
+  label: LabelSpec
+): Promise<void> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/labels`;
+  await requestJson(fetchImpl, url, token, {
+    method: 'POST',
+    body: JSON.stringify({
+      name: label.name,
+      color: label.color,
+      description: label.description
+    })
+  });
+}
+
+async function updateLabel(
+  fetchImpl: typeof fetch,
+  owner: string,
+  repo: string,
+  token: string,
+  label: LabelSpec
+): Promise<void> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/labels/${encodeURIComponent(label.name)}`;
+  await requestJson(fetchImpl, url, token, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      name: label.name,
+      color: label.color,
+      description: label.description
+    })
+  });
+}
+
+function needsUpdate(existing: ExistingLabel, desired: LabelSpec): boolean {
+  return (
+    normalizeColor(existing.color) !== normalizeColor(desired.color) ||
+    normalizeDescription(existing.description) !== normalizeDescription(desired.description)
+  );
+}
+
+async function confirmProceed(message: string): Promise<boolean> {
+  const rl = createInterface({ input, output });
+  const answer: string = await new Promise((resolve) => {
+    rl.question(message, (value) => resolve(value.trim()));
+  });
+  rl.close();
+
+  return ['y', 'yes'].includes(answer.toLowerCase());
+}
+
+export async function ensureLabels(options: EnsureOptions): Promise<Summary> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const requiredLabels = options.requiredLabels ?? DEFAULT_REQUIRED_LABELS;
+  const repoValue = options.repo ?? process.env.GITHUB_REPOSITORY;
+  const token = options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const dryRun = options.dryRun ?? false;
+  const yes = options.yes ?? false;
+
+  if (!token) {
+    throw new ExitError('Missing GITHUB_TOKEN or GH_TOKEN environment variable.', 2);
+  }
+  if (!repoValue) {
+    throw new Error('Missing --repo and GITHUB_REPOSITORY is not set.');
+  }
+
+  const { owner, repo } = parseRepo(repoValue);
+
+  if (!dryRun && !yes) {
+    const confirmed = await confirmProceed(
+      `This will update labels in ${owner}/${repo}. Continue? (y/N): `
+    );
+    if (!confirmed) {
+      return { created: [], updated: [], unchanged: [] };
+    }
+  }
+
+  const existingLabels = await listLabels(fetchImpl, owner, repo, token);
+  const existingByName = new Map(existingLabels.map((label) => [label.name, label]));
+
+  const summary: Summary = { created: [], updated: [], unchanged: [] };
+  const toCreate: LabelSpec[] = [];
+  const toUpdate: LabelSpec[] = [];
+
+  for (const label of requiredLabels) {
+    const existing = existingByName.get(label.name);
+    if (!existing) {
+      summary.created.push(label.name);
+      toCreate.push(label);
+      continue;
+    }
+    if (needsUpdate(existing, label)) {
+      summary.updated.push(label.name);
+      toUpdate.push(label);
+    } else {
+      summary.unchanged.push(label.name);
+    }
+  }
+
+  if (!dryRun) {
+    for (const label of toCreate) {
+      await createLabel(fetchImpl, owner, repo, token, label);
+    }
+    for (const label of toUpdate) {
+      await updateLabel(fetchImpl, owner, repo, token, label);
+    }
+  }
+
+  return summary;
+}
+
+function printSummary(summary: Summary, dryRun: boolean): void {
+  const prefix = dryRun ? 'dry-run: ' : '';
+  const formatList = (values: string[]) => (values.length === 0 ? 'none' : values.join(', '));
+  output.write(`${prefix}created: ${formatList(summary.created)}\n`);
+  output.write(`${prefix}updated: ${formatList(summary.updated)}\n`);
+  output.write(`${prefix}unchanged: ${formatList(summary.unchanged)}\n`);
+}
+
+async function main(): Promise<void> {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const summary = await ensureLabels({
+      repo: args.repo,
+      dryRun: args.dryRun,
+      yes: args.yes
+    });
+    printSummary(summary, args.dryRun);
+  } catch (error) {
+    const exitError = error instanceof ExitError ? error : undefined;
+    const message = error instanceof Error ? error.message : String(error);
+    output.write(`${message}\n`);
+    process.exitCode = exitError?.exitCode ?? 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}
+
+export const REQUIRED_LABELS = DEFAULT_REQUIRED_LABELS;
+export const parseCliArgs = parseArgs;

--- a/docs/code-factory-governance.md
+++ b/docs/code-factory-governance.md
@@ -25,6 +25,10 @@ CI fails if the PR body evidence tier differs from the tier label. Update the PR
 
 GitHub Actions re-runs may use stale PR payload data for labels/body. If governance checks still show old labels/body after edits, push a new commit to refresh what CI reads.
 
+## Label bootstrap
+
+If a required label is missing (for example `tier-3`), run the label bootstrap runbook to create or update labels before re-running governance checks. See `docs/runbooks/label-bootstrap.md`.
+
 ## Required Evidence block format
 
 Every PR body must include this fenced block exactly:
@@ -88,5 +92,4 @@ Determinism Statement: Pure parser/inference logic with mocked PR payload data.
 5. Confirm declared tier is not lower than changed-path tier from `control-plane/risk-contract.json`.
 6. Run relevant tests/type checks and include what you ran in `Tests Added`.
 7. If a rerun still shows old labels/body, push a new commit and rerun.
-
 

--- a/docs/runbooks/label-bootstrap.md
+++ b/docs/runbooks/label-bootstrap.md
@@ -1,0 +1,33 @@
+# Label Bootstrap Runbook
+
+## Purpose
+
+Ensure required governance labels exist so tier enforcement cannot fail with "label not found" errors. The script is idempotent and safe to run multiple times.
+
+## Requirements
+
+- A GitHub token with label management permissions.
+  - Public repos: `public_repo` scope (classic) or equivalent fine-grained permissions.
+  - Private repos: `repo` scope (classic) or equivalent fine-grained permissions.
+- If running in GitHub Actions, ensure workflow permissions include `contents: read` and `issues: write` (labels are treated as issue metadata).
+
+## Local Usage (Codespaces)
+
+```bash
+export GITHUB_TOKEN="..."
+
+npm run bootstrap:labels -- --repo jonathanjoseph20/smartfunds-agent-sandbox --yes
+npm run bootstrap:labels -- --repo jonathanjoseph20/smartfunds-agent-sandbox --dry-run
+```
+
+## Verification
+
+```bash
+gh label list --limit 200 | egrep 'tier-0|tier-1|tier-2|tier-3|tier-3-approved'
+```
+
+## Notes
+
+- Use `--dry-run` to see planned changes without mutations.
+- `--yes` skips the interactive confirmation prompt.
+- If `--repo` is omitted, the script uses `GITHUB_REPOSITORY`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
-    "typecheck": "npm run typecheck --workspaces --if-present"
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "bootstrap:labels": "npx tsc --target ES2022 --module ES2022 --moduleResolution node --lib ES2022,DOM --outDir control-plane/dist control-plane/bootstrap-labels.ts && node control-plane/dist/bootstrap-labels.js"
   },
   "devDependencies": {
     "typescript": "^5.6.3",


### PR DESCRIPTION
tier-3

```evidence
Risk Tier: 3
Justification: Adds idempotent governance label bootstrap script and documentation.
Affected Paths: control-plane/bootstrap-labels.ts, control-plane/bootstrap-labels.test.ts, docs/runbooks/label-bootstrap.md, docs/code-factory-governance.md, package.json
Tests Added: Yes (unit tests for create, update, dry-run idempotency).
Determinism Statement: Script is idempotent and produces deterministic summary output.
```
