### PR TITLE
Sprint 23 — ChargeIntent v1 + Multi-Rail Abstraction

### DIFF
--- a/control-plane/finance/adapters/onchain-mock.test.ts
+++ b/control-plane/finance/adapters/onchain-mock.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalStringify, sha256 } from '../determinism.ts';
+import type { ChargeIntent } from '../charge-intent.ts';
+import { OnchainMockAdapter } from './onchain-mock.ts';
+
+const baseIntent: ChargeIntent = {
+  intentId: 'ci_test',
+  entityId: 'entity',
+  railProfileId: 'hybrid',
+  amount: '75.00',
+  currency: 'USDC',
+  counterparty: '0x1111111111111111111111111111111111111111',
+  purpose: 'payment',
+  status: 'CREATED',
+  determinismHash: 'b'.repeat(64)
+};
+
+describe('OnchainMockAdapter', () => {
+  it('executes USDC intents with valid counterparty', () => {
+    const result = OnchainMockAdapter.execute(baseIntent);
+
+    expect(result.outcome).toBe('EXECUTED');
+    expect(result.receiptRef).toBe(`rcpt_${baseIntent.determinismHash.slice(0, 12)}_onchain_mock`);
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'onchain_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'EXECUTED',
+        receiptRef: result.receiptRef
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+
+  it('fails when currency is unsupported', () => {
+    const result = OnchainMockAdapter.execute({ ...baseIntent, currency: 'USD' });
+
+    expect(result.outcome).toBe('FAILED');
+    expect(result.errorCode).toBe('ERR_ONCHAIN_MOCK_UNSUPPORTED_CURRENCY');
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'onchain_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'FAILED',
+        receiptRef: result.receiptRef,
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+
+  it('fails when counterparty is invalid', () => {
+    const result = OnchainMockAdapter.execute({ ...baseIntent, counterparty: 'not-an-address' });
+
+    expect(result.outcome).toBe('FAILED');
+    expect(result.errorCode).toBe('ERR_ONCHAIN_MOCK_INVALID_COUNTERPARTY');
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'onchain_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'FAILED',
+        receiptRef: result.receiptRef,
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+});

--- a/control-plane/finance/adapters/onchain-mock.ts
+++ b/control-plane/finance/adapters/onchain-mock.ts
@@ -1,0 +1,39 @@
+import type { ChargeIntent } from '../charge-intent.ts';
+import { buildReceiptRef, buildSettlementResult, type SettlementAdapter } from './types.ts';
+
+const ONCHAIN_COUNTERPARTY = /^0x[a-fA-F0-9]{40}$/;
+
+export const OnchainMockAdapter: SettlementAdapter = {
+  adapterId: 'onchain_mock',
+  execute(intent: ChargeIntent) {
+    const receiptRef = buildReceiptRef(intent.determinismHash, 'onchain_mock');
+    if (intent.currency !== 'USDC') {
+      return buildSettlementResult({
+        adapterId: 'onchain_mock',
+        intentId: intent.intentId,
+        outcome: 'FAILED',
+        receiptRef,
+        errorCode: 'ERR_ONCHAIN_MOCK_UNSUPPORTED_CURRENCY',
+        errorMessage: 'Onchain mock supports USDC only.'
+      });
+    }
+
+    if (!ONCHAIN_COUNTERPARTY.test(intent.counterparty)) {
+      return buildSettlementResult({
+        adapterId: 'onchain_mock',
+        intentId: intent.intentId,
+        outcome: 'FAILED',
+        receiptRef,
+        errorCode: 'ERR_ONCHAIN_MOCK_INVALID_COUNTERPARTY',
+        errorMessage: 'Onchain mock requires a 0x-prefixed 40-byte address.'
+      });
+    }
+
+    return buildSettlementResult({
+      adapterId: 'onchain_mock',
+      intentId: intent.intentId,
+      outcome: 'EXECUTED',
+      receiptRef
+    });
+  }
+};

--- a/control-plane/finance/adapters/stripe-mock.test.ts
+++ b/control-plane/finance/adapters/stripe-mock.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalStringify, sha256 } from '../determinism.ts';
+import type { ChargeIntent } from '../charge-intent.ts';
+import { StripeMockAdapter } from './stripe-mock.ts';
+
+const baseIntent: ChargeIntent = {
+  intentId: 'ci_test',
+  entityId: 'entity',
+  railProfileId: 'hybrid',
+  amount: '50.00',
+  currency: 'USD',
+  counterparty: 'customer-1',
+  purpose: 'payment',
+  status: 'CREATED',
+  determinismHash: 'a'.repeat(64)
+};
+
+describe('StripeMockAdapter', () => {
+  it('executes USD intents', () => {
+    const result = StripeMockAdapter.execute(baseIntent);
+
+    expect(result.outcome).toBe('EXECUTED');
+    expect(result.receiptRef).toBe(`rcpt_${baseIntent.determinismHash.slice(0, 12)}_stripe_mock`);
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'stripe_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'EXECUTED',
+        receiptRef: result.receiptRef
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+
+  it('fails when currency is unsupported', () => {
+    const result = StripeMockAdapter.execute({ ...baseIntent, currency: 'USDC' });
+
+    expect(result.outcome).toBe('FAILED');
+    expect(result.errorCode).toBe('ERR_STRIPE_MOCK_UNSUPPORTED_CURRENCY');
+    expect(result.receiptRef).toBe(`rcpt_${baseIntent.determinismHash.slice(0, 12)}_stripe_mock`);
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'stripe_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'FAILED',
+        receiptRef: result.receiptRef,
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+});

--- a/control-plane/finance/adapters/stripe-mock.ts
+++ b/control-plane/finance/adapters/stripe-mock.ts
@@ -1,0 +1,26 @@
+import type { ChargeIntent } from '../charge-intent.ts';
+import { buildReceiptRef, buildSettlementResult, type SettlementAdapter } from './types.ts';
+
+export const StripeMockAdapter: SettlementAdapter = {
+  adapterId: 'stripe_mock',
+  execute(intent: ChargeIntent) {
+    const receiptRef = buildReceiptRef(intent.determinismHash, 'stripe_mock');
+    if (intent.currency !== 'USD') {
+      return buildSettlementResult({
+        adapterId: 'stripe_mock',
+        intentId: intent.intentId,
+        outcome: 'FAILED',
+        receiptRef,
+        errorCode: 'ERR_STRIPE_MOCK_UNSUPPORTED_CURRENCY',
+        errorMessage: 'Stripe mock supports USD only.'
+      });
+    }
+
+    return buildSettlementResult({
+      adapterId: 'stripe_mock',
+      intentId: intent.intentId,
+      outcome: 'EXECUTED',
+      receiptRef
+    });
+  }
+};

--- a/control-plane/finance/adapters/types.ts
+++ b/control-plane/finance/adapters/types.ts
@@ -1,0 +1,60 @@
+import { canonicalStringify, sha256 } from '../determinism.ts';
+import type { ChargeIntent } from '../charge-intent.ts';
+
+export type SettlementOutcome = 'EXECUTED' | 'FAILED';
+
+export type SettlementAdapterId = 'stripe_mock' | 'onchain_mock' | 'wire_mock';
+
+export type SettlementResult = {
+  adapterId: SettlementAdapterId;
+  intentId: string;
+  outcome: SettlementOutcome;
+  receiptRef: string;
+  errorCode?: string;
+  errorMessage?: string;
+  resultHash: string;
+};
+
+export interface SettlementAdapter {
+  adapterId: SettlementAdapterId;
+  execute(intent: ChargeIntent): SettlementResult;
+}
+
+export function buildReceiptRef(intentHash: string, adapterId: SettlementAdapterId): string {
+  return `rcpt_${intentHash.slice(0, 12)}_${adapterId}`;
+}
+
+export function buildSettlementResult(input: {
+  adapterId: SettlementAdapterId;
+  intentId: string;
+  outcome: SettlementOutcome;
+  receiptRef: string;
+  errorCode?: string;
+  errorMessage?: string;
+}): SettlementResult {
+  const resultCore: Record<string, string> = {
+    adapterId: input.adapterId,
+    intentId: input.intentId,
+    outcome: input.outcome,
+    receiptRef: input.receiptRef
+  };
+
+  if (input.errorCode) {
+    resultCore.errorCode = input.errorCode;
+  }
+  if (input.errorMessage) {
+    resultCore.errorMessage = input.errorMessage;
+  }
+
+  const resultHash = sha256(canonicalStringify(resultCore));
+
+  return {
+    adapterId: input.adapterId,
+    intentId: input.intentId,
+    outcome: input.outcome,
+    receiptRef: input.receiptRef,
+    ...(input.errorCode ? { errorCode: input.errorCode } : {}),
+    ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+    resultHash
+  };
+}

--- a/control-plane/finance/adapters/wire-mock.test.ts
+++ b/control-plane/finance/adapters/wire-mock.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalStringify, sha256 } from '../determinism.ts';
+import type { ChargeIntent } from '../charge-intent.ts';
+import { WireMockAdapter } from './wire-mock.ts';
+
+const baseIntent: ChargeIntent = {
+  intentId: 'ci_test',
+  entityId: 'entity',
+  railProfileId: 'hybrid',
+  amount: '125.00',
+  currency: 'USD',
+  counterparty: 'wire:acct-1',
+  purpose: 'payment',
+  status: 'CREATED',
+  determinismHash: 'c'.repeat(64)
+};
+
+describe('WireMockAdapter', () => {
+  it('executes when counterparty uses wire prefix', () => {
+    const result = WireMockAdapter.execute(baseIntent);
+
+    expect(result.outcome).toBe('EXECUTED');
+    expect(result.receiptRef).toBe(`rcpt_${baseIntent.determinismHash.slice(0, 12)}_wire_mock`);
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'wire_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'EXECUTED',
+        receiptRef: result.receiptRef
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+
+  it('fails when counterparty lacks wire prefix', () => {
+    const result = WireMockAdapter.execute({ ...baseIntent, counterparty: 'acct-1' });
+
+    expect(result.outcome).toBe('FAILED');
+    expect(result.errorCode).toBe('ERR_WIRE_MOCK_INVALID_REFERENCE');
+    const expectedHash = sha256(
+      canonicalStringify({
+        adapterId: 'wire_mock',
+        intentId: baseIntent.intentId,
+        outcome: 'FAILED',
+        receiptRef: result.receiptRef,
+        errorCode: result.errorCode,
+        errorMessage: result.errorMessage
+      })
+    );
+    expect(result.resultHash).toBe(expectedHash);
+  });
+});

--- a/control-plane/finance/adapters/wire-mock.ts
+++ b/control-plane/finance/adapters/wire-mock.ts
@@ -1,0 +1,26 @@
+import type { ChargeIntent } from '../charge-intent.ts';
+import { buildReceiptRef, buildSettlementResult, type SettlementAdapter } from './types.ts';
+
+export const WireMockAdapter: SettlementAdapter = {
+  adapterId: 'wire_mock',
+  execute(intent: ChargeIntent) {
+    const receiptRef = buildReceiptRef(intent.determinismHash, 'wire_mock');
+    if (!intent.counterparty.startsWith('wire:')) {
+      return buildSettlementResult({
+        adapterId: 'wire_mock',
+        intentId: intent.intentId,
+        outcome: 'FAILED',
+        receiptRef,
+        errorCode: 'ERR_WIRE_MOCK_INVALID_REFERENCE',
+        errorMessage: 'Wire mock requires counterparty to start with wire:.'
+      });
+    }
+
+    return buildSettlementResult({
+      adapterId: 'wire_mock',
+      intentId: intent.intentId,
+      outcome: 'EXECUTED',
+      receiptRef
+    });
+  }
+};

--- a/control-plane/finance/charge-intent.test.ts
+++ b/control-plane/finance/charge-intent.test.ts
@@ -1,0 +1,181 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { buildChargeIntentHash, createChargeIntent, type ChargeIntentInput } from './charge-intent.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-finance');
+const projectsDir = path.join(tmpRoot, 'projects');
+const entityRegistryPath = path.join(tmpRoot, 'registry.json');
+const railsRegistryPath = path.join(tmpRoot, 'rails.json');
+
+function resetTmpDir(): void {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.mkdirSync(projectsDir, { recursive: true });
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+function writeProject(projectId: string): void {
+  writeJson(path.join(projectsDir, `${projectId}.json`), {
+    projectId,
+    ownedPaths: ['control-plane/**']
+  });
+}
+
+function writeEntityRegistry(entityId: string, projectId: string): void {
+  writeJson(entityRegistryPath, [
+    {
+      entityId,
+      legalName: 'Alpha Entity',
+      projects: [projectId],
+      complianceProfile: 'phase-1',
+      custodyMode: 'non_custodial'
+    }
+  ]);
+}
+
+function writeRailsRegistry(entityId: string, railProfile: 'structured-only' | 'autonomous-only' | 'hybrid' | 'restricted'): void {
+  writeJson(railsRegistryPath, {
+    version: 1,
+    entities: [
+      {
+        entityId,
+        railProfile
+      }
+    ]
+  });
+}
+
+function baseInput(overrides: Partial<ChargeIntentInput> = {}): ChargeIntentInput {
+  return {
+    entityId: 'alpha-entity',
+    railProfileId: 'hybrid',
+    amount: '100.00',
+    currency: 'USD',
+    counterparty: 'customer-1',
+    purpose: 'subscription',
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  resetTmpDir();
+  writeProject('alpha-project');
+  writeEntityRegistry('alpha-entity', 'alpha-project');
+  writeRailsRegistry('alpha-entity', 'hybrid');
+});
+
+describe('charge intent hashing', () => {
+  it('produces deterministic hashes for identical input', () => {
+    const intentA = createChargeIntent(baseInput(), {
+      entityRegistryPath,
+      projectsDir,
+      railsRegistryPath
+    });
+    const intentB = createChargeIntent(baseInput(), {
+      entityRegistryPath,
+      projectsDir,
+      railsRegistryPath
+    });
+
+    expect(intentA.determinismHash).toBe(intentB.determinismHash);
+  });
+
+  it('canonicalizes metadata key ordering', () => {
+    const intentA = createChargeIntent(
+      baseInput({ metadata: { b: '2', a: '1' } }),
+      { entityRegistryPath, projectsDir, railsRegistryPath }
+    );
+    const intentB = createChargeIntent(
+      baseInput({ metadata: { a: '1', b: '2' } }),
+      { entityRegistryPath, projectsDir, railsRegistryPath }
+    );
+
+    expect(intentA.determinismHash).toBe(intentB.determinismHash);
+  });
+
+  it('omits undefined metadata from hashing', () => {
+    const intentA = createChargeIntent(
+      baseInput({ metadata: undefined }),
+      { entityRegistryPath, projectsDir, railsRegistryPath }
+    );
+    const intentB = createChargeIntent(
+      baseInput(),
+      { entityRegistryPath, projectsDir, railsRegistryPath }
+    );
+
+    expect(intentA.determinismHash).toBe(intentB.determinismHash);
+  });
+
+  it('derives intentId from the determinism hash when absent', () => {
+    const intent = createChargeIntent(baseInput(), {
+      entityRegistryPath,
+      projectsDir,
+      railsRegistryPath
+    });
+
+    expect(intent.intentId).toBe(`ci_${intent.determinismHash.slice(0, 12)}`);
+  });
+
+  it('excludes status from the hash input', () => {
+    const intent = createChargeIntent(baseInput(), {
+      entityRegistryPath,
+      projectsDir,
+      railsRegistryPath
+    });
+    const coreHash = buildChargeIntentHash({
+      entityId: intent.entityId,
+      railProfileId: intent.railProfileId,
+      amount: intent.amount,
+      currency: intent.currency,
+      counterparty: intent.counterparty,
+      purpose: intent.purpose,
+      ...(intent.metadata ? { metadata: intent.metadata } : {})
+    });
+
+    expect(intent.determinismHash).toBe(coreHash);
+  });
+});
+
+describe('charge intent validation', () => {
+  it('fails when entity is missing', () => {
+    writeJson(entityRegistryPath, []);
+
+    expect(() =>
+      createChargeIntent(baseInput(), {
+        entityRegistryPath,
+        projectsDir,
+        railsRegistryPath
+      })
+    ).toThrow(/ERR_ENTITY_NOT_FOUND/);
+  });
+
+  it('fails when rail profile is missing', () => {
+    writeJson(railsRegistryPath, { version: 1, entities: [] });
+
+    expect(() =>
+      createChargeIntent(baseInput(), {
+        entityRegistryPath,
+        projectsDir,
+        railsRegistryPath
+      })
+    ).toThrow(/ERR_RAIL_PROFILE_MISSING/);
+  });
+
+  it('fails when rail profile is incompatible', () => {
+    writeRailsRegistry('alpha-entity', 'structured-only');
+
+    expect(() =>
+      createChargeIntent(baseInput(), {
+        entityRegistryPath,
+        projectsDir,
+        railsRegistryPath
+      })
+    ).toThrow(/ERR_RAIL_PROFILE_INCOMPATIBLE/);
+  });
+});

--- a/control-plane/finance/charge-intent.ts
+++ b/control-plane/finance/charge-intent.ts
@@ -1,0 +1,116 @@
+import { getRailProfile, loadRailsRegistry, type RailProfile } from '../entities/rails.ts';
+import { loadEntityRegistry } from '../studio/entity-registry.ts';
+import { canonicalStringify, sha256 } from './determinism.ts';
+import type { SettlementAdapter, SettlementResult } from './adapters/types.ts';
+import type { SettlementLogEntry, SettlementLogStore } from './settlement-log.ts';
+
+export type ChargeIntentStatus = 'CREATED' | 'EXECUTED' | 'FAILED';
+
+export type ChargeIntent = {
+  intentId: string;
+  entityId: string;
+  railProfileId: RailProfile;
+  amount: string;
+  currency: string;
+  counterparty: string;
+  purpose: string;
+  metadata?: Record<string, string>;
+  status: ChargeIntentStatus;
+  determinismHash: string;
+};
+
+export type ChargeIntentInput = {
+  intentId?: string;
+  entityId: string;
+  railProfileId: RailProfile;
+  amount: string;
+  currency: string;
+  counterparty: string;
+  purpose: string;
+  metadata?: Record<string, string>;
+};
+
+export type ChargeIntentCore = {
+  entityId: string;
+  railProfileId: RailProfile;
+  amount: string;
+  currency: string;
+  counterparty: string;
+  purpose: string;
+  metadata?: Record<string, string>;
+};
+
+type ChargeIntentValidationOptions = {
+  entityRegistryPath?: string;
+  projectsDir?: string;
+  railsRegistryPath?: string;
+};
+
+function buildIntentCore(input: ChargeIntentInput): ChargeIntentCore {
+  return {
+    entityId: input.entityId,
+    railProfileId: input.railProfileId,
+    amount: input.amount,
+    currency: input.currency,
+    counterparty: input.counterparty,
+    purpose: input.purpose,
+    ...(input.metadata ? { metadata: input.metadata } : {})
+  };
+}
+
+export function buildChargeIntentHash(core: ChargeIntentCore): string {
+  return sha256(canonicalStringify(core));
+}
+
+function requireEntity(entityId: string, options: ChargeIntentValidationOptions): void {
+  const registry = loadEntityRegistry({ registryPath: options.entityRegistryPath, projectsDir: options.projectsDir });
+  const hasEntity = registry.entities.some((entity) => entity.entityId === entityId);
+  if (!hasEntity) {
+    throw new Error(`ERR_ENTITY_NOT_FOUND: ${entityId}`);
+  }
+}
+
+function requireRailProfile(entityId: string, railProfileId: RailProfile, options: ChargeIntentValidationOptions): void {
+  const registry = loadRailsRegistry({ registryPath: options.railsRegistryPath });
+  const mappedProfile = getRailProfile(entityId, registry);
+  if (!mappedProfile) {
+    throw new Error(`ERR_RAIL_PROFILE_MISSING: ${entityId}`);
+  }
+  if (mappedProfile !== railProfileId) {
+    throw new Error(`ERR_RAIL_PROFILE_INCOMPATIBLE: ${entityId}`);
+  }
+}
+
+export function createChargeIntent(
+  input: ChargeIntentInput,
+  options: ChargeIntentValidationOptions = {}
+): ChargeIntent {
+  requireEntity(input.entityId, options);
+  requireRailProfile(input.entityId, input.railProfileId, options);
+
+  const core = buildIntentCore(input);
+  const determinismHash = buildChargeIntentHash(core);
+  const intentId = input.intentId ?? `ci_${determinismHash.slice(0, 12)}`;
+
+  return {
+    intentId,
+    ...core,
+    status: 'CREATED',
+    determinismHash
+  };
+}
+
+export function executeChargeIntent(
+  intent: ChargeIntent,
+  adapter: SettlementAdapter,
+  log: SettlementLogStore
+): { updatedIntent: ChargeIntent; result: SettlementResult; logEntry: SettlementLogEntry } {
+  const result = adapter.execute(intent);
+  const updatedIntent: ChargeIntent = {
+    ...intent,
+    status: result.outcome === 'EXECUTED' ? 'EXECUTED' : 'FAILED'
+  };
+  const logEntry = log.appendFromResult(intent.determinismHash, result);
+
+  return { updatedIntent, result, logEntry };
+}

--- a/control-plane/finance/determinism.ts
+++ b/control-plane/finance/determinism.ts
@@ -1,0 +1,54 @@
+import { createHash } from 'node:crypto';
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+function normalizeArray(values: unknown[]): JsonValue[] {
+  return values.map((value) => {
+    const normalized = normalizeValue(value);
+    return normalized === undefined ? null : normalized;
+  });
+}
+
+function normalizeObject(value: Record<string, unknown>): { [key: string]: JsonValue } {
+  const entries = Object.entries(value)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  const result: { [key: string]: JsonValue } = {};
+  for (const [key, entryValue] of entries) {
+    const normalized = normalizeValue(entryValue);
+    if (normalized !== undefined) {
+      result[key] = normalized;
+    }
+  }
+
+  return result;
+}
+
+function normalizeValue(value: unknown): JsonValue | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return normalizeArray(value);
+  }
+  if (typeof value === 'object') {
+    return normalizeObject(value as Record<string, unknown>);
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as JsonValue;
+}
+
+export function canonicalStringify(value: unknown): string {
+  const normalized = normalizeValue(value);
+  return JSON.stringify(normalized ?? null);
+}
+
+export function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}

--- a/control-plane/finance/execution.test.ts
+++ b/control-plane/finance/execution.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createChargeIntent, executeChargeIntent } from './charge-intent.ts';
+import { createSettlementLogStore } from './settlement-log.ts';
+import { StripeMockAdapter } from './adapters/stripe-mock.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-finance-exec');
+const projectsDir = path.join(tmpRoot, 'projects');
+const entityRegistryPath = path.join(tmpRoot, 'registry.json');
+const railsRegistryPath = path.join(tmpRoot, 'rails.json');
+
+function resetTmpDir(): void {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.mkdirSync(projectsDir, { recursive: true });
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+beforeEach(() => {
+  resetTmpDir();
+  writeJson(path.join(projectsDir, 'alpha-project.json'), {
+    projectId: 'alpha-project',
+    ownedPaths: ['control-plane/**']
+  });
+  writeJson(entityRegistryPath, [
+    {
+      entityId: 'alpha-entity',
+      legalName: 'Alpha Entity',
+      projects: ['alpha-project'],
+      complianceProfile: 'phase-1',
+      custodyMode: 'non_custodial'
+    }
+  ]);
+  writeJson(railsRegistryPath, {
+    version: 1,
+    entities: [
+      {
+        entityId: 'alpha-entity',
+        railProfile: 'hybrid'
+      }
+    ]
+  });
+});
+
+describe('executeChargeIntent', () => {
+  it('executes and logs deterministically', () => {
+    const intent = createChargeIntent(
+      {
+        entityId: 'alpha-entity',
+        railProfileId: 'hybrid',
+        amount: '100.00',
+        currency: 'USD',
+        counterparty: 'customer-1',
+        purpose: 'subscription'
+      },
+      { entityRegistryPath, projectsDir, railsRegistryPath }
+    );
+
+    const log = createSettlementLogStore();
+    const { updatedIntent, result, logEntry } = executeChargeIntent(intent, StripeMockAdapter, log);
+
+    expect(updatedIntent.status).toBe('EXECUTED');
+    expect(result.outcome).toBe('EXECUTED');
+    expect(logEntry.entryId).toBe(`sl_${intent.determinismHash.slice(0, 12)}_001`);
+    expect(log.listByIntentHash(intent.determinismHash)).toHaveLength(1);
+  });
+});

--- a/control-plane/finance/settlement-log.test.ts
+++ b/control-plane/finance/settlement-log.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSettlementLogStore } from './settlement-log.ts';
+import type { SettlementResult } from './adapters/types.ts';
+
+const result: SettlementResult = {
+  adapterId: 'stripe_mock',
+  intentId: 'ci_test',
+  outcome: 'EXECUTED',
+  receiptRef: 'rcpt_aaaaaaaaaaaa_stripe_mock',
+  resultHash: 'hash-1'
+};
+
+describe('settlement log', () => {
+  it('assigns deterministic entryIds per intent hash', () => {
+    const log = createSettlementLogStore();
+
+    const first = log.appendFromResult('a'.repeat(64), result);
+    const second = log.appendFromResult('a'.repeat(64), { ...result, resultHash: 'hash-2' });
+
+    expect(first.entryId).toBe('sl_aaaaaaaaaaaa_001');
+    expect(second.entryId).toBe('sl_aaaaaaaaaaaa_002');
+  });
+
+  it('lists entries in stable order', () => {
+    const log = createSettlementLogStore();
+    log.appendFromResult('b'.repeat(64), { ...result, resultHash: 'hash-1' });
+    log.appendFromResult('b'.repeat(64), { ...result, resultHash: 'hash-2' });
+
+    const entries = log.listByIntentHash('b'.repeat(64));
+    expect(entries.map((entry) => entry.entryId)).toEqual(['sl_bbbbbbbbbbbb_001', 'sl_bbbbbbbbbbbb_002']);
+  });
+});

--- a/control-plane/finance/settlement-log.ts
+++ b/control-plane/finance/settlement-log.ts
@@ -1,0 +1,54 @@
+import type { SettlementAdapterId, SettlementOutcome, SettlementResult } from './adapters/types.ts';
+
+export type SettlementLogEntry = {
+  entryId: string;
+  intentHash: string;
+  adapterId: SettlementAdapterId;
+  outcome: SettlementOutcome;
+  receiptRef: string;
+  resultHash: string;
+};
+
+export type SettlementLogStore = {
+  append(entry: SettlementLogEntry): void;
+  appendFromResult(intentHash: string, result: SettlementResult): SettlementLogEntry;
+  listByIntentHash(intentHash: string): SettlementLogEntry[];
+};
+
+function buildEntryId(intentHash: string, attemptIndex: number): string {
+  return `sl_${intentHash.slice(0, 12)}_${String(attemptIndex).padStart(3, '0')}`;
+}
+
+export function createSettlementLogStore(): SettlementLogStore {
+  const entries: SettlementLogEntry[] = [];
+  const attemptsByIntent = new Map<string, number>();
+
+  function append(entry: SettlementLogEntry): void {
+    entries.push(entry);
+  }
+
+  function appendFromResult(intentHash: string, result: SettlementResult): SettlementLogEntry {
+    const current = attemptsByIntent.get(intentHash) ?? 0;
+    const nextAttempt = current + 1;
+    attemptsByIntent.set(intentHash, nextAttempt);
+    const entry: SettlementLogEntry = {
+      entryId: buildEntryId(intentHash, nextAttempt),
+      intentHash,
+      adapterId: result.adapterId,
+      outcome: result.outcome,
+      receiptRef: result.receiptRef,
+      resultHash: result.resultHash
+    };
+    append(entry);
+    return entry;
+  }
+
+  function listByIntentHash(intentHash: string): SettlementLogEntry[] {
+    return entries
+      .filter((entry) => entry.intentHash === intentHash)
+      .slice()
+      .sort((a, b) => a.entryId.localeCompare(b.entryId));
+  }
+
+  return { append, appendFromResult, listByIntentHash };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,6 +1326,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
tier-3

```evidence
Risk Tier: 3
Justification: Adds ChargeIntent v1 (entity/rail-bound) plus deterministic mock settlement adapters and deterministic settlement logging; establishes financial execution spine.
Affected Paths: control-plane/finance/** package-lock.json
Tests Added: control-plane/finance/*.test.ts; control-plane/finance/adapters/*.test.ts
Determinism Statement: Canonical JSON normalization with sorted keys; undefined omitted; no timestamps/randomness in hashes/receipts/log IDs; stable error codes and deterministic ordering.
```
