### PR TITLE
Sprint 65: Execution Memory Bus

### DIFF
--- a/control-plane/cli/swarm-inspect.test.ts
+++ b/control-plane/cli/swarm-inspect.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { main } from './swarm-inspect.ts';
+
+const inspectRun = vi.fn();
+const getSwarmRunStatus = vi.fn();
+
+vi.mock('../journal/journal.ts', () => ({
+  createExecutionJournal: vi.fn(() => ({
+    inspectRun
+  }))
+}));
+
+vi.mock('../swarm/swarm-runner.ts', () => ({
+  createSwarmRunner: vi.fn(() => ({
+    getSwarmRunStatus
+  }))
+}));
+
+describe('swarm-inspect CLI', () => {
+  it('prints deterministic run inspection output and exits 0', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    inspectRun.mockReturnValueOnce({
+      run: {
+        runId: 'run_control-plane_0001'
+      },
+      events: [
+        {
+          sequence: 1,
+          payload: {}
+        },
+        {
+          sequence: 2,
+          payload: {
+            context_snapshot: {
+              runId: 'run_control-plane_0001',
+              phase: 'setup',
+              taskId: 'load-run-context',
+              memory: {
+                b: 2,
+                a: 1
+              },
+              artifacts: ['z.md', 'a.md'],
+              metadata: {
+                z: true,
+                a: false
+              }
+            }
+          }
+        }
+      ]
+    });
+
+    getSwarmRunStatus.mockReturnValueOnce({
+      runId: 'run_control-plane_0001',
+      currentPhase: 'setup',
+      taskSummaries: [
+        {
+          taskId: 'load-run-context',
+          phase: 'setup',
+          status: 'completed',
+          order: 1,
+          description: 'Load deterministic run context'
+        }
+      ]
+    });
+
+    const code = await main(['--run', 'run_control-plane_0001']);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify({
+      runId: 'run_control-plane_0001',
+      currentPhase: 'setup',
+      tasks: [
+        {
+          taskId: 'load-run-context',
+          phase: 'setup',
+          status: 'completed',
+          order: 1,
+          description: 'Load deterministic run context'
+        }
+      ],
+      context: {
+        memory: {
+          b: 2,
+          a: 1
+        },
+        artifacts: ['a.md', 'z.md'],
+        metadata: {
+          z: true,
+          a: false
+        }
+      }
+    })}\n`);
+
+    stdout.mockRestore();
+  });
+
+  it('prints stable error for missing run and exits 1', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    inspectRun.mockImplementationOnce(() => {
+      throw new Error('Run not found: run_missing_0001');
+    });
+
+    const code = await main(['--run', 'run_missing_0001']);
+
+    expect(code).toBe(1);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify({ error: 'Run not found: run_missing_0001' })}\n`);
+
+    stdout.mockRestore();
+  });
+
+  it('prints stable error for unknown arguments and exits 1', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await main(['--project', 'control-plane']);
+
+    expect(code).toBe(1);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify({ error: 'UNKNOWN_ARGUMENT: --project' })}\n`);
+
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/cli/swarm-inspect.ts
+++ b/control-plane/cli/swarm-inspect.ts
@@ -1,0 +1,113 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createExecutionJournal } from '../journal/journal.ts';
+import type { ExecutionEvent } from '../journal/types.ts';
+import { createSwarmRunner } from '../swarm/swarm-runner.ts';
+
+type ParsedArgs = {
+  runId: string;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let runId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--run') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --run');
+      }
+      runId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--run=')) {
+      runId = arg.slice('--run='.length);
+      if (!runId) {
+        throw new Error('MISSING_ARGUMENT: --run');
+      }
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!runId) {
+    throw new Error('MISSING_ARGUMENT: --run');
+  }
+
+  return {
+    runId
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function extractLatestContextSnapshot(events: ExecutionEvent[]): Record<string, unknown> {
+  const ordered = [...events].sort((left, right) => left.sequence - right.sequence);
+
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const payload = ordered[index].payload;
+    if (!isRecord(payload)) {
+      continue;
+    }
+
+    const snapshot = payload.context_snapshot;
+    if (isRecord(snapshot)) {
+      return snapshot;
+    }
+  }
+
+  return {
+    memory: {},
+    artifacts: [],
+    metadata: {}
+  };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const journal = createExecutionJournal();
+    const runner = createSwarmRunner({ journal });
+
+    const inspected = journal.inspectRun(args.runId);
+    const summary = runner.getSwarmRunStatus({ runId: args.runId });
+    const contextSnapshot = extractLatestContextSnapshot(inspected.events);
+
+    printJson({
+      runId: summary.runId,
+      currentPhase: summary.currentPhase,
+      tasks: summary.taskSummaries,
+      context: {
+        memory: isRecord(contextSnapshot.memory) ? contextSnapshot.memory : {},
+        artifacts: Array.isArray(contextSnapshot.artifacts)
+          ? contextSnapshot.artifacts.filter((entry): entry is string => typeof entry === 'string').sort((left, right) => left.localeCompare(right))
+          : [],
+        metadata: isRecord(contextSnapshot.metadata) ? contextSnapshot.metadata : {}
+      }
+    });
+
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/execution/context-merge.ts
+++ b/control-plane/execution/context-merge.ts
@@ -1,0 +1,65 @@
+import type { TaskResult } from '../tasks/task-result.ts';
+import type { ContextUpdates, ExecutionContext } from './context-types.ts';
+import { createExecutionContext } from './execution-context.ts';
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function extractTaskArtifactPaths(taskResult: TaskResult): string[] {
+  const paths = taskResult.artifacts
+    .map((artifact) => artifact.path)
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+  return sortedUnique(paths);
+}
+
+export function mergeContextUpdates(context: ExecutionContext, updates?: ContextUpdates): ExecutionContext {
+  if (!updates || Object.keys(updates).length === 0) {
+    return createExecutionContext({
+      runId: context.runId,
+      ...(context.missionId ? { missionId: context.missionId } : {}),
+      phase: context.phase,
+      taskId: context.taskId,
+      memory: context.memory,
+      artifacts: context.artifacts,
+      metadata: context.metadata
+    });
+  }
+
+  const mergedMemory: Record<string, unknown> = { ...context.memory };
+
+  for (const key of Object.keys(updates).sort((left, right) => left.localeCompare(right))) {
+    const value = updates[key];
+    if (value !== undefined) {
+      mergedMemory[key] = value;
+    }
+  }
+
+  return createExecutionContext({
+    runId: context.runId,
+    ...(context.missionId ? { missionId: context.missionId } : {}),
+    phase: context.phase,
+    taskId: context.taskId,
+    memory: mergedMemory,
+    artifacts: context.artifacts,
+    metadata: context.metadata
+  });
+}
+
+export function applyTaskResultToContext(context: ExecutionContext, taskResult: TaskResult): ExecutionContext {
+  const mergedContext = mergeContextUpdates(context, taskResult.context_updates);
+  const artifactPaths = extractTaskArtifactPaths(taskResult);
+  if (artifactPaths.length === 0) {
+    return mergedContext;
+  }
+
+  return createExecutionContext({
+    runId: mergedContext.runId,
+    ...(mergedContext.missionId ? { missionId: mergedContext.missionId } : {}),
+    phase: mergedContext.phase,
+    taskId: mergedContext.taskId,
+    memory: mergedContext.memory,
+    artifacts: sortedUnique([...mergedContext.artifacts, ...artifactPaths]),
+    metadata: mergedContext.metadata
+  });
+}

--- a/control-plane/execution/context-serializer.ts
+++ b/control-plane/execution/context-serializer.ts
@@ -1,0 +1,11 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { cloneExecutionContext } from './execution-context.ts';
+import type { ExecutionContext } from './context-types.ts';
+
+export function canonicalizeExecutionContext(context: ExecutionContext): ExecutionContext {
+  return cloneExecutionContext(context);
+}
+
+export function serializeExecutionContext(context: ExecutionContext): string {
+  return canonicalStringify(canonicalizeExecutionContext(context));
+}

--- a/control-plane/execution/context-types.ts
+++ b/control-plane/execution/context-types.ts
@@ -1,0 +1,15 @@
+export type ExecutionMemoryValue = unknown;
+
+export type ContextUpdates = Record<string, ExecutionMemoryValue>;
+
+export type ExecutionContext = {
+  runId: string;
+  missionId?: string;
+  phase: string;
+  taskId: string;
+  memory: Record<string, ExecutionMemoryValue>;
+  artifacts: string[];
+  metadata: Record<string, unknown>;
+};
+
+export type JournalContextSnapshot = ExecutionContext;

--- a/control-plane/execution/execution-context.ts
+++ b/control-plane/execution/execution-context.ts
@@ -1,0 +1,102 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import type { ExecutionContext } from './context-types.ts';
+
+type CreateExecutionContextInput = {
+  runId: string;
+  missionId?: string;
+  phase: string;
+  taskId: string;
+  memory?: Record<string, unknown>;
+  artifacts?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+function sortRecord<T>(record: Record<string, T>): Record<string, T> {
+  const sortedEntries = Object.entries(record)
+    .filter(([, value]) => value !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return Object.fromEntries(sortedEntries);
+}
+
+function stableCloneValue<T>(value: T): T {
+  return JSON.parse(canonicalStringify(value)) as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepFreeze(item);
+    }
+    return Object.freeze(value);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    for (const key of Object.keys(objectValue)) {
+      deepFreeze(objectValue[key]);
+    }
+    return Object.freeze(value);
+  }
+
+  return value;
+}
+
+function canonicalizeArtifacts(artifacts: string[]): string[] {
+  return [...artifacts].sort((left, right) => left.localeCompare(right));
+}
+
+export function createExecutionContext(input: CreateExecutionContextInput): ExecutionContext {
+  return {
+    runId: input.runId,
+    ...(input.missionId ? { missionId: input.missionId } : {}),
+    phase: input.phase,
+    taskId: input.taskId,
+    memory: sortRecord(stableCloneValue(input.memory ?? {})),
+    artifacts: canonicalizeArtifacts(input.artifacts ?? []),
+    metadata: sortRecord(stableCloneValue(input.metadata ?? {}))
+  };
+}
+
+export function createEmptyExecutionContext(runId: string): ExecutionContext {
+  return createExecutionContext({
+    runId,
+    phase: 'plan',
+    taskId: '__run_start__',
+    memory: {},
+    artifacts: [],
+    metadata: {}
+  });
+}
+
+export function cloneExecutionContext(context: ExecutionContext): ExecutionContext {
+  return createExecutionContext({
+    runId: context.runId,
+    ...(context.missionId ? { missionId: context.missionId } : {}),
+    phase: context.phase,
+    taskId: context.taskId,
+    memory: context.memory,
+    artifacts: context.artifacts,
+    metadata: context.metadata
+  });
+}
+
+export function withExecutionIdentity(
+  context: ExecutionContext,
+  identity: { phase: string; taskId: string }
+): ExecutionContext {
+  return createExecutionContext({
+    runId: context.runId,
+    ...(context.missionId ? { missionId: context.missionId } : {}),
+    phase: identity.phase,
+    taskId: identity.taskId,
+    memory: context.memory,
+    artifacts: context.artifacts,
+    metadata: context.metadata
+  });
+}
+
+export function toReadonlyExecutionContext(context: ExecutionContext): Readonly<ExecutionContext> {
+  const cloned = cloneExecutionContext(context);
+  return deepFreeze(cloned);
+}

--- a/control-plane/execution/tests/context-merge.test.ts
+++ b/control-plane/execution/tests/context-merge.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { serializeExecutionContext } from '../context-serializer.ts';
+import { applyTaskResultToContext, mergeContextUpdates } from '../context-merge.ts';
+import { createExecutionContext } from '../execution-context.ts';
+
+describe('context merge', () => {
+  it('overwrites existing keys with shallow replacement semantics', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task-a',
+      memory: {
+        keep: 'x',
+        obj: { left: 1, right: 2 }
+      }
+    });
+
+    const merged = mergeContextUpdates(context, {
+      obj: { right: 9 },
+      newKey: 'new-value'
+    });
+
+    expect(merged.memory).toEqual({
+      keep: 'x',
+      newKey: 'new-value',
+      obj: { right: 9 }
+    });
+  });
+
+  it('replaces arrays without deep merge', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task-a',
+      memory: {
+        arr: [1, 2, 3]
+      }
+    });
+
+    const merged = mergeContextUpdates(context, {
+      arr: ['a']
+    });
+
+    expect(merged.memory).toEqual({
+      arr: ['a']
+    });
+  });
+
+  it('allows null values and ignores undefined updates', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task-a',
+      memory: {
+        keyA: 'value'
+      }
+    });
+
+    const merged = mergeContextUpdates(context, {
+      keyA: undefined,
+      keyB: null
+    });
+
+    expect(merged.memory).toEqual({
+      keyA: 'value',
+      keyB: null
+    });
+  });
+
+  it('keeps serialized output byte-identical for empty updates', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task-a',
+      memory: {
+        a: 1,
+        b: 2
+      }
+    });
+
+    const before = serializeExecutionContext(context);
+    const merged = mergeContextUpdates(context, {});
+    const after = serializeExecutionContext(merged);
+
+    expect(after).toBe(before);
+  });
+
+  it('applies task result updates and tracks artifact paths deterministically', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task-a',
+      memory: {},
+      artifacts: ['b.md']
+    });
+
+    const merged = applyTaskResultToContext(context, {
+      status: 'success',
+      outputs: {},
+      artifacts: [
+        { kind: 'report', path: 'z.md' },
+        { kind: 'report', path: 'a.md' }
+      ],
+      logs: [],
+      context_updates: {
+        summary: 'ok'
+      }
+    });
+
+    expect(merged.memory).toEqual({ summary: 'ok' });
+    expect(merged.artifacts).toEqual(['a.md', 'b.md', 'z.md']);
+  });
+
+  it('produces deterministic serialized output across repeated merges', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task-a',
+      memory: { a: 1 }
+    });
+
+    const first = mergeContextUpdates(context, { b: 2 });
+    const second = mergeContextUpdates(context, { b: 2 });
+
+    expect(serializeExecutionContext(first)).toBe(serializeExecutionContext(second));
+  });
+});

--- a/control-plane/execution/tests/execution-context.test.ts
+++ b/control-plane/execution/tests/execution-context.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { serializeExecutionContext } from '../context-serializer.ts';
+import {
+  cloneExecutionContext,
+  createEmptyExecutionContext,
+  createExecutionContext,
+  toReadonlyExecutionContext,
+  withExecutionIdentity
+} from '../execution-context.ts';
+
+describe('execution context', () => {
+  it('creates deterministic empty context', () => {
+    const first = createEmptyExecutionContext('run_control-plane_0001');
+    const second = createEmptyExecutionContext('run_control-plane_0001');
+
+    expect(first).toEqual(second);
+    expect(serializeExecutionContext(first)).toBe(serializeExecutionContext(second));
+    expect(first).toEqual({
+      runId: 'run_control-plane_0001',
+      phase: 'plan',
+      taskId: '__run_start__',
+      memory: {},
+      artifacts: [],
+      metadata: {}
+    });
+  });
+
+  it('normalizes ordering for memory, metadata, and artifacts', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'load-run-context',
+      memory: {
+        z: 2,
+        a: 1
+      },
+      artifacts: ['z.md', 'a.md'],
+      metadata: {
+        z: true,
+        a: false
+      }
+    });
+
+    expect(Object.keys(context.memory)).toEqual(['a', 'z']);
+    expect(context.artifacts).toEqual(['a.md', 'z.md']);
+    expect(Object.keys(context.metadata)).toEqual(['a', 'z']);
+  });
+
+  it('clone isolates references', () => {
+    const original = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'load-run-context',
+      memory: { nested: { value: 1 } },
+      artifacts: ['a.md'],
+      metadata: { nested: { ok: true } }
+    });
+
+    const cloned = cloneExecutionContext(original);
+    (cloned.memory.nested as { value: number }).value = 99;
+    (cloned.metadata.nested as { ok: boolean }).ok = false;
+    cloned.artifacts.push('b.md');
+
+    expect(original.memory).toEqual({ nested: { value: 1 } });
+    expect(original.metadata).toEqual({ nested: { ok: true } });
+    expect(original.artifacts).toEqual(['a.md']);
+  });
+
+  it('serializes stably across repeated calls', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'implement',
+      taskId: 'execute-work-unit',
+      memory: {
+        b: { y: 2, x: 1 },
+        a: [2, 1]
+      },
+      metadata: {
+        c: 'x',
+        a: 'y'
+      }
+    });
+
+    const first = serializeExecutionContext(context);
+    const second = serializeExecutionContext(context);
+
+    expect(first).toBe(second);
+  });
+
+  it('updates phase and task identity deterministically', () => {
+    const base = createEmptyExecutionContext('run_control-plane_0001');
+    const updated = withExecutionIdentity(base, {
+      phase: 'verify',
+      taskId: 'verify-phase-output'
+    });
+
+    expect(updated.phase).toBe('verify');
+    expect(updated.taskId).toBe('verify-phase-output');
+    expect(updated.memory).toEqual(base.memory);
+    expect(updated.artifacts).toEqual(base.artifacts);
+  });
+
+  it('provides readonly execution context snapshot', () => {
+    const readonlyContext = toReadonlyExecutionContext(createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'load-run-context',
+      memory: { nested: { count: 1 } }
+    }));
+
+    expect(() => {
+      (readonlyContext.memory as Record<string, unknown>).newKey = 'x';
+    }).toThrow();
+
+    expect(() => {
+      ((readonlyContext.memory.nested as { count: number }).count) = 2;
+    }).toThrow();
+  });
+});

--- a/control-plane/swarm/swarm-runner.test.ts
+++ b/control-plane/swarm/swarm-runner.test.ts
@@ -88,6 +88,14 @@ describe('swarm-runner', () => {
       'test',
       'release'
     ]);
+
+    const completed = inspected.events[inspected.events.length - 1];
+    expect(completed.type).toBe('RUN_COMPLETED');
+    expect(completed.payload).toMatchObject({
+      context_snapshot: {
+        runId: created.runId
+      }
+    });
   });
 
   it('emits TASK_FAILED and RUN_FAILED and stops later phases on task failure', async () => {

--- a/control-plane/swarm/swarm-runner.ts
+++ b/control-plane/swarm/swarm-runner.ts
@@ -1,4 +1,6 @@
 import { createExecutionJournal, type ExecutionJournal } from '../journal/journal.ts';
+import type { ExecutionContext } from '../execution/context-types.ts';
+import { createExecutionContext, createEmptyExecutionContext } from '../execution/execution-context.ts';
 import type { ExecutionEvent, ExecutionRun, RunKind } from '../journal/types.ts';
 import { getOrderedPhases } from './phase-engine.ts';
 import { executePhaseTasks } from './task-executor.ts';
@@ -135,7 +137,6 @@ function buildTaskDefinitions(
       description: task.description,
       type: task.type,
       inputs: task.inputs,
-      executionContext: {},
       ...(executor ? { executor } : {}),
       order: task.order
     });
@@ -277,6 +278,65 @@ function deriveSwarmRunSummary(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toExecutionContextFromPayload(payload: unknown): ExecutionContext | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const snapshot = payload.context_snapshot;
+  if (!isRecord(snapshot)) {
+    return null;
+  }
+
+  const runId = snapshot.runId;
+  const phase = snapshot.phase;
+  const taskId = snapshot.taskId;
+  const memory = snapshot.memory;
+  const artifacts = snapshot.artifacts;
+  const metadata = snapshot.metadata;
+  const missionId = snapshot.missionId;
+
+  if (typeof runId !== 'string' || typeof phase !== 'string' || typeof taskId !== 'string') {
+    return null;
+  }
+  if (!isRecord(memory) || !Array.isArray(artifacts) || !isRecord(metadata)) {
+    return null;
+  }
+  if (!artifacts.every((entry) => typeof entry === 'string')) {
+    return null;
+  }
+  if (missionId !== undefined && typeof missionId !== 'string') {
+    return null;
+  }
+
+  return createExecutionContext({
+    runId,
+    ...(missionId ? { missionId } : {}),
+    phase,
+    taskId,
+    memory,
+    artifacts,
+    metadata
+  });
+}
+
+function deriveLatestExecutionContext(runId: string, events: ExecutionEvent[]): ExecutionContext {
+  const ordered = [...events].sort((left, right) => left.sequence - right.sequence);
+
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const context = toExecutionContextFromPayload(ordered[index].payload);
+    if (context) {
+      return context;
+    }
+  }
+
+  return createEmptyExecutionContext(runId);
+}
+
 export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
   const journal = options.journal ?? createExecutionJournal({ rootDir: options.rootDir });
   const tasksByPhase = buildTaskDefinitions(options.taskExecutors ?? {});
@@ -327,6 +387,8 @@ export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
       return initialSummary;
     }
 
+    const inspected = journal.inspectRun(input.runId);
+    let executionContext = deriveLatestExecutionContext(input.runId, inspected.events);
     const completedPhaseSet = new Set(initialSummary.completedPhases);
 
     for (const phase of getOrderedPhases()) {
@@ -345,6 +407,7 @@ export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
         runId: input.runId,
         phase,
         tasks: tasksByPhase[phase],
+        executionContext,
         emitEvent: (event) => {
           journal.appendEvent({
             runId: input.runId,
@@ -355,6 +418,7 @@ export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
           });
         }
       });
+      executionContext = result.executionContext;
 
       if (result.status === 'failed') {
         journal.appendEvent({
@@ -363,7 +427,8 @@ export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
           phase,
           taskId: result.failedTaskId,
           payload: {
-            failedTaskId: result.failedTaskId ?? null
+            failedTaskId: result.failedTaskId ?? null,
+            context_snapshot: executionContext
           }
         });
         return deriveRunSummary(input.runId);
@@ -381,7 +446,9 @@ export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
       runId: input.runId,
       type: 'RUN_COMPLETED',
       phase: 'release',
-      payload: {}
+      payload: {
+        context_snapshot: executionContext
+      }
     });
 
     return deriveRunSummary(input.runId);

--- a/control-plane/swarm/swarm-types.ts
+++ b/control-plane/swarm/swarm-types.ts
@@ -1,5 +1,6 @@
 import type { ExecutionPhase, ExecutionRun, ExecutionEvent } from '../journal/types.ts';
 import type { TaskType } from '../tasks/task-types.ts';
+import type { ExecutionContext } from '../execution/context-types.ts';
 
 export const SWARM_PHASES = [
   'plan',
@@ -27,7 +28,7 @@ export type SwarmTaskDefinition = {
   order: number;
   type: TaskType;
   inputs: Record<string, unknown>;
-  executionContext?: Record<string, unknown>;
+  executionContext?: ExecutionContext;
   executor?: SwarmTaskExecutor;
 };
 

--- a/control-plane/swarm/task-executor.test.ts
+++ b/control-plane/swarm/task-executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { createEmptyExecutionContext } from '../execution/execution-context.ts';
 import { executePhaseTasks, type TaskExecutionEvent } from './task-executor.ts';
 import type { SwarmTaskDefinition } from './swarm-types.ts';
 
@@ -36,6 +37,7 @@ describe('task-executor', () => {
       runId: 'run_control-plane_0001',
       phase: 'implement',
       tasks: [createTask('a', 1, executed)],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
       emitEvent: (event) => {
         events.push(event);
       }
@@ -57,6 +59,7 @@ describe('task-executor', () => {
         createTask('task-c', 1, executed),
         createTask('task-a', 1, executed)
       ],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
       emitEvent: (event) => {
         events.push(event);
       }
@@ -85,6 +88,7 @@ describe('task-executor', () => {
         createTask('task-b', 2, executed, true),
         createTask('task-c', 3, executed)
       ],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
       emitEvent: (event) => {
         events.push(event);
       }
@@ -115,6 +119,7 @@ describe('task-executor', () => {
         createTask('task-a', 1, executedFirst),
         createTask('task-c', 2, executedFirst)
       ],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
       emitEvent: (event) => {
         first.push(event);
       }
@@ -128,6 +133,7 @@ describe('task-executor', () => {
         createTask('task-a', 1, executedSecond),
         createTask('task-c', 2, executedSecond)
       ],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
       emitEvent: (event) => {
         second.push(event);
       }

--- a/control-plane/swarm/task-executor.ts
+++ b/control-plane/swarm/task-executor.ts
@@ -1,3 +1,7 @@
+import { applyTaskResultToContext } from '../execution/context-merge.ts';
+import { serializeExecutionContext } from '../execution/context-serializer.ts';
+import { toReadonlyExecutionContext, withExecutionIdentity } from '../execution/execution-context.ts';
+import type { ExecutionContext } from '../execution/context-types.ts';
 import { getAdapter } from '../tasks/adapter-registry.ts';
 import type { TaskContext } from '../tasks/task-context.ts';
 import type { TaskResult } from '../tasks/task-result.ts';
@@ -15,12 +19,14 @@ export type PhaseTaskExecutionResult = {
   status: 'completed' | 'failed';
   executedTaskIds: string[];
   failedTaskId?: string;
+  executionContext: ExecutionContext;
 };
 
 export type ExecutePhaseTasksInput = {
   runId: string;
   phase: SwarmPhase;
   tasks: SwarmTaskDefinition[];
+  executionContext: ExecutionContext;
   emitEvent: (event: TaskExecutionEvent) => void;
 };
 
@@ -75,27 +81,42 @@ function runLegacyExecutor(task: SwarmTaskDefinition): TaskResult {
   }
 }
 
-function buildTaskContext(runId: string, phase: SwarmPhase, task: SwarmTaskDefinition): TaskContext {
+function buildTaskContext(
+  runId: string,
+  phase: SwarmPhase,
+  task: SwarmTaskDefinition,
+  executionContext: ExecutionContext
+): TaskContext {
   return {
     runId,
     phase,
     taskId: task.taskId,
     taskType: task.type,
     inputs: task.inputs,
-    executionContext: task.executionContext ?? {}
+    executionContext: toReadonlyExecutionContext(executionContext)
   };
+}
+
+function parseSerializedContext(serialized: string): Record<string, unknown> {
+  return JSON.parse(serialized) as Record<string, unknown>;
 }
 
 export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<PhaseTaskExecutionResult> {
   const orderedTasks = sortTasks(input.tasks);
   const executedTaskIds: string[] = [];
+  let phaseContext = input.executionContext;
 
   for (const task of orderedTasks) {
     if (task.phase !== input.phase) {
       throw new Error(`TASK_PHASE_MISMATCH: ${task.taskId}`);
     }
 
-    const taskContext = buildTaskContext(input.runId, input.phase, task);
+    const taskExecutionContext = withExecutionIdentity(phaseContext, {
+      phase: input.phase,
+      taskId: task.taskId
+    });
+
+    const taskContext = buildTaskContext(input.runId, input.phase, task, taskExecutionContext);
 
     input.emitEvent({
       type: 'TASK_STARTED',
@@ -104,7 +125,9 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
       payload: {
         runId: input.runId,
         taskType: task.type,
-        inputs: task.inputs
+        inputs: task.inputs,
+        task_inputs: task.inputs,
+        context_snapshot: parseSerializedContext(serializeExecutionContext(taskExecutionContext))
       }
     });
 
@@ -112,8 +135,11 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
       ? runLegacyExecutor(task)
       : await executeByAdapter(taskContext);
 
+    const nextContext = applyTaskResultToContext(taskExecutionContext, result);
+
     if (result.status === 'success') {
       executedTaskIds.push(task.taskId);
+      phaseContext = nextContext;
       input.emitEvent({
         type: 'TASK_COMPLETED',
         phase: input.phase,
@@ -121,12 +147,15 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
         payload: {
           runId: input.runId,
           taskType: task.type,
-          result
+          result,
+          task_outputs: result.outputs,
+          context_snapshot: parseSerializedContext(serializeExecutionContext(nextContext))
         }
       });
       continue;
     }
 
+    phaseContext = nextContext;
     input.emitEvent({
       type: 'TASK_FAILED',
       phase: input.phase,
@@ -135,6 +164,8 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
         runId: input.runId,
         taskType: task.type,
         result,
+        task_outputs: result.outputs,
+        context_snapshot: parseSerializedContext(serializeExecutionContext(nextContext)),
         error: result.errorMessage ?? 'TASK_EXECUTION_FAILED'
       }
     });
@@ -143,13 +174,15 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
       phase: input.phase,
       status: 'failed',
       executedTaskIds,
-      failedTaskId: task.taskId
+      failedTaskId: task.taskId,
+      executionContext: phaseContext
     };
   }
 
   return {
     phase: input.phase,
     status: 'completed',
-    executedTaskIds
+    executedTaskIds,
+    executionContext: phaseContext
   };
 }

--- a/control-plane/tasks/task-context.ts
+++ b/control-plane/tasks/task-context.ts
@@ -1,4 +1,5 @@
 import type { TaskType } from './task-types.ts';
+import type { ExecutionContext } from '../execution/context-types.ts';
 
 export type TaskContext = {
   runId: string;
@@ -6,5 +7,5 @@ export type TaskContext = {
   taskId: string;
   taskType: TaskType;
   inputs: Record<string, unknown>;
-  executionContext: Record<string, unknown>;
+  executionContext: Readonly<ExecutionContext>;
 };

--- a/control-plane/tasks/task-result.ts
+++ b/control-plane/tasks/task-result.ts
@@ -5,6 +5,7 @@ export type TaskResult = {
   outputs: Record<string, unknown>;
   artifacts: Array<Record<string, unknown>>;
   logs: string[];
+  context_updates?: Record<string, unknown>;
   errorCode?: string;
   errorMessage?: string;
 };

--- a/control-plane/tasks/tests/llm-task.test.ts
+++ b/control-plane/tasks/tests/llm-task.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { createExecutionContext } from '../../execution/execution-context.ts';
 import { llmTaskAdapter } from '../adapters/llm-task.ts';
 import type { TaskContext } from '../task-context.ts';
 
@@ -10,7 +11,11 @@ function context(inputs: Record<string, unknown>): TaskContext {
     taskId: 'task_llm',
     taskType: 'llm',
     inputs,
-    executionContext: {}
+    executionContext: createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'setup',
+      taskId: 'task_llm'
+    })
   };
 }
 

--- a/control-plane/tasks/tests/repo-task.test.ts
+++ b/control-plane/tasks/tests/repo-task.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { createExecutionContext } from '../../execution/execution-context.ts';
 import { repoTaskAdapter } from '../adapters/repo-task.ts';
 import type { TaskContext } from '../task-context.ts';
 
@@ -20,7 +21,11 @@ function context(inputs: Record<string, unknown>): TaskContext {
     taskId: 'task_repo',
     taskType: 'repo',
     inputs,
-    executionContext: {}
+    executionContext: createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'implement',
+      taskId: 'task_repo'
+    })
   };
 }
 

--- a/control-plane/tasks/tests/shell-task.test.ts
+++ b/control-plane/tasks/tests/shell-task.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { createExecutionContext } from '../../execution/execution-context.ts';
 import { shellTaskAdapter } from '../adapters/shell-task.ts';
 import type { TaskContext } from '../task-context.ts';
 
@@ -20,7 +21,11 @@ function context(inputs: Record<string, unknown>): TaskContext {
     taskId: 'task_shell',
     taskType: 'shell',
     inputs,
-    executionContext: {}
+    executionContext: createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'verify',
+      taskId: 'task_shell'
+    })
   };
 }
 

--- a/control-plane/tasks/tests/swarm-runner-task-adapters.test.ts
+++ b/control-plane/tasks/tests/swarm-runner-task-adapters.test.ts
@@ -46,21 +46,36 @@ describe('swarm runner task adapter integration', () => {
       inputs: {
         prompt: 'Load deterministic run context'
       },
-      executionContext: {}
+      executionContext: {
+        runId: created.runId,
+        phase: 'setup',
+        taskId: 'load-run-context',
+        memory: {},
+        artifacts: [],
+        metadata: {}
+      }
     });
 
     const taskStarted = inspected.events.find((event) => event.type === 'TASK_STARTED' && event.taskId === 'load-run-context');
     const taskCompleted = inspected.events.find((event) => event.type === 'TASK_COMPLETED' && event.taskId === 'load-run-context');
 
-    expect(taskStarted?.payload).toEqual({
+    expect(taskStarted?.payload).toMatchObject({
       runId: created.runId,
       taskType: 'llm',
       inputs: {
         prompt: 'Load deterministic run context'
+      },
+      task_inputs: {
+        prompt: 'Load deterministic run context'
+      },
+      context_snapshot: {
+        runId: created.runId,
+        phase: 'setup',
+        taskId: 'load-run-context'
       }
     });
 
-    expect(taskCompleted?.payload).toEqual({
+    expect(taskCompleted?.payload).toMatchObject({
       runId: created.runId,
       taskType: 'llm',
       result: {
@@ -71,6 +86,18 @@ describe('swarm runner task adapter integration', () => {
         },
         artifacts: [],
         logs: ['LLM_TASK_EXECUTED_STUB_MODE']
+      },
+      task_outputs: {
+        response: 'stub:deterministic-stub-model:Load deterministic run context',
+        mode: 'stub'
+      },
+      context_snapshot: {
+        runId: created.runId,
+        phase: 'setup',
+        taskId: 'load-run-context',
+        memory: {},
+        artifacts: [],
+        metadata: {}
       }
     });
   });
@@ -96,7 +123,7 @@ describe('swarm runner task adapter integration', () => {
     expect(finalSummary.failedPhase).toBe('setup');
 
     const failedEvent = inspected.events.find((event) => event.type === 'TASK_FAILED' && event.taskId === 'load-run-context');
-    expect(failedEvent?.payload).toEqual({
+    expect(failedEvent?.payload).toMatchObject({
       runId: created.runId,
       taskType: 'llm',
       result: {
@@ -107,9 +134,122 @@ describe('swarm runner task adapter integration', () => {
         errorCode: 'ERR_TEST_FAILURE',
         errorMessage: 'forced-failure'
       },
+      task_outputs: {},
+      context_snapshot: {
+        runId: created.runId,
+        phase: 'setup',
+        taskId: 'load-run-context'
+      },
       error: 'forced-failure'
     });
 
     expect(inspected.events[inspected.events.length - 1].type).toBe('RUN_FAILED');
+  });
+
+  it('propagates context_updates to downstream tasks across phases', async () => {
+    vi.spyOn(llmTaskAdapter, 'execute').mockImplementation(async (context) => {
+      if (context.taskId === 'load-run-context') {
+        return {
+          status: 'success',
+          outputs: { seeded: true },
+          artifacts: [],
+          logs: ['LLM_TASK_EXECUTED_STUB_MODE'],
+          context_updates: {
+            research_summary: 'deterministic-summary'
+          }
+        };
+      }
+
+      if (context.taskId === 'run-phase-checks') {
+        return {
+          status: 'success',
+          outputs: {
+            observed: context.executionContext.memory.research_summary
+          },
+          artifacts: [],
+          logs: ['LLM_TASK_EXECUTED_STUB_MODE']
+        };
+      }
+
+      return {
+        status: 'success',
+        outputs: {},
+        artifacts: [],
+        logs: ['LLM_TASK_EXECUTED_STUB_MODE']
+      };
+    });
+
+    const runner = createSwarmRunner({ rootDir: tmpRoot });
+    const created = runner.createSwarmRun({ projectId: 'control-plane' });
+    await runner.executeSwarmRun({ runId: created.runId });
+
+    const journal = createExecutionJournal({ rootDir: tmpRoot });
+    const inspected = journal.inspectRun(created.runId);
+    const downstream = inspected.events.find((event) => event.type === 'TASK_COMPLETED' && event.taskId === 'run-phase-checks');
+
+    expect(downstream?.payload).toMatchObject({
+      task_outputs: {
+        observed: 'deterministic-summary'
+      },
+      context_snapshot: {
+        memory: {
+          research_summary: 'deterministic-summary'
+        }
+      }
+    });
+  });
+
+  it('prevents adapters from mutating shared execution context by reference', async () => {
+    vi.spyOn(llmTaskAdapter, 'execute').mockImplementation(async (context) => {
+      if (context.taskId === 'load-run-context') {
+        expect(() => {
+          (context.executionContext.memory as Record<string, unknown>).unsafe = 'mutation';
+        }).toThrow();
+
+        return {
+          status: 'success',
+          outputs: {},
+          artifacts: [],
+          logs: ['LLM_TASK_EXECUTED_STUB_MODE'],
+          context_updates: {
+            safe: 'update'
+          }
+        };
+      }
+
+      if (context.taskId === 'run-phase-checks') {
+        return {
+          status: 'success',
+          outputs: {
+            safe: context.executionContext.memory.safe,
+            unsafe: context.executionContext.memory.unsafe ?? null
+          },
+          artifacts: [],
+          logs: ['LLM_TASK_EXECUTED_STUB_MODE']
+        };
+      }
+
+      return {
+        status: 'success',
+        outputs: {},
+        artifacts: [],
+        logs: ['LLM_TASK_EXECUTED_STUB_MODE']
+      };
+    });
+
+    const runner = createSwarmRunner({ rootDir: tmpRoot });
+    const created = runner.createSwarmRun({ projectId: 'control-plane' });
+    await runner.executeSwarmRun({ runId: created.runId });
+
+    const journal = createExecutionJournal({ rootDir: tmpRoot });
+    const inspected = journal.inspectRun(created.runId);
+    const downstream = inspected.events.find((event) => event.type === 'TASK_COMPLETED' && event.taskId === 'run-phase-checks');
+
+    expect(downstream?.payload).toMatchObject({
+      task_outputs: {
+        safe: 'update',
+        unsafe: null
+      }
+    });
   });
 });

--- a/docs/architecture/execution-memory-bus.md
+++ b/docs/architecture/execution-memory-bus.md
@@ -1,0 +1,62 @@
+# Execution Memory Bus
+
+## Why It Exists
+Sprint 65 introduces a deterministic execution memory bus so swarm tasks can pass structured state to downstream tasks and phases without hidden mutation.
+
+Before this change, tasks executed in isolation. After this change, each task may emit `context_updates` and the runtime applies those updates to a shared execution context that is threaded through the run.
+
+## Execution Context Model
+`ExecutionContext` lives in `control-plane/execution/context-types.ts`:
+
+- `runId: string`
+- `missionId?: string`
+- `phase: string`
+- `taskId: string`
+- `memory: Record<string, unknown>`
+- `artifacts: string[]`
+- `metadata: Record<string, unknown>`
+
+Construction and identity helpers are in `control-plane/execution/execution-context.ts`.
+
+## Merge Semantics
+`control-plane/execution/context-merge.ts` implements deterministic merge rules:
+
+- Shallow key replacement only.
+- No deep merge.
+- Arrays are replaced wholesale.
+- Objects are replaced wholesale.
+- `undefined` update values are ignored.
+- `null` is preserved.
+
+The merge API is pure and returns a new context.
+
+## Runtime Propagation Flow
+Swarm runtime flow in `control-plane/swarm/swarm-runner.ts` and `control-plane/swarm/task-executor.ts`:
+
+1. Initialize context for run.
+2. Set task identity (`phase`, `taskId`) before each task.
+3. Pass frozen read-only context into adapter execution.
+4. Apply `TaskResult.context_updates` through merge engine.
+5. Emit journal event payload with `task_inputs`, `task_outputs`, `context_snapshot`.
+6. Pass updated context to downstream tasks.
+
+## Determinism Guarantees
+- Context serialization uses canonical key ordering via `canonicalStringify`.
+- No timestamps are stored in context snapshots.
+- No random IDs are introduced.
+- Task ordering remains deterministic by `(order, taskId)`.
+- Empty updates are a no-op at serialized context level.
+
+## Adapter Contract
+Adapters receive `TaskContext.executionContext` as a frozen read-only snapshot.
+
+Adapters must not mutate it directly. All state changes must be returned in `TaskResult.context_updates`.
+
+## Journal Snapshot Behavior
+No new event types were added. Existing task lifecycle event payloads now include deterministic fields:
+
+- `task_inputs`
+- `task_outputs`
+- `context_snapshot`
+
+These snapshots are replayable and used by `swarm:inspect` to reconstruct current memory/artifact state.

--- a/docs/runbooks/execution-context.md
+++ b/docs/runbooks/execution-context.md
@@ -1,0 +1,63 @@
+# Execution Context Runbook
+
+## Purpose
+Use this runbook to debug deterministic context propagation in swarm runs.
+
+## Inspect a Run
+Run:
+
+```bash
+npm run swarm:inspect -- --run <runId>
+```
+
+Output includes:
+
+- `runId`
+- `currentPhase`
+- `tasks`
+- `context.memory`
+- `context.artifacts`
+- `context.metadata`
+
+All output is canonical JSON with stable ordering.
+
+## Expected `context_updates` Shape
+Each task can return:
+
+```ts
+{
+  context_updates: {
+    key_name: value
+  }
+}
+```
+
+Rules:
+
+- Keys must be deterministic strings.
+- Values must be structured JSON-compatible data.
+- No direct context mutation.
+
+## Debugging Propagation
+If downstream tasks do not see expected values:
+
+1. Inspect `TASK_COMPLETED` payload for upstream task and verify `task_outputs` and `context_snapshot`.
+2. Inspect `TASK_STARTED` payload for downstream task and verify `context_snapshot.memory` includes expected keys.
+3. Check that upstream adapter returned `context_updates` (not only `outputs`).
+
+## Common Failure Modes
+- Returning data in `outputs` but not `context_updates`.
+- Attempting to mutate `executionContext` directly inside adapter (blocked by frozen snapshot).
+- Assuming deep-merge behavior for object/array values.
+
+## Determinism Pitfalls to Avoid
+- Do not add timestamps to context snapshots.
+- Do not depend on filesystem enumeration order.
+- Do not depend on object insertion order from non-canonical sources.
+- Do not add random identifiers to context state.
+
+## Best Practices
+- Keep `context_updates` small and explicit.
+- Use stable key names for memory fields.
+- Prefer one logical update payload per task.
+- Validate context flow with `swarm:inspect` and task lifecycle journal events.

--- a/entities/projects/control-plane.json
+++ b/entities/projects/control-plane.json
@@ -6,6 +6,7 @@
   "mode": "structured",
   "ownedPaths": [
     "control-plane/cli/",
+    "control-plane/execution/",
     "control-plane/entities/",
     "control-plane/governance/",
     "control-plane/projects/",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "demo:scenario": "bash scripts/demo.sh --scenario",
     "swarm:execute": "node --experimental-strip-types control-plane/cli/swarm-execute.ts",
     "swarm:run": "node --experimental-strip-types control-plane/cli/swarm-run.ts",
+    "swarm:inspect": "node --experimental-strip-types control-plane/cli/swarm-inspect.ts",
     "journal:create": "node --experimental-strip-types control-plane/cli/journal-create.ts",
     "journal:event": "node --experimental-strip-types control-plane/cli/journal-event.ts",
     "journal:inspect": "node --experimental-strip-types control-plane/cli/journal-inspect.ts",


### PR DESCRIPTION
tier-3

```evidence
- Added deterministic execution memory bus under control-plane/execution/.
- Extended TaskResult with context_updates for task-to-task state propagation.
- Threaded read-only execution context through swarm runtime and adapters.
- Added deterministic context merge + serialization behavior.
- Extended journal payloads with task_inputs, task_outputs, and context_snapshot.
- Added swarm:inspect CLI for stable run context inspection.
- Added docs:
  - docs/architecture/execution-memory-bus.md
  - docs/runbooks/execution-context.md
- Validation passed:
  - npm test
  - npm run build
  - npm run typecheck
  - npm run governance:preflight