### PR TITLE
fix(governance): restrict core-app ownedPaths

### DIFF
--- a/control-plane/projects/core-app.json
+++ b/control-plane/projects/core-app.json
@@ -1,7 +1,6 @@
 {
   "projectId": "core-app",
   "ownedPaths": [
-    "**",
     "control-plane/**"
   ],
   "description": "Default project boundary including governance",


### PR DESCRIPTION
tier-3

```evidence
Risk Tier: 3
Justification: Fix project ownership mapping so docs are not incorrectly owned by core-app.
Affected Paths: control-plane/projects/core-app.json
Tests Added: None (config only).
Determinism Statement: Deterministic; no randomness/timestamps/IO.
```
