### PR TITLE
fix(governance): register docs project ownership

### DIFF
--- a/control-plane/projects/docs.json
+++ b/control-plane/projects/docs.json
@@ -1,0 +1,6 @@
+{
+  "projectId": "docs",
+  "ownedPaths": ["docs/**"],
+  "description": "Documentation project",
+  "tags": ["seed"]
+}


### PR DESCRIPTION
tier-3

```evidence
Risk Tier: 3
Justification: Governance metadata change (register docs/** as a project so docs PRs map to an owned project).
Affected Paths: control-plane/projects/docs.json
Tests Added: npm test
Determinism Statement: Config-only change; no runtime randomness; deterministic behavior preserved.
```
