### PR TITLE
fix(governance): skip preflight validation when no changed files

### DIFF
--- a/control-plane/cli/governance-preflight.ts
+++ b/control-plane/cli/governance-preflight.ts
@@ -538,7 +538,13 @@ async function main(): Promise<void> {
 
   const branch = getBranchName(gitExec);
   const changedFiles = getChangedFiles(gitExec);
-  const resolvedMetadata = resolveLocalMetadata({
+  
+if (changedFiles.length === 0) {
+  console.log('No changed files detected. Skipping governance validation.');
+  return;
+}
+
+const resolvedMetadata = resolveLocalMetadata({
     bodyFile: args.bodyFile,
     labelsFile: args.labelsFile,
     readFile,


### PR DESCRIPTION
tier-3

## Summary
- Skip governance preflight validation when there are no changed files (clean tree).
- Preserve normal behavior when files changed (ownership + tier + evidence gates still enforced).

## Rationale
Preflight should not fail or require ownership mapping when there is nothing to validate. This avoids false negatives during clean runs while keeping governance strict when diffs exist.

```evidence
Risk Tier: 3
Justification: Governance CLI behavior change; must remain deterministic and preserve enforcement when diffs exist.
Affected Paths: control-plane/cli/governance-preflight.ts
Tests Added: (if you added one, name it; otherwise say "none")
Determinism Statement: No timestamps/UUIDs/randomness added; decision derived only from git diff state.
```
