### PR TITLE
Sprint 67: Agent Runtime Integration

### DIFF
--- a/control-plane/agents/runtime/agent-context.ts
+++ b/control-plane/agents/runtime/agent-context.ts
@@ -1,0 +1,44 @@
+import { createExecutionContext } from '../../execution/execution-context.ts';
+import type { ExecutionContext } from '../../execution/context-types.ts';
+import type { AgentExecutionEnvelope } from './agent-envelope.ts';
+
+export type AgentRuntimeContextInput = {
+  teamId?: string;
+  activeAgent: string;
+  agentEnvelope: AgentExecutionEnvelope;
+  agentRoster: AgentExecutionEnvelope[];
+};
+
+function sortedRoster(roster: AgentExecutionEnvelope[]): AgentExecutionEnvelope[] {
+  return [...roster].sort((left, right) => left.agentId.localeCompare(right.agentId));
+}
+
+export function withAgentContext(
+  baseContext: ExecutionContext,
+  runtimeInfo: AgentRuntimeContextInput
+): ExecutionContext {
+  const metadata = {
+    ...baseContext.metadata,
+    teamId: runtimeInfo.teamId ?? baseContext.teamId ?? baseContext.metadata.teamId,
+    agentId: runtimeInfo.activeAgent,
+    ...(runtimeInfo.agentEnvelope.role ? { agentRole: runtimeInfo.agentEnvelope.role } : {})
+  };
+
+  return createExecutionContext({
+    runId: baseContext.runId,
+    ...(baseContext.missionId ? { missionId: baseContext.missionId } : {}),
+    ...(runtimeInfo.teamId || baseContext.teamId ? { teamId: runtimeInfo.teamId ?? baseContext.teamId } : {}),
+    phase: baseContext.phase,
+    taskId: baseContext.taskId,
+    memory: baseContext.memory,
+    artifacts: baseContext.artifacts,
+    metadata,
+    activeAgent: runtimeInfo.activeAgent,
+    agentEnvelope: runtimeInfo.agentEnvelope,
+    agentRoster: sortedRoster(runtimeInfo.agentRoster)
+  });
+}
+
+export function getActiveAgentFromContext(context: ExecutionContext): string | undefined {
+  return context.activeAgent;
+}

--- a/control-plane/agents/runtime/agent-envelope.ts
+++ b/control-plane/agents/runtime/agent-envelope.ts
@@ -1,0 +1,96 @@
+import { canonicalStringify } from '../../finance/determinism.ts';
+import { SUPPORTED_AGENT_ADAPTERS, type AgentProfileDefinition } from '../agent-profile-types.ts';
+
+export type AgentExecutionEnvelope = {
+  agentId: string;
+  role?: string;
+  personality: {
+    tone?: string;
+    reasoningStyle?: string;
+    [key: string]: unknown;
+  };
+  skills: string[];
+  background: Record<string, unknown>;
+  outputStyle: Record<string, unknown>;
+  constraints: {
+    mustDo?: string[];
+    mustNotDo?: string[];
+    [key: string]: unknown;
+  };
+  allowedTools: string[];
+};
+
+type BuildEnvelopeInput = Pick<AgentProfileDefinition,
+'agentId' | 'role' | 'personalityProfile' | 'skillsProfile' | 'backgroundProfile' | 'outputProfile' | 'constraintsProfile' | 'toolProfile'>;
+
+function sortRecord<T>(record: Record<string, T>): Record<string, T> {
+  const entries = Object.entries(record)
+    .filter(([, value]) => value !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return Object.fromEntries(entries);
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.trim().length > 0)))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function stableClone<T>(value: T): T {
+  return JSON.parse(canonicalStringify(value)) as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      deepFreeze(entry);
+    }
+    return Object.freeze(value);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    for (const key of Object.keys(objectValue)) {
+      deepFreeze(objectValue[key]);
+    }
+    return Object.freeze(value);
+  }
+
+  return value;
+}
+
+function deriveSkills(profile: BuildEnvelopeInput): string[] {
+  return sortedUnique([
+    ...(profile.skillsProfile?.coreSkills ?? []),
+    ...(profile.skillsProfile?.secondarySkills ?? []),
+    ...(profile.skillsProfile?.domains ?? [])
+  ]);
+}
+
+function deriveAllowedTools(profile: BuildEnvelopeInput): string[] {
+  const allowlist = sortedUnique(profile.toolProfile?.allowedAdapters ?? [...SUPPORTED_AGENT_ADAPTERS]);
+  const forbidden = new Set(sortedUnique(profile.toolProfile?.forbiddenTools ?? []));
+
+  return allowlist
+    .filter((adapter) => !forbidden.has(adapter))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function buildAgentExecutionEnvelope(profile: BuildEnvelopeInput): AgentExecutionEnvelope {
+  const personality = sortRecord(stableClone(profile.personalityProfile ?? {}));
+  const background = sortRecord(stableClone(profile.backgroundProfile ?? {}));
+  const outputStyle = sortRecord(stableClone(profile.outputProfile ?? {}));
+  const constraints = sortRecord(stableClone(profile.constraintsProfile ?? {}));
+
+  const envelope: AgentExecutionEnvelope = {
+    agentId: profile.agentId,
+    ...(profile.role ? { role: profile.role } : {}),
+    personality,
+    skills: deriveSkills(profile),
+    background,
+    outputStyle,
+    constraints,
+    allowedTools: deriveAllowedTools(profile)
+  };
+
+  return deepFreeze(stableClone(envelope));
+}

--- a/control-plane/agents/runtime/agent-runtime.ts
+++ b/control-plane/agents/runtime/agent-runtime.ts
@@ -1,0 +1,143 @@
+import { loadAgentProfilesFromDir } from '../agent-profile-loader.ts';
+import type { AgentProfileDefinition } from '../agent-profile-types.ts';
+import type { ExecutionContext } from '../../execution/context-types.ts';
+import { buildAgentExecutionEnvelope, type AgentExecutionEnvelope } from './agent-envelope.ts';
+
+export type AgentRuntimeInfo = {
+  teamId?: string;
+  activeAgent: string;
+  agentEnvelope: AgentExecutionEnvelope;
+  agentRoster: AgentExecutionEnvelope[];
+};
+
+type ResolveAgentProfileInput = {
+  agentId: string;
+  profiles?: AgentProfileDefinition[];
+  agentsDir?: string;
+};
+
+type ResolveTaskAgentInput = {
+  taskAgent: string;
+  executionContext: ExecutionContext;
+  profiles?: AgentProfileDefinition[];
+  agentsDir?: string;
+};
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function parseErrorCode(message: string): string {
+  const prefix = message.match(/^(ERR_[A-Z0-9_]+):/);
+  return prefix ? prefix[1] : 'ERR_AGENT_RUNTIME_INVALID';
+}
+
+function extractRosterFromMetadata(context: ExecutionContext): string[] {
+  const roster = context.metadata.agentRoster;
+  if (!Array.isArray(roster)) {
+    return [];
+  }
+
+  const ids = roster.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+  return sortedUnique(ids);
+}
+
+function resolveTeamId(context: ExecutionContext): string | undefined {
+  if (context.teamId) {
+    return context.teamId;
+  }
+
+  const metadataTeamId = context.metadata.teamId;
+  if (typeof metadataTeamId === 'string' && metadataTeamId.trim().length > 0) {
+    return metadataTeamId;
+  }
+
+  return undefined;
+}
+
+function profileIndex(profiles: AgentProfileDefinition[]): Map<string, AgentProfileDefinition> {
+  return new Map(profiles.map((profile) => [profile.agentId, profile]));
+}
+
+function getProfiles(input: { profiles?: AgentProfileDefinition[]; agentsDir?: string }): AgentProfileDefinition[] {
+  return input.profiles ?? loadAgentProfilesFromDir(input.agentsDir);
+}
+
+export function resolveAgentProfile(input: ResolveAgentProfileInput): AgentProfileDefinition {
+  const profiles = getProfiles(input);
+  const profile = profiles.find((entry) => entry.agentId === input.agentId);
+  if (!profile) {
+    throw new Error(`ERR_AGENT_NOT_FOUND: Agent profile not found: ${input.agentId}`);
+  }
+  return profile;
+}
+
+export function resolveMissionAgentRoster(
+  context: ExecutionContext,
+  profiles: AgentProfileDefinition[]
+): AgentExecutionEnvelope[] {
+  const rosterIds = extractRosterFromMetadata(context);
+  if (rosterIds.length === 0) {
+    return [];
+  }
+
+  const indexed = profileIndex(profiles);
+  return rosterIds.map((agentId) => {
+    const profile = indexed.get(agentId);
+    if (!profile) {
+      throw new Error(`ERR_AGENT_NOT_FOUND: Agent profile not found: ${agentId}`);
+    }
+    return buildAgentExecutionEnvelope(profile);
+  });
+}
+
+export function buildAgentRuntime(input: ResolveTaskAgentInput): AgentRuntimeInfo {
+  const profiles = getProfiles(input);
+  const roster = resolveMissionAgentRoster(input.executionContext, profiles);
+  const rosterIds = roster.map((entry) => entry.agentId);
+
+  if (rosterIds.length > 0) {
+    const matching = rosterIds.filter((agentId) => agentId === input.taskAgent);
+    if (matching.length > 1) {
+      throw new Error(`ERR_TASK_AGENT_AMBIGUOUS: Agent resolution is ambiguous for ${input.taskAgent}`);
+    }
+    if (matching.length === 0) {
+      throw new Error(
+        `ERR_TASK_AGENT_UNRESOLVED: Agent ${input.taskAgent} is not part of the mission roster`
+      );
+    }
+  }
+
+  const envelope = buildAgentExecutionEnvelope(resolveAgentProfile({
+    agentId: input.taskAgent,
+    profiles
+  }));
+
+  const agentRoster = roster.length > 0
+    ? roster
+    : [envelope];
+
+  return {
+    teamId: resolveTeamId(input.executionContext),
+    activeAgent: envelope.agentId,
+    agentEnvelope: envelope,
+    agentRoster
+  };
+}
+
+export function resolveTaskAgent(input: ResolveTaskAgentInput): AgentRuntimeInfo {
+  if (typeof input.taskAgent !== 'string' || input.taskAgent.trim().length === 0) {
+    throw new Error('ERR_TASK_AGENT_UNRESOLVED: task.agent must be a non-empty string');
+  }
+
+  try {
+    return buildAgentRuntime(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ERR_AGENT_RUNTIME_INVALID: invalid agent runtime state';
+    const code = parseErrorCode(message);
+    if (message.startsWith(`${code}:`)) {
+      throw new Error(message);
+    }
+    throw new Error(`${code}: ${message}`);
+  }
+}

--- a/control-plane/agents/runtime/agent-tools.ts
+++ b/control-plane/agents/runtime/agent-tools.ts
@@ -1,0 +1,19 @@
+import { TASK_TYPES, type TaskType } from '../../tasks/task-types.ts';
+import type { AgentExecutionEnvelope } from './agent-envelope.ts';
+
+function isTaskType(value: string): value is TaskType {
+  return TASK_TYPES.includes(value as TaskType);
+}
+
+export function assertAgentCanUseAdapter(agentEnvelope: AgentExecutionEnvelope, adapterId: string): void {
+  if (!isTaskType(adapterId)) {
+    throw new Error(`ERR_AGENT_RUNTIME_INVALID: Unsupported adapter identifier: ${adapterId}`);
+  }
+
+  if (!agentEnvelope.allowedTools.includes(adapterId)) {
+    const allowed = agentEnvelope.allowedTools.join(', ');
+    throw new Error(
+      `ERR_AGENT_TOOL_FORBIDDEN: Agent ${agentEnvelope.agentId} cannot use adapter ${adapterId}. Allowed adapters: ${allowed}`
+    );
+  }
+}

--- a/control-plane/agents/runtime/tests/agent-envelope.test.ts
+++ b/control-plane/agents/runtime/tests/agent-envelope.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentProfileDefinition } from '../../agent-profile-types.ts';
+import { buildAgentExecutionEnvelope } from '../agent-envelope.ts';
+
+function createProfile(overrides: Partial<AgentProfileDefinition> = {}): AgentProfileDefinition {
+  return {
+    agentId: 'macro-signal-analyst',
+    displayName: 'Macro Signal Analyst',
+    role: 'macro-analyst',
+    projectId: 'smartfunds-core',
+    adapterType: 'llm',
+    personalityProfile: {
+      tone: 'analytical',
+      reasoningStyle: 'evidence-first',
+      temperament: 'calm',
+      collaborationStyle: 'iterative',
+      communicationStyle: 'concise'
+    },
+    skillsProfile: {
+      coreSkills: ['macro analysis', 'scenario building'],
+      secondarySkills: ['risk framing'],
+      domains: ['credit', 'tokenization']
+    },
+    backgroundProfile: {
+      professionalArchetype: 'macro strategist',
+      domainBackground: ['fixed income', 'liquidity cycles'],
+      perspectiveBiases: ['downside containment']
+    },
+    outputProfile: {
+      preferredFormat: 'analysis brief',
+      verbosity: 'medium',
+      citationStyle: 'internal evidence references',
+      decisionStyle: 'state tradeoffs'
+    },
+    constraintsProfile: {
+      mustDo: ['differentiate scenarios'],
+      mustNotDo: ['hide uncertainty']
+    },
+    toolProfile: {
+      allowedAdapters: ['repo', 'llm', 'shell'],
+      preferredTools: ['llm'],
+      forbiddenTools: ['shell']
+    },
+    ...overrides
+  };
+}
+
+describe('agent envelope', () => {
+  it('T-AR1 maps profile to deterministic execution envelope', () => {
+    const profile = createProfile();
+    const envelope = buildAgentExecutionEnvelope(profile);
+
+    expect(envelope).toEqual({
+      agentId: 'macro-signal-analyst',
+      role: 'macro-analyst',
+      personality: {
+        collaborationStyle: 'iterative',
+        communicationStyle: 'concise',
+        reasoningStyle: 'evidence-first',
+        temperament: 'calm',
+        tone: 'analytical'
+      },
+      skills: [
+        'credit',
+        'macro analysis',
+        'risk framing',
+        'scenario building',
+        'tokenization'
+      ],
+      background: {
+        domainBackground: ['fixed income', 'liquidity cycles'],
+        perspectiveBiases: ['downside containment'],
+        professionalArchetype: 'macro strategist'
+      },
+      outputStyle: {
+        citationStyle: 'internal evidence references',
+        decisionStyle: 'state tradeoffs',
+        preferredFormat: 'analysis brief',
+        verbosity: 'medium'
+      },
+      constraints: {
+        mustDo: ['differentiate scenarios'],
+        mustNotDo: ['hide uncertainty']
+      },
+      allowedTools: ['llm', 'repo']
+    });
+  });
+
+  it('T-AR2 keeps deterministic ordering for repeated calls and freezes the envelope', () => {
+    const profile = createProfile({
+      skillsProfile: {
+        coreSkills: ['b', 'a'],
+        secondarySkills: ['c'],
+        domains: ['d', 'a']
+      },
+      toolProfile: {
+        allowedAdapters: ['shell', 'llm', 'repo'],
+        preferredTools: ['repo'],
+        forbiddenTools: ['shell']
+      }
+    });
+
+    const first = buildAgentExecutionEnvelope(profile);
+    const second = buildAgentExecutionEnvelope(profile);
+
+    expect(first).toEqual(second);
+    expect(first.skills).toEqual(['a', 'b', 'c', 'd']);
+    expect(first.allowedTools).toEqual(['llm', 'repo']);
+
+    expect(() => {
+      (first.allowedTools as string[]).push('shell');
+    }).toThrow();
+  });
+});

--- a/control-plane/agents/runtime/tests/agent-runtime.test.ts
+++ b/control-plane/agents/runtime/tests/agent-runtime.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentProfileDefinition } from '../../agent-profile-types.ts';
+import { createExecutionContext } from '../../../execution/execution-context.ts';
+import { resolveAgentProfile, resolveMissionAgentRoster, resolveTaskAgent } from '../agent-runtime.ts';
+
+const profiles: AgentProfileDefinition[] = [
+  {
+    agentId: 'lead-thesis-architect',
+    displayName: 'Lead Thesis Architect',
+    role: 'research-lead',
+    projectId: 'smartfunds-core',
+    adapterType: 'llm',
+    personalityProfile: {
+      tone: 'measured',
+      reasoningStyle: 'top-down synthesis',
+      temperament: 'calm',
+      collaborationStyle: 'delegates detail work',
+      communicationStyle: 'structured'
+    },
+    skillsProfile: {
+      coreSkills: ['market synthesis', 'thesis construction'],
+      secondarySkills: ['summarization'],
+      domains: ['RWA']
+    },
+    backgroundProfile: {
+      professionalArchetype: 'buy-side strategist',
+      domainBackground: ['private markets'],
+      perspectiveBiases: ['asymmetric opportunities']
+    },
+    outputProfile: {
+      preferredFormat: 'memo',
+      verbosity: 'medium',
+      citationStyle: 'internal',
+      decisionStyle: 'rank and justify'
+    },
+    constraintsProfile: {
+      mustDo: ['state assumptions'],
+      mustNotDo: ['overstate market size']
+    },
+    toolProfile: {
+      allowedAdapters: ['llm', 'repo'],
+      preferredTools: ['llm'],
+      forbiddenTools: ['shell']
+    }
+  },
+  {
+    agentId: 'macro-signal-analyst',
+    displayName: 'Macro Signal Analyst',
+    role: 'macro-analyst',
+    projectId: 'smartfunds-core',
+    adapterType: 'llm',
+    personalityProfile: {
+      tone: 'analytical',
+      reasoningStyle: 'evidence-first',
+      temperament: 'skeptical',
+      collaborationStyle: 'iterative',
+      communicationStyle: 'concise'
+    },
+    skillsProfile: {
+      coreSkills: ['macro analysis'],
+      secondarySkills: ['risk framing'],
+      domains: ['credit']
+    },
+    backgroundProfile: {
+      professionalArchetype: 'macro strategist',
+      domainBackground: ['fixed income'],
+      perspectiveBiases: ['downside containment']
+    },
+    outputProfile: {
+      preferredFormat: 'analysis brief',
+      verbosity: 'medium',
+      citationStyle: 'internal',
+      decisionStyle: 'tradeoffs'
+    },
+    constraintsProfile: {
+      mustDo: ['differentiate scenarios'],
+      mustNotDo: ['hide uncertainty']
+    },
+    toolProfile: {
+      allowedAdapters: ['llm', 'repo'],
+      preferredTools: ['llm'],
+      forbiddenTools: ['shell']
+    }
+  }
+];
+
+describe('agent runtime', () => {
+  it('T-AR3 resolves deterministic mission roster from execution context metadata', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      missionId: 'rwa-market-analysis',
+      teamId: 'smartfunds-research-team',
+      phase: 'implement',
+      taskId: 'research',
+      metadata: {
+        agentRoster: ['macro-signal-analyst', 'lead-thesis-architect', 'macro-signal-analyst']
+      }
+    });
+
+    const roster = resolveMissionAgentRoster(context, profiles);
+
+    expect(roster.map((entry) => entry.agentId)).toEqual([
+      'lead-thesis-architect',
+      'macro-signal-analyst'
+    ]);
+  });
+
+  it('T-AR4 resolves task-bound agent and returns deterministic runtime payload', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      missionId: 'rwa-market-analysis',
+      teamId: 'smartfunds-research-team',
+      phase: 'implement',
+      taskId: 'research',
+      metadata: {
+        teamId: 'smartfunds-research-team',
+        agentRoster: ['lead-thesis-architect', 'macro-signal-analyst']
+      }
+    });
+
+    const runtime = resolveTaskAgent({
+      taskAgent: 'macro-signal-analyst',
+      executionContext: context,
+      profiles
+    });
+
+    expect(runtime).toMatchObject({
+      teamId: 'smartfunds-research-team',
+      activeAgent: 'macro-signal-analyst',
+      agentEnvelope: {
+        agentId: 'macro-signal-analyst',
+        role: 'macro-analyst',
+        allowedTools: ['llm', 'repo']
+      }
+    });
+    expect(runtime.agentRoster.map((entry) => entry.agentId)).toEqual([
+      'lead-thesis-architect',
+      'macro-signal-analyst'
+    ]);
+  });
+
+  it('T-AR5 fails deterministically for missing or unresolved task agent', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      phase: 'implement',
+      taskId: 'research',
+      metadata: {
+        agentRoster: ['lead-thesis-architect']
+      }
+    });
+
+    expect(() => resolveAgentProfile({ agentId: 'missing-agent', profiles })).toThrow(
+      'ERR_AGENT_NOT_FOUND: Agent profile not found: missing-agent'
+    );
+
+    expect(() => resolveTaskAgent({
+      taskAgent: 'macro-signal-analyst',
+      executionContext: context,
+      profiles
+    })).toThrow('ERR_TASK_AGENT_UNRESOLVED: Agent macro-signal-analyst is not part of the mission roster');
+  });
+});

--- a/control-plane/cli/agent-inspect.test.ts
+++ b/control-plane/cli/agent-inspect.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { main } from './agent-inspect.ts';
+
+const { loadAgentProfilesFromDir, loadTeamDefinitionsFromDir } = vi.hoisted(() => ({
+  loadAgentProfilesFromDir: vi.fn(),
+  loadTeamDefinitionsFromDir: vi.fn()
+}));
+
+vi.mock('../agents/agent-profile-loader.ts', () => ({
+  loadAgentProfilesFromDir
+}));
+
+vi.mock('../teams/team-loader.ts', () => ({
+  loadTeamDefinitionsFromDir
+}));
+
+describe('agent-inspect CLI', () => {
+  it('prints deterministic agent runtime inspection payload and exits 0', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    loadAgentProfilesFromDir.mockReturnValueOnce([
+      {
+        agentId: 'lead-thesis-architect',
+        displayName: 'Lead Thesis Architect',
+        role: 'research-lead',
+        projectId: 'smartfunds-core',
+        adapterType: 'llm',
+        personalityProfile: {
+          tone: 'measured',
+          reasoningStyle: 'top-down',
+          temperament: 'calm',
+          collaborationStyle: 'delegates',
+          communicationStyle: 'structured'
+        },
+        skillsProfile: {
+          coreSkills: ['market synthesis'],
+          secondarySkills: ['summarization'],
+          domains: ['RWA']
+        },
+        backgroundProfile: {
+          professionalArchetype: 'strategist',
+          domainBackground: ['private markets'],
+          perspectiveBiases: ['asymmetric opportunities']
+        },
+        outputProfile: {
+          preferredFormat: 'memo',
+          verbosity: 'medium',
+          citationStyle: 'internal',
+          decisionStyle: 'rank'
+        },
+        constraintsProfile: {
+          mustDo: ['state assumptions'],
+          mustNotDo: ['overstate market size']
+        },
+        toolProfile: {
+          allowedAdapters: ['llm', 'repo'],
+          preferredTools: ['llm'],
+          forbiddenTools: ['shell']
+        }
+      }
+    ]);
+
+    loadTeamDefinitionsFromDir.mockReturnValueOnce([
+      {
+        teamId: 'smartfunds-research-team',
+        projectId: 'smartfunds-core',
+        members: ['lead-thesis-architect'],
+        executionMode: 'structured'
+      }
+    ]);
+
+    const code = await main(['--agent', 'lead-thesis-architect']);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify({
+      agentId: 'lead-thesis-architect',
+      profile: {
+        agentId: 'lead-thesis-architect',
+        displayName: 'Lead Thesis Architect',
+        role: 'research-lead',
+        projectId: 'smartfunds-core',
+        adapterType: 'llm',
+        personalityProfile: {
+          tone: 'measured',
+          reasoningStyle: 'top-down',
+          temperament: 'calm',
+          collaborationStyle: 'delegates',
+          communicationStyle: 'structured'
+        },
+        skillsProfile: {
+          coreSkills: ['market synthesis'],
+          secondarySkills: ['summarization'],
+          domains: ['RWA']
+        },
+        backgroundProfile: {
+          professionalArchetype: 'strategist',
+          domainBackground: ['private markets'],
+          perspectiveBiases: ['asymmetric opportunities']
+        },
+        outputProfile: {
+          preferredFormat: 'memo',
+          verbosity: 'medium',
+          citationStyle: 'internal',
+          decisionStyle: 'rank'
+        },
+        constraintsProfile: {
+          mustDo: ['state assumptions'],
+          mustNotDo: ['overstate market size']
+        },
+        toolProfile: {
+          allowedAdapters: ['llm', 'repo'],
+          preferredTools: ['llm'],
+          forbiddenTools: ['shell']
+        }
+      },
+      executionEnvelope: {
+        agentId: 'lead-thesis-architect',
+        role: 'research-lead',
+        personality: {
+          collaborationStyle: 'delegates',
+          communicationStyle: 'structured',
+          reasoningStyle: 'top-down',
+          temperament: 'calm',
+          tone: 'measured'
+        },
+        skills: ['market synthesis', 'RWA', 'summarization'],
+        background: {
+          domainBackground: ['private markets'],
+          perspectiveBiases: ['asymmetric opportunities'],
+          professionalArchetype: 'strategist'
+        },
+        outputStyle: {
+          citationStyle: 'internal',
+          decisionStyle: 'rank',
+          preferredFormat: 'memo',
+          verbosity: 'medium'
+        },
+        constraints: {
+          mustDo: ['state assumptions'],
+          mustNotDo: ['overstate market size']
+        },
+        allowedTools: ['llm', 'repo']
+      },
+      permissions: {
+        allowedAdapters: ['llm', 'repo'],
+        forbiddenAdapters: ['shell']
+      },
+      teams: [{
+        teamId: 'smartfunds-research-team',
+        projectId: 'smartfunds-core',
+        executionMode: 'structured'
+      }]
+    })}\n`);
+
+    stdout.mockRestore();
+  });
+
+  it('prints stable error output and exits 1', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    loadAgentProfilesFromDir.mockReturnValueOnce([]);
+
+    const code = await main(['--agent', 'missing']);
+
+    expect(code).toBe(1);
+    expect(stdout).toHaveBeenCalledWith(
+      `${canonicalStringify({ error: 'ERR_AGENT_NOT_FOUND: Agent profile not found: missing' })}\n`
+    );
+
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/cli/agent-inspect.ts
+++ b/control-plane/cli/agent-inspect.ts
@@ -1,0 +1,92 @@
+import { loadAgentProfilesFromDir } from '../agents/agent-profile-loader.ts';
+import { buildAgentExecutionEnvelope } from '../agents/runtime/agent-envelope.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+import { loadTeamDefinitionsFromDir } from '../teams/team-loader.ts';
+
+type ParsedArgs = {
+  agentId: string;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let agentId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--agent') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --agent');
+      }
+      agentId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--agent=')) {
+      agentId = arg.slice('--agent='.length);
+      if (!agentId) {
+        throw new Error('MISSING_ARGUMENT: --agent');
+      }
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!agentId) {
+    throw new Error('MISSING_ARGUMENT: --agent');
+  }
+
+  return { agentId };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const profiles = loadAgentProfilesFromDir();
+    const profile = profiles.find((entry) => entry.agentId === args.agentId);
+    if (!profile) {
+      throw new Error(`ERR_AGENT_NOT_FOUND: Agent profile not found: ${args.agentId}`);
+    }
+
+    const teams = loadTeamDefinitionsFromDir(undefined, profiles)
+      .filter((team) => team.members.includes(profile.agentId))
+      .sort((left, right) => left.teamId.localeCompare(right.teamId));
+
+    const envelope = buildAgentExecutionEnvelope(profile);
+
+    printJson({
+      agentId: profile.agentId,
+      profile,
+      executionEnvelope: envelope,
+      permissions: {
+        allowedAdapters: envelope.allowedTools,
+        forbiddenAdapters: profile.toolProfile.forbiddenTools
+      },
+      teams: teams.map((team) => ({
+        teamId: team.teamId,
+        projectId: team.projectId,
+        executionMode: team.executionMode
+      }))
+    });
+
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-agents.test.ts
+++ b/control-plane/cli/mission-agents.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { main } from './mission-agents.ts';
+
+const { createMissionRunner, inspectMission } = vi.hoisted(() => ({
+  inspectMission: vi.fn(),
+  createMissionRunner: vi.fn(() => ({
+    inspectMission
+  }))
+}));
+
+vi.mock('../missions/mission-runner.ts', () => ({
+  createMissionRunner
+}));
+
+describe('mission-agents CLI', () => {
+  it('prints deterministic mission roster with runtime envelopes and exits 0', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    inspectMission.mockReturnValueOnce({
+      mission: {
+        missionId: 'rwa-market-analysis',
+        projectId: 'smartfunds-core'
+      },
+      team: {
+        teamId: 'smartfunds-research-team'
+      },
+      workflowId: 'research-analysis-workflow',
+      agentRoster: [
+        {
+          agentId: 'macro-signal-analyst',
+          role: 'macro-analyst',
+          personalityProfile: {
+            tone: 'analytical',
+            reasoningStyle: 'evidence-first',
+            temperament: 'skeptical',
+            collaborationStyle: 'iterative',
+            communicationStyle: 'concise'
+          },
+          skillsProfile: {
+            coreSkills: ['macro analysis'],
+            secondarySkills: ['risk framing'],
+            domains: ['credit']
+          },
+          backgroundProfile: {
+            professionalArchetype: 'strategist',
+            domainBackground: ['fixed income'],
+            perspectiveBiases: []
+          },
+          outputProfile: {
+            preferredFormat: 'brief',
+            verbosity: 'medium',
+            citationStyle: 'internal',
+            decisionStyle: 'tradeoffs'
+          },
+          constraintsProfile: {
+            mustDo: ['differentiate scenarios'],
+            mustNotDo: ['hide uncertainty']
+          },
+          toolProfile: {
+            allowedAdapters: ['llm', 'repo'],
+            preferredTools: ['llm'],
+            forbiddenTools: ['shell']
+          },
+          adapterType: 'llm'
+        }
+      ]
+    });
+
+    const code = await main(['--mission', 'rwa-market-analysis']);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify({
+      mission: {
+        missionId: 'rwa-market-analysis',
+        projectId: 'smartfunds-core',
+        teamId: 'smartfunds-research-team',
+        workflowId: 'research-analysis-workflow'
+      },
+      roster: [{
+        agentId: 'macro-signal-analyst',
+        role: 'macro-analyst',
+        allowedTools: ['llm', 'repo'],
+        adapterType: 'llm'
+      }]
+    })}\n`);
+
+    stdout.mockRestore();
+  });
+
+  it('prints deterministic error output and exits 1', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await main([]);
+
+    expect(code).toBe(1);
+    expect(stdout).toHaveBeenCalledWith(
+      `${canonicalStringify({ error: 'MISSING_ARGUMENT: --mission' })}\n`
+    );
+
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/cli/mission-agents.ts
+++ b/control-plane/cli/mission-agents.ts
@@ -1,0 +1,90 @@
+import { buildAgentExecutionEnvelope } from '../agents/runtime/agent-envelope.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionRunner } from '../missions/mission-runner.ts';
+
+type ParsedArgs = {
+  missionId: string;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let missionId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--mission') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --mission');
+      }
+      missionId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--mission=')) {
+      missionId = arg.slice('--mission='.length);
+      if (!missionId) {
+        throw new Error('MISSING_ARGUMENT: --mission');
+      }
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!missionId) {
+    throw new Error('MISSING_ARGUMENT: --mission');
+  }
+
+  return { missionId };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const runner = createMissionRunner();
+    const inspected = runner.inspectMission(args.missionId);
+
+    const roster = [...inspected.agentRoster]
+      .sort((left, right) => left.agentId.localeCompare(right.agentId))
+      .map((profile) => {
+        const envelope = buildAgentExecutionEnvelope(profile);
+
+        return {
+          agentId: profile.agentId,
+          role: profile.role,
+          allowedTools: envelope.allowedTools,
+          adapterType: profile.adapterType
+        };
+      });
+
+    printJson({
+      mission: {
+        missionId: inspected.mission.missionId,
+        projectId: inspected.mission.projectId,
+        teamId: inspected.team.teamId,
+        workflowId: inspected.workflowId
+      },
+      roster
+    });
+
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/execution/context-merge.ts
+++ b/control-plane/execution/context-merge.ts
@@ -18,11 +18,15 @@ export function mergeContextUpdates(context: ExecutionContext, updates?: Context
     return createExecutionContext({
       runId: context.runId,
       ...(context.missionId ? { missionId: context.missionId } : {}),
+      ...(context.teamId ? { teamId: context.teamId } : {}),
       phase: context.phase,
       taskId: context.taskId,
       memory: context.memory,
       artifacts: context.artifacts,
-      metadata: context.metadata
+      metadata: context.metadata,
+      ...(context.activeAgent ? { activeAgent: context.activeAgent } : {}),
+      ...(context.agentEnvelope ? { agentEnvelope: context.agentEnvelope } : {}),
+      ...(context.agentRoster ? { agentRoster: context.agentRoster } : {})
     });
   }
 
@@ -38,11 +42,15 @@ export function mergeContextUpdates(context: ExecutionContext, updates?: Context
   return createExecutionContext({
     runId: context.runId,
     ...(context.missionId ? { missionId: context.missionId } : {}),
+    ...(context.teamId ? { teamId: context.teamId } : {}),
     phase: context.phase,
     taskId: context.taskId,
     memory: mergedMemory,
     artifacts: context.artifacts,
-    metadata: context.metadata
+    metadata: context.metadata,
+    ...(context.activeAgent ? { activeAgent: context.activeAgent } : {}),
+    ...(context.agentEnvelope ? { agentEnvelope: context.agentEnvelope } : {}),
+    ...(context.agentRoster ? { agentRoster: context.agentRoster } : {})
   });
 }
 
@@ -56,10 +64,14 @@ export function applyTaskResultToContext(context: ExecutionContext, taskResult: 
   return createExecutionContext({
     runId: mergedContext.runId,
     ...(mergedContext.missionId ? { missionId: mergedContext.missionId } : {}),
+    ...(mergedContext.teamId ? { teamId: mergedContext.teamId } : {}),
     phase: mergedContext.phase,
     taskId: mergedContext.taskId,
     memory: mergedContext.memory,
     artifacts: sortedUnique([...mergedContext.artifacts, ...artifactPaths]),
-    metadata: mergedContext.metadata
+    metadata: mergedContext.metadata,
+    ...(mergedContext.activeAgent ? { activeAgent: mergedContext.activeAgent } : {}),
+    ...(mergedContext.agentEnvelope ? { agentEnvelope: mergedContext.agentEnvelope } : {}),
+    ...(mergedContext.agentRoster ? { agentRoster: mergedContext.agentRoster } : {})
   });
 }

--- a/control-plane/execution/context-types.ts
+++ b/control-plane/execution/context-types.ts
@@ -1,3 +1,5 @@
+import type { AgentExecutionEnvelope } from '../agents/runtime/agent-envelope.ts';
+
 export type ExecutionMemoryValue = unknown;
 
 export type ContextUpdates = Record<string, ExecutionMemoryValue>;
@@ -5,11 +7,15 @@ export type ContextUpdates = Record<string, ExecutionMemoryValue>;
 export type ExecutionContext = {
   runId: string;
   missionId?: string;
+  teamId?: string;
   phase: string;
   taskId: string;
   memory: Record<string, ExecutionMemoryValue>;
   artifacts: string[];
   metadata: Record<string, unknown>;
+  activeAgent?: string;
+  agentEnvelope?: AgentExecutionEnvelope;
+  agentRoster?: AgentExecutionEnvelope[];
 };
 
 export type JournalContextSnapshot = ExecutionContext;

--- a/control-plane/execution/execution-context.ts
+++ b/control-plane/execution/execution-context.ts
@@ -1,14 +1,19 @@
 import { canonicalStringify } from '../finance/determinism.ts';
 import type { ExecutionContext } from './context-types.ts';
+import type { AgentExecutionEnvelope } from '../agents/runtime/agent-envelope.ts';
 
 type CreateExecutionContextInput = {
   runId: string;
   missionId?: string;
+  teamId?: string;
   phase: string;
   taskId: string;
   memory?: Record<string, unknown>;
   artifacts?: string[];
   metadata?: Record<string, unknown>;
+  activeAgent?: string;
+  agentEnvelope?: AgentExecutionEnvelope;
+  agentRoster?: AgentExecutionEnvelope[];
 };
 
 function sortRecord<T>(record: Record<string, T>): Record<string, T> {
@@ -46,15 +51,27 @@ function canonicalizeArtifacts(artifacts: string[]): string[] {
   return [...artifacts].sort((left, right) => left.localeCompare(right));
 }
 
+function canonicalizeAgentRoster(roster?: AgentExecutionEnvelope[]): AgentExecutionEnvelope[] | undefined {
+  if (!roster) {
+    return undefined;
+  }
+
+  return [...stableCloneValue(roster)].sort((left, right) => left.agentId.localeCompare(right.agentId));
+}
+
 export function createExecutionContext(input: CreateExecutionContextInput): ExecutionContext {
   return {
     runId: input.runId,
     ...(input.missionId ? { missionId: input.missionId } : {}),
+    ...(input.teamId ? { teamId: input.teamId } : {}),
     phase: input.phase,
     taskId: input.taskId,
     memory: sortRecord(stableCloneValue(input.memory ?? {})),
     artifacts: canonicalizeArtifacts(input.artifacts ?? []),
-    metadata: sortRecord(stableCloneValue(input.metadata ?? {}))
+    metadata: sortRecord(stableCloneValue(input.metadata ?? {})),
+    ...(input.activeAgent ? { activeAgent: input.activeAgent } : {}),
+    ...(input.agentEnvelope ? { agentEnvelope: stableCloneValue(input.agentEnvelope) } : {}),
+    ...(input.agentRoster ? { agentRoster: canonicalizeAgentRoster(input.agentRoster) } : {})
   };
 }
 
@@ -73,11 +90,15 @@ export function cloneExecutionContext(context: ExecutionContext): ExecutionConte
   return createExecutionContext({
     runId: context.runId,
     ...(context.missionId ? { missionId: context.missionId } : {}),
+    ...(context.teamId ? { teamId: context.teamId } : {}),
     phase: context.phase,
     taskId: context.taskId,
     memory: context.memory,
     artifacts: context.artifacts,
-    metadata: context.metadata
+    metadata: context.metadata,
+    ...(context.activeAgent ? { activeAgent: context.activeAgent } : {}),
+    ...(context.agentEnvelope ? { agentEnvelope: context.agentEnvelope } : {}),
+    ...(context.agentRoster ? { agentRoster: context.agentRoster } : {})
   });
 }
 
@@ -88,11 +109,15 @@ export function withExecutionIdentity(
   return createExecutionContext({
     runId: context.runId,
     ...(context.missionId ? { missionId: context.missionId } : {}),
+    ...(context.teamId ? { teamId: context.teamId } : {}),
     phase: identity.phase,
     taskId: identity.taskId,
     memory: context.memory,
     artifacts: context.artifacts,
-    metadata: context.metadata
+    metadata: context.metadata,
+    ...(context.activeAgent ? { activeAgent: context.activeAgent } : {}),
+    ...(context.agentEnvelope ? { agentEnvelope: context.agentEnvelope } : {}),
+    ...(context.agentRoster ? { agentRoster: context.agentRoster } : {})
   });
 }
 

--- a/control-plane/execution/tests/execution-context.test.ts
+++ b/control-plane/execution/tests/execution-context.test.ts
@@ -117,4 +117,55 @@ describe('execution context', () => {
       ((readonlyContext.memory.nested as { count: number }).count) = 2;
     }).toThrow();
   });
+
+  it('supports additive agent metadata without changing base deterministic behavior', () => {
+    const context = createExecutionContext({
+      runId: 'run_control-plane_0001',
+      missionId: 'rwa-market-analysis',
+      teamId: 'smartfunds-research-team',
+      phase: 'implement',
+      taskId: 'agent-task',
+      activeAgent: 'macro-signal-analyst',
+      agentEnvelope: {
+        agentId: 'macro-signal-analyst',
+        role: 'macro-analyst',
+        personality: {
+          tone: 'analytical',
+          reasoningStyle: 'evidence-first'
+        },
+        skills: ['macro analysis'],
+        background: {},
+        outputStyle: {},
+        constraints: {},
+        allowedTools: ['llm', 'repo']
+      },
+      agentRoster: [
+        {
+          agentId: 'macro-signal-analyst',
+          personality: {},
+          skills: [],
+          background: {},
+          outputStyle: {},
+          constraints: {},
+          allowedTools: ['llm']
+        },
+        {
+          agentId: 'lead-thesis-architect',
+          personality: {},
+          skills: [],
+          background: {},
+          outputStyle: {},
+          constraints: {},
+          allowedTools: ['llm']
+        }
+      ]
+    });
+
+    expect(context.teamId).toBe('smartfunds-research-team');
+    expect(context.activeAgent).toBe('macro-signal-analyst');
+    expect(context.agentRoster?.map((entry) => entry.agentId)).toEqual([
+      'lead-thesis-architect',
+      'macro-signal-analyst'
+    ]);
+  });
 });

--- a/control-plane/missions/mission-runner.ts
+++ b/control-plane/missions/mission-runner.ts
@@ -81,6 +81,7 @@ export function createMissionRunner(options: MissionRunnerOptions = {}) {
       kind: 'mission',
       entrypoint: `mission:${loaded.mission.missionId}`,
       missionId: loaded.mission.missionId,
+      teamId: loaded.executionSeed.teamId,
       initialMemory: loaded.mission.initialContext,
       metadata: {
         missionId: loaded.executionSeed.missionId,

--- a/control-plane/swarm/swarm-runner.ts
+++ b/control-plane/swarm/swarm-runner.ts
@@ -19,6 +19,7 @@ type CreateSwarmRunInput = {
   kind?: RunKind;
   entrypoint?: string;
   missionId?: string;
+  teamId?: string;
   initialMemory?: Record<string, unknown>;
   initialArtifacts?: string[];
   metadata?: Record<string, unknown>;
@@ -45,6 +46,7 @@ type TaskTemplate = {
   order: number;
   type: 'llm' | 'shell' | 'repo';
   inputs: Record<string, unknown>;
+  agent?: string;
   executorKey?: string;
 };
 
@@ -141,6 +143,7 @@ function buildTaskDefinitions(
       description: task.description,
       type: task.type,
       inputs: task.inputs,
+      ...(task.agent ? { agent: task.agent } : {}),
       ...(executor ? { executor } : {}),
       order: task.order
     });
@@ -303,6 +306,10 @@ function toExecutionContextFromPayload(payload: unknown): ExecutionContext | nul
   const artifacts = snapshot.artifacts;
   const metadata = snapshot.metadata;
   const missionId = snapshot.missionId;
+  const teamId = snapshot.teamId;
+  const activeAgent = snapshot.activeAgent;
+  const agentEnvelope = snapshot.agentEnvelope;
+  const agentRoster = snapshot.agentRoster;
 
   if (typeof runId !== 'string' || typeof phase !== 'string' || typeof taskId !== 'string') {
     return null;
@@ -316,15 +323,34 @@ function toExecutionContextFromPayload(payload: unknown): ExecutionContext | nul
   if (missionId !== undefined && typeof missionId !== 'string') {
     return null;
   }
+  if (teamId !== undefined && typeof teamId !== 'string') {
+    return null;
+  }
+  if (activeAgent !== undefined && typeof activeAgent !== 'string') {
+    return null;
+  }
+  if (agentEnvelope !== undefined && !isRecord(agentEnvelope)) {
+    return null;
+  }
+  if (agentRoster !== undefined && !Array.isArray(agentRoster)) {
+    return null;
+  }
+  if (Array.isArray(agentRoster) && !agentRoster.every((entry) => isRecord(entry))) {
+    return null;
+  }
 
   return createExecutionContext({
     runId,
     ...(missionId ? { missionId } : {}),
+    ...(teamId ? { teamId } : {}),
     phase,
     taskId,
     memory,
     artifacts,
-    metadata
+    metadata,
+    ...(activeAgent ? { activeAgent } : {}),
+    ...(agentEnvelope ? { agentEnvelope } : {}),
+    ...(agentRoster ? { agentRoster } : {})
   });
 }
 
@@ -375,6 +401,7 @@ export function createSwarmRunner(options: SwarmRunnerOptions = {}) {
     const initialContext = createExecutionContext({
       runId: run.runId,
       ...(input.missionId ? { missionId: input.missionId } : {}),
+      ...(input.teamId ? { teamId: input.teamId } : {}),
       phase: 'plan',
       taskId: '__run_start__',
       memory: input.initialMemory ?? {},

--- a/control-plane/swarm/swarm-types.ts
+++ b/control-plane/swarm/swarm-types.ts
@@ -28,6 +28,7 @@ export type SwarmTaskDefinition = {
   order: number;
   type: TaskType;
   inputs: Record<string, unknown>;
+  agent?: string;
   executionContext?: ExecutionContext;
   executor?: SwarmTaskExecutor;
 };

--- a/control-plane/swarm/task-executor.test.ts
+++ b/control-plane/swarm/task-executor.test.ts
@@ -141,4 +141,86 @@ describe('task-executor', () => {
 
     expect(first.map(eventKey)).toEqual(second.map(eventKey));
   });
+
+  it('injects deterministic agent context for agent-bound tasks', async () => {
+    const events: TaskExecutionEvent[] = [];
+
+    const result = await executePhaseTasks({
+      runId: 'run_control-plane_0001',
+      phase: 'implement',
+      tasks: [{
+        taskId: 'agent-llm-task',
+        phase: 'implement',
+        description: 'Agent bound llm task',
+        order: 1,
+        type: 'llm',
+        agent: 'macro-signal-analyst',
+        inputs: {
+          prompt: 'deterministic prompt'
+        }
+      }],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
+      emitEvent: (event) => {
+        events.push(event);
+      }
+    });
+
+    expect(result.status).toBe('completed');
+    expect(events.map(eventKey)).toEqual([
+      'TASK_STARTED:agent-llm-task',
+      'TASK_COMPLETED:agent-llm-task'
+    ]);
+    expect(events[0].payload).toMatchObject({
+      adapterId: 'llm',
+      agentId: 'macro-signal-analyst',
+      context_snapshot: {
+        activeAgent: 'macro-signal-analyst',
+        agentEnvelope: {
+          agentId: 'macro-signal-analyst'
+        },
+        agentRoster: [{ agentId: 'macro-signal-analyst' }]
+      }
+    });
+  });
+
+  it('fails deterministically when task agent attempts forbidden adapter', async () => {
+    const events: TaskExecutionEvent[] = [];
+
+    const result = await executePhaseTasks({
+      runId: 'run_control-plane_0001',
+      phase: 'implement',
+      tasks: [{
+        taskId: 'agent-shell-task',
+        phase: 'implement',
+        description: 'Agent bound shell task',
+        order: 1,
+        type: 'shell',
+        agent: 'lead-thesis-architect',
+        inputs: {
+          command: 'printf',
+          args: ['blocked']
+        }
+      }],
+      executionContext: createEmptyExecutionContext('run_control-plane_0001'),
+      emitEvent: (event) => {
+        events.push(event);
+      }
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.failedTaskId).toBe('agent-shell-task');
+    expect(events.map(eventKey)).toEqual([
+      'TASK_STARTED:agent-shell-task',
+      'TASK_FAILED:agent-shell-task'
+    ]);
+    expect(events[1].payload).toMatchObject({
+      adapterId: 'shell',
+      agentId: 'lead-thesis-architect',
+      result: {
+        status: 'failed',
+        errorCode: 'ERR_AGENT_TOOL_FORBIDDEN',
+        errorMessage: 'Agent lead-thesis-architect cannot use adapter shell. Allowed adapters: llm, repo'
+      }
+    });
+  });
 });

--- a/control-plane/swarm/task-executor.ts
+++ b/control-plane/swarm/task-executor.ts
@@ -1,3 +1,7 @@
+import { withAgentContext } from '../agents/runtime/agent-context.ts';
+import type { AgentExecutionEnvelope } from '../agents/runtime/agent-envelope.ts';
+import { resolveTaskAgent } from '../agents/runtime/agent-runtime.ts';
+import { assertAgentCanUseAdapter } from '../agents/runtime/agent-tools.ts';
 import { applyTaskResultToContext } from '../execution/context-merge.ts';
 import { serializeExecutionContext } from '../execution/context-serializer.ts';
 import { toReadonlyExecutionContext, withExecutionIdentity } from '../execution/execution-context.ts';
@@ -47,23 +51,43 @@ function toErrorMessage(error: unknown): string {
   return 'TASK_EXECUTION_FAILED';
 }
 
-function failedResult(errorCode: string, errorMessage: string): TaskResult {
+function splitErrorCode(message: string): { code: string; detail: string } {
+  const match = message.match(/^(ERR_[A-Z0-9_]+):\s*(.*)$/);
+  if (!match) {
+    return {
+      code: 'ERR_TASK_ADAPTER_EXECUTION',
+      detail: message
+    };
+  }
+
+  return {
+    code: match[1],
+    detail: match[2] || match[1]
+  };
+}
+
+function failedResult(errorCode: string, errorMessage: string, logCode: string = 'TASK_ADAPTER_EXECUTION_FAILED'): TaskResult {
   return {
     status: 'failed',
     outputs: {},
     artifacts: [],
-    logs: ['TASK_ADAPTER_EXECUTION_FAILED'],
+    logs: [logCode],
     errorCode,
     errorMessage
   };
 }
 
-async function executeByAdapter(context: TaskContext): Promise<TaskResult> {
+async function executeByAdapter(context: TaskContext, agentEnvelope?: AgentExecutionEnvelope): Promise<TaskResult> {
   try {
+    if (agentEnvelope) {
+      assertAgentCanUseAdapter(agentEnvelope, context.taskType);
+    }
+
     const adapter = getAdapter(context.taskType);
     return await adapter.execute(context);
   } catch (error) {
-    return failedResult('ERR_TASK_ADAPTER_EXECUTION', toErrorMessage(error));
+    const parsed = splitErrorCode(toErrorMessage(error));
+    return failedResult(parsed.code, parsed.detail);
   }
 }
 
@@ -101,6 +125,11 @@ function parseSerializedContext(serialized: string): Record<string, unknown> {
   return JSON.parse(serialized) as Record<string, unknown>;
 }
 
+function toAgentResolutionFailure(error: unknown): TaskResult {
+  const parsed = splitErrorCode(toErrorMessage(error));
+  return failedResult(parsed.code, parsed.detail, 'TASK_AGENT_RESOLUTION_FAILED');
+}
+
 export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<PhaseTaskExecutionResult> {
   const orderedTasks = sortTasks(input.tasks);
   const executedTaskIds: string[] = [];
@@ -111,10 +140,68 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
       throw new Error(`TASK_PHASE_MISMATCH: ${task.taskId}`);
     }
 
-    const taskExecutionContext = withExecutionIdentity(phaseContext, {
+    let taskExecutionContext = withExecutionIdentity(phaseContext, {
       phase: input.phase,
       taskId: task.taskId
     });
+
+    let activeAgent: string | null = null;
+    let agentEnvelope: AgentExecutionEnvelope | undefined;
+
+    if (task.agent) {
+      try {
+        const runtime = resolveTaskAgent({
+          taskAgent: task.agent,
+          executionContext: taskExecutionContext
+        });
+
+        taskExecutionContext = withAgentContext(taskExecutionContext, runtime);
+        activeAgent = runtime.activeAgent;
+        agentEnvelope = runtime.agentEnvelope;
+      } catch (error) {
+        const result = toAgentResolutionFailure(error);
+        const nextContext = applyTaskResultToContext(taskExecutionContext, result);
+
+        input.emitEvent({
+          type: 'TASK_STARTED',
+          phase: input.phase,
+          taskId: task.taskId,
+          payload: {
+            runId: input.runId,
+            taskType: task.type,
+            adapterId: task.type,
+            agentId: null,
+            inputs: task.inputs,
+            task_inputs: task.inputs,
+            context_snapshot: parseSerializedContext(serializeExecutionContext(taskExecutionContext))
+          }
+        });
+
+        input.emitEvent({
+          type: 'TASK_FAILED',
+          phase: input.phase,
+          taskId: task.taskId,
+          payload: {
+            runId: input.runId,
+            taskType: task.type,
+            adapterId: task.type,
+            agentId: null,
+            result,
+            task_outputs: result.outputs,
+            context_snapshot: parseSerializedContext(serializeExecutionContext(nextContext)),
+            error: result.errorMessage ?? 'TASK_EXECUTION_FAILED'
+          }
+        });
+
+        return {
+          phase: input.phase,
+          status: 'failed',
+          executedTaskIds,
+          failedTaskId: task.taskId,
+          executionContext: nextContext
+        };
+      }
+    }
 
     const taskContext = buildTaskContext(input.runId, input.phase, task, taskExecutionContext);
 
@@ -125,6 +212,8 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
       payload: {
         runId: input.runId,
         taskType: task.type,
+        adapterId: task.type,
+        agentId: activeAgent,
         inputs: task.inputs,
         task_inputs: task.inputs,
         context_snapshot: parseSerializedContext(serializeExecutionContext(taskExecutionContext))
@@ -133,7 +222,7 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
 
     const result = task.executor
       ? runLegacyExecutor(task)
-      : await executeByAdapter(taskContext);
+      : await executeByAdapter(taskContext, agentEnvelope);
 
     const nextContext = applyTaskResultToContext(taskExecutionContext, result);
 
@@ -147,6 +236,8 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
         payload: {
           runId: input.runId,
           taskType: task.type,
+          adapterId: task.type,
+          agentId: activeAgent,
           result,
           task_outputs: result.outputs,
           context_snapshot: parseSerializedContext(serializeExecutionContext(nextContext))
@@ -163,6 +254,8 @@ export async function executePhaseTasks(input: ExecutePhaseTasksInput): Promise<
       payload: {
         runId: input.runId,
         taskType: task.type,
+        adapterId: task.type,
+        agentId: activeAgent,
         result,
         task_outputs: result.outputs,
         context_snapshot: parseSerializedContext(serializeExecutionContext(nextContext)),

--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -1,0 +1,77 @@
+# Agent Runtime Layer
+
+## Overview
+
+Sprint 67 activates agent profiles as runtime actors.
+
+Before this layer, agent profiles were inspected and validated but did not directly control task execution.
+After this layer, a task may bind to an agent (`task.agent`), and the runtime resolves a deterministic execution envelope, injects agent context, and enforces adapter boundaries before invocation.
+
+## Profile -> Envelope
+
+`control-plane/agents/runtime/agent-envelope.ts` builds an immutable `AgentExecutionEnvelope` from the validated profile shape.
+
+Determinism guarantees:
+- stable key ordering via canonical normalization
+- stable sorted arrays (`skills`, `allowedTools`)
+- no runtime IDs/timestamps
+- no mutation of source profile
+- frozen envelope output
+
+Tool policy mapping:
+- `allowedTools` derives from `toolProfile.allowedAdapters`
+- `toolProfile.forbiddenTools` is subtracted
+- adapter identifiers use canonical `TaskType` values (`llm`, `repo`, `shell`)
+
+## Runtime Resolution
+
+`control-plane/agents/runtime/agent-runtime.ts` resolves task-level agent bindings.
+
+Flow:
+1. parse mission roster from execution metadata (`metadata.agentRoster`) when present
+2. resolve task agent deterministically
+3. build active agent envelope
+4. build deterministic roster envelopes
+5. fail with stable `ERR_*` messages when unresolved or missing
+
+Backward compatibility:
+- tasks without `task.agent` continue through existing generic execution path
+- adapter policy enforcement only runs for resolved agent-bound tasks
+
+## Context Injection
+
+`control-plane/agents/runtime/agent-context.ts` adds optional agent fields to `ExecutionContext`.
+
+Additive context fields:
+- `teamId?`
+- `activeAgent?`
+- `agentEnvelope?`
+- `agentRoster?`
+
+Agent injection is performed per task when bound, and context remains deterministic through existing serializer and context cloning utilities.
+
+## Tool Boundary Enforcement
+
+`control-plane/agents/runtime/agent-tools.ts` enforces adapter policy before adapter invocation.
+
+`assertAgentCanUseAdapter(envelope, adapterId)`:
+- allows only canonical `TaskType` ids
+- throws deterministic `ERR_AGENT_RUNTIME_INVALID` or `ERR_AGENT_TOOL_FORBIDDEN`
+- no silent fallback or bypass path
+
+## Journal and Memory Propagation
+
+Agent metadata now propagates through existing task lifecycle payloads:
+- `agentId`
+- `adapterId`
+- context snapshot containing optional agent/team fields
+
+This keeps attribution traceable while preserving existing event ordering and deterministic serialization.
+
+## CLI Inspection
+
+Two additive CLI commands expose runtime state:
+- `npm run agent:inspect -- --agent <agentId>`
+- `npm run mission:agents -- --mission <missionId>`
+
+Both follow existing JSON-only deterministic CLI output conventions.

--- a/docs/runbooks/agent-runtime.md
+++ b/docs/runbooks/agent-runtime.md
@@ -1,0 +1,68 @@
+# Agent Runtime Runbook
+
+## Designing Runtime-Effective Agent Profiles
+
+Agent runtime behavior is driven by existing profile fields:
+- `personalityProfile`
+- `skillsProfile`
+- `backgroundProfile`
+- `outputProfile`
+- `constraintsProfile`
+- `toolProfile` (`allowedAdapters`, `forbiddenTools`)
+
+Profiles remain configuration artifacts. Runtime envelopes are deterministic projections of those profiles.
+
+## Binding Tasks to Agents
+
+Task definitions may set:
+
+```json
+{
+  "taskId": "research",
+  "agent": "macro-signal-analyst"
+}
+```
+
+Behavior:
+- if `task.agent` is absent: legacy execution path (no policy enforcement)
+- if `task.agent` is present: runtime resolves agent envelope and enforces tool boundaries before adapter execution
+
+## Allowed vs Forbidden Adapters
+
+Adapter policy is evaluated against canonical adapter IDs:
+- `llm`
+- `repo`
+- `shell`
+
+Rules:
+- adapter in `allowedAdapters` and not in `forbiddenTools` -> allowed
+- otherwise -> deterministic pre-invocation failure
+
+Common errors:
+- `ERR_AGENT_NOT_FOUND`
+- `ERR_TASK_AGENT_UNRESOLVED`
+- `ERR_AGENT_TOOL_FORBIDDEN`
+- `ERR_AGENT_RUNTIME_INVALID`
+
+## Inspecting Runtime State
+
+Inspect one agent:
+
+```bash
+npm run agent:inspect -- --agent lead-thesis-architect
+```
+
+Inspect mission roster envelopes:
+
+```bash
+npm run mission:agents -- --mission rwa-market-analysis
+```
+
+Both commands return deterministic JSON suitable for CI assertions.
+
+## Deterministic Troubleshooting
+
+1. Verify agent exists in profile registry and matches exact `agentId`.
+2. Verify mission/team roster includes the task-bound agent when roster metadata is present.
+3. Verify adapter is in `allowedAdapters` and not in `forbiddenTools`.
+4. Re-run command and compare JSON output; ordering is stable and should not drift between runs.

--- a/entities/projects/control-plane.json
+++ b/entities/projects/control-plane.json
@@ -7,6 +7,7 @@
   "ownedPaths": [
     "control-plane/cli/",
     "control-plane/agents/",
+    "control-plane/agents/runtime/",
     "control-plane/execution/",
     "control-plane/entities/",
     "control-plane/governance/",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "swarms:execute": "node --experimental-strip-types control-plane/cli/swarms-execute.ts",
     "mission:run": "node --experimental-strip-types control-plane/cli/mission-run.ts",
     "mission:inspect": "node --experimental-strip-types control-plane/cli/mission-inspect.ts",
+    "mission:agents": "node --experimental-strip-types control-plane/cli/mission-agents.ts",
+    "agent:inspect": "node --experimental-strip-types control-plane/cli/agent-inspect.ts",
     "team:inspect": "node --experimental-strip-types control-plane/cli/team-inspect.ts",
     "governance:generate": "node --experimental-strip-types control-plane/cli/governance-generate.ts",
     "governance:normalize": "node --experimental-strip-types control-plane/cli/governance-normalize.ts",


### PR DESCRIPTION
tier-3

```evidence
- Implemented deterministic agent runtime integration end-to-end.
- Added agent execution envelope, runtime resolution, context injection, and tool-boundary enforcement.
- Added task.agent support without breaking legacy tasks.
- Extended journal/context snapshots with lightweight agent metadata.
- Added CLI inspection commands: agent:inspect and mission:agents.
- Registered ownership for control-plane/agents/runtime/ in canonical project registry.
- Added docs and runtime-focused tests.
- Validation passed: build, typecheck, lint, test, governance:preflight.
```
