### PR TITLE
Sprint 68: implement declarative workflow DAG engine

### DIFF
--- a/control-plane/cli/workflow-inspect.ts
+++ b/control-plane/cli/workflow-inspect.ts
@@ -1,0 +1,81 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { WorkflowDag } from '../workflows/workflow-dag.ts';
+import { loadWorkflowDefinitionById } from '../workflows/workflow-loader.ts';
+import type { WorkflowInspectResult } from '../workflows/workflow-types.ts';
+
+function parseArgs(argv: string[]): { workflowId: string } {
+  let workflowId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--workflow') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --workflow');
+      }
+      workflowId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--workflow=')) {
+      workflowId = arg.slice('--workflow='.length);
+      if (!workflowId) {
+        throw new Error('MISSING_ARGUMENT: --workflow');
+      }
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!workflowId) {
+    throw new Error('MISSING_ARGUMENT: --workflow');
+  }
+
+  return { workflowId };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+function buildInspectResult(workflowId: string): WorkflowInspectResult {
+  const workflow = loadWorkflowDefinitionById(workflowId);
+  const dag = new WorkflowDag(workflow);
+
+  return {
+    workflowId: workflow.workflowId,
+    nodes: workflow.nodes
+      .map((node) => ({
+        id: node.id,
+        task: node.task,
+        ...(node.agent ? { agent: node.agent } : {}),
+        ...(node.phase ? { phase: node.phase } : {}),
+        dependsOn: [...(node.dependsOn ?? [])]
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    executionOrder: dag.getExecutionOrder()
+  };
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(buildInspectResult(args.workflowId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/workflow-validate.ts
+++ b/control-plane/cli/workflow-validate.ts
@@ -1,0 +1,61 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { loadWorkflowDefinitionById } from '../workflows/workflow-loader.ts';
+
+function parseArgs(argv: string[]): { workflowId: string } {
+  let workflowId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--workflow') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --workflow');
+      }
+      workflowId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--workflow=')) {
+      workflowId = arg.slice('--workflow='.length);
+      if (!workflowId) {
+        throw new Error('MISSING_ARGUMENT: --workflow');
+      }
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!workflowId) {
+    throw new Error('MISSING_ARGUMENT: --workflow');
+  }
+
+  return { workflowId };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const workflow = loadWorkflowDefinitionById(args.workflowId);
+    printJson({ valid: true, workflowId: workflow.workflowId });
+    return 0;
+  } catch (error) {
+    printJson({ valid: false, error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ valid: false, error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/workflows/definitions/rwa-market-analysis.json
+++ b/control-plane/workflows/definitions/rwa-market-analysis.json
@@ -1,0 +1,36 @@
+{
+  "workflowId": "rwa-market-analysis",
+  "nodes": [
+    {
+      "id": "market-research",
+      "agent": "macro-signal-analyst",
+      "task": "research",
+      "phase": "research"
+    },
+    {
+      "id": "regulatory-scan",
+      "agent": "compliance-risk-reviewer",
+      "task": "regulatory-scan",
+      "phase": "analysis"
+    },
+    {
+      "id": "thesis-synthesis",
+      "agent": "lead-thesis-architect",
+      "task": "synthesis",
+      "phase": "synthesis",
+      "dependsOn": [
+        "market-research",
+        "regulatory-scan"
+      ]
+    },
+    {
+      "id": "final-review",
+      "agent": "compliance-risk-reviewer",
+      "task": "review",
+      "phase": "review",
+      "dependsOn": [
+        "thesis-synthesis"
+      ]
+    }
+  ]
+}

--- a/control-plane/workflows/tests/workflow-dag.test.ts
+++ b/control-plane/workflows/tests/workflow-dag.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { WorkflowDag } from '../workflow-dag.ts';
+import { loadWorkflowDefinition } from '../workflow-loader.ts';
+import { validateWorkflowDefinition } from '../workflow-validator.ts';
+
+function validWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    workflowId: 'wf-basic',
+    nodes: [
+      { id: 'a', task: 'task-a' },
+      { id: 'b', task: 'task-b', dependsOn: ['a'] },
+      { id: 'c', task: 'task-c', dependsOn: ['a'] }
+    ],
+    ...overrides
+  };
+}
+
+describe('workflow-dag', () => {
+  it('T-WD1 accepts valid DAG and exposes deterministic order', () => {
+    const loaded = loadWorkflowDefinition(validWorkflow());
+    const dag = new WorkflowDag(loaded);
+
+    expect(dag.getExecutionOrder()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('T-WD2 rejects cycle A->B->C->A', () => {
+    const result = validateWorkflowDefinition({
+      workflowId: 'wf-cycle',
+      nodes: [
+        { id: 'a', task: 'task-a', dependsOn: ['c'] },
+        { id: 'b', task: 'task-b', dependsOn: ['a'] },
+        { id: 'c', task: 'task-c', dependsOn: ['b'] }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('workflow.cycle_detected: a->b->c');
+  });
+
+  it('T-WD3 rejects duplicate node ids', () => {
+    const result = validateWorkflowDefinition({
+      workflowId: 'wf-dup',
+      nodes: [
+        { id: 'a', task: 'task-a' },
+        { id: 'a', task: 'task-b' }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('workflow.duplicate_node_id: a');
+  });
+
+  it('T-WD4 rejects missing dependency', () => {
+    const result = validateWorkflowDefinition({
+      workflowId: 'wf-missing-dep',
+      nodes: [
+        { id: 'a', task: 'task-a', dependsOn: ['unknown'] }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('workflow.missing_dependency: node=a dependsOn=unknown');
+  });
+
+  it('T-WD5 rejects self-dependency', () => {
+    const result = validateWorkflowDefinition({
+      workflowId: 'wf-self',
+      nodes: [
+        { id: 'a', task: 'task-a', dependsOn: ['a'] }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('workflow.self_dependency: node=a');
+  });
+
+  it('T-WD6 enforces deterministic lexicographic tie-break in topological order', () => {
+    const loaded = loadWorkflowDefinition({
+      workflowId: 'wf-order',
+      nodes: [
+        { id: 'z', task: 'task-z' },
+        { id: 'a', task: 'task-a' },
+        { id: 'm', task: 'task-m', dependsOn: ['a'] }
+      ]
+    });
+    const dag = new WorkflowDag(loaded);
+
+    expect(dag.getExecutionOrder()).toEqual(['a', 'm', 'z']);
+  });
+
+  it('T-WD7 detects runnable nodes before/after prerequisite completion', () => {
+    const loaded = loadWorkflowDefinition(validWorkflow());
+    const dag = new WorkflowDag(loaded);
+
+    expect(dag.getRunnableNodeIds([])).toEqual(['a']);
+    expect(dag.getRunnableNodeIds(['a'])).toEqual(['b', 'c']);
+    expect(dag.getRunnableNodeIds(['a', 'b', 'c'])).toEqual([]);
+    expect(dag.isComplete(['a', 'b', 'c'])).toBe(true);
+  });
+});

--- a/control-plane/workflows/tests/workflow-runner.test.ts
+++ b/control-plane/workflows/tests/workflow-runner.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { loadWorkflowDefinition } from '../workflow-loader.ts';
+import { runWorkflow, type WorkflowTaskExecutor } from '../workflow-runner.ts';
+
+describe('workflow-runner', () => {
+  it('T-WR1 executes nodes in deterministic order', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-order',
+      nodes: [
+        { id: 'b', task: 'task-b' },
+        { id: 'a', task: 'task-a' },
+        { id: 'c', task: 'task-c', dependsOn: ['a'] }
+      ]
+    });
+
+    const seen: string[] = [];
+    const executor: WorkflowTaskExecutor = {
+      execute(input) {
+        seen.push(input.workflowNodeId);
+        return { ok: input.workflowNodeId };
+      }
+    };
+
+    const result = await runWorkflow({
+      missionId: 'mission-1',
+      workflow,
+      executor
+    });
+
+    expect(seen).toEqual(['a', 'b', 'c']);
+    expect(result.executionOrder).toEqual(['a', 'b', 'c']);
+  });
+
+  it('T-WR2 passes agent binding to executor', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-agent',
+      nodes: [
+        { id: 'a', task: 'task-a', agent: 'macro-signal-analyst' }
+      ]
+    });
+
+    const execute = vi.fn((input: Parameters<WorkflowTaskExecutor['execute']>[0]) => ({ ok: input.agent }));
+
+    await runWorkflow({
+      missionId: 'mission-2',
+      workflow,
+      executor: { execute }
+    });
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      workflowNodeId: 'a',
+      agent: 'macro-signal-analyst'
+    }));
+  });
+
+  it('T-WR3 propagates previousOutputs to downstream nodes', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-context',
+      nodes: [
+        { id: 'research', task: 'research' },
+        { id: 'review', task: 'review', dependsOn: ['research'] }
+      ]
+    });
+
+    const seenPreviousOutputs: Array<Record<string, unknown>> = [];
+    const executor: WorkflowTaskExecutor = {
+      execute(input) {
+        seenPreviousOutputs.push(input.previousOutputs);
+        return { node: input.workflowNodeId, result: `${input.workflowNodeId}-output` };
+      }
+    };
+
+    await runWorkflow({
+      missionId: 'mission-3',
+      workflow,
+      executor
+    });
+
+    expect(seenPreviousOutputs[0]).toEqual({});
+    expect(seenPreviousOutputs[1]).toEqual({
+      research: {
+        node: 'research',
+        result: 'research-output'
+      }
+    });
+  });
+
+  it('T-WR4 supports fan-in dependencies with both upstream outputs', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-fanin',
+      nodes: [
+        { id: 'a', task: 'task-a' },
+        { id: 'b', task: 'task-b' },
+        { id: 'c', task: 'task-c', dependsOn: ['a', 'b'] }
+      ]
+    });
+
+    const execute = vi.fn((input: Parameters<WorkflowTaskExecutor['execute']>[0]) => {
+      if (input.workflowNodeId === 'c') {
+        expect(input.previousOutputs).toEqual({
+          a: { value: 'A' },
+          b: { value: 'B' }
+        });
+      }
+
+      if (input.workflowNodeId === 'a') {
+        return { value: 'A' };
+      }
+      if (input.workflowNodeId === 'b') {
+        return { value: 'B' };
+      }
+      return { value: 'C' };
+    });
+
+    const result = await runWorkflow({
+      missionId: 'mission-4',
+      workflow,
+      executor: { execute }
+    });
+
+    expect(result.executionOrder).toEqual(['a', 'b', 'c']);
+  });
+
+  it('T-WR5 preserves sequential execution when multiple nodes are runnable', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-sequential',
+      nodes: [
+        { id: 'b', task: 'task-b' },
+        { id: 'a', task: 'task-a' },
+        { id: 'c', task: 'task-c' }
+      ]
+    });
+
+    const sequence: string[] = [];
+    const executor: WorkflowTaskExecutor = {
+      execute(input) {
+        sequence.push(input.workflowNodeId);
+        return { ok: true };
+      }
+    };
+
+    await runWorkflow({
+      missionId: 'mission-5',
+      workflow,
+      executor
+    });
+
+    expect(sequence).toEqual(['a', 'b', 'c']);
+  });
+
+  it('T-WR6 surfaces execution failures with workflow/node context', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-failure',
+      nodes: [
+        { id: 'a', task: 'task-a' }
+      ]
+    });
+
+    const executor: WorkflowTaskExecutor = {
+      execute() {
+        throw new Error('boom');
+      }
+    };
+
+    await expect(runWorkflow({
+      missionId: 'mission-6',
+      workflow,
+      executor
+    })).rejects.toThrow('workflow.execution_failed: workflowId=wf-failure workflowNodeId=a reason=boom');
+  });
+
+  it('T-WR7 runs simple linear workflow for backward-compatible sequential pattern', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-linear',
+      nodes: [
+        { id: 'one', task: 'task-1' },
+        { id: 'two', task: 'task-2', dependsOn: ['one'] },
+        { id: 'three', task: 'task-3', dependsOn: ['two'] }
+      ]
+    });
+
+    const result = await runWorkflow({
+      missionId: 'mission-7',
+      workflow,
+      executor: {
+        execute(input) {
+          return { completed: input.workflowNodeId };
+        }
+      }
+    });
+
+    expect(result.executionOrder).toEqual(['one', 'two', 'three']);
+    expect(result.nodeResults.map((entry) => entry.workflowNodeId)).toEqual(['one', 'two', 'three']);
+  });
+});

--- a/control-plane/workflows/workflow-dag.ts
+++ b/control-plane/workflows/workflow-dag.ts
@@ -1,0 +1,131 @@
+import type { RunnableNode, ValidatedWorkflowDefinition, WorkflowNode } from './workflow-types.ts';
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function sortNodes(nodes: WorkflowNode[]): WorkflowNode[] {
+  return [...nodes].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export class WorkflowDag {
+  private readonly workflowId: string;
+  private readonly nodeById: Map<string, WorkflowNode>;
+  private readonly nodeIds: string[];
+  private readonly executionOrder: string[];
+
+  constructor(workflow: ValidatedWorkflowDefinition) {
+    this.workflowId = workflow.workflowId;
+    const sortedNodes = sortNodes(workflow.nodes).map((node) => ({
+      ...node,
+      dependsOn: sortedUnique(node.dependsOn ?? [])
+    }));
+
+    this.nodeById = new Map(sortedNodes.map((node) => [node.id, node]));
+    this.nodeIds = sortedNodes.map((node) => node.id);
+    this.executionOrder = this.computeExecutionOrder();
+  }
+
+  private computeExecutionOrder(): string[] {
+    const inDegree = new Map<string, number>(this.nodeIds.map((nodeId) => [nodeId, 0]));
+    const adjacency = new Map<string, string[]>(this.nodeIds.map((nodeId) => [nodeId, []]));
+
+    for (const nodeId of this.nodeIds) {
+      const node = this.nodeById.get(nodeId);
+      const dependencies = sortedUnique(node?.dependsOn ?? []);
+      for (const dependency of dependencies) {
+        if (!this.nodeById.has(dependency)) {
+          continue;
+        }
+
+        const neighbors = adjacency.get(dependency) ?? [];
+        neighbors.push(nodeId);
+        adjacency.set(dependency, sortedUnique(neighbors));
+        inDegree.set(nodeId, (inDegree.get(nodeId) ?? 0) + 1);
+      }
+    }
+
+    const available = this.nodeIds
+      .filter((nodeId) => (inDegree.get(nodeId) ?? 0) === 0)
+      .sort((left, right) => left.localeCompare(right));
+
+    const order: string[] = [];
+    while (available.length > 0) {
+      const next = available.shift();
+      if (!next) {
+        break;
+      }
+
+      order.push(next);
+
+      for (const neighbor of adjacency.get(next) ?? []) {
+        const nextDegree = (inDegree.get(neighbor) ?? 0) - 1;
+        inDegree.set(neighbor, nextDegree);
+        if (nextDegree === 0) {
+          available.push(neighbor);
+          available.sort((left, right) => left.localeCompare(right));
+        }
+      }
+    }
+
+    if (order.length !== this.nodeIds.length) {
+      throw new Error(`workflow.dag_invalid: unable to compute topological order for workflow ${this.workflowId}`);
+    }
+
+    return order;
+  }
+
+  getWorkflowId(): string {
+    return this.workflowId;
+  }
+
+  getNodeIds(): string[] {
+    return [...this.nodeIds];
+  }
+
+  getExecutionOrder(): string[] {
+    return [...this.executionOrder];
+  }
+
+  getRunnableNodeIds(completedNodeIds: string[]): string[] {
+    const completed = new Set(sortedUnique(completedNodeIds));
+
+    return this.nodeIds
+      .filter((nodeId) => {
+        if (completed.has(nodeId)) {
+          return false;
+        }
+
+        const node = this.nodeById.get(nodeId);
+        if (!node) {
+          return false;
+        }
+
+        const dependencies = sortedUnique(node.dependsOn ?? []);
+        return dependencies.every((dependency) => completed.has(dependency));
+      })
+      .sort((left, right) => left.localeCompare(right));
+  }
+
+  getRunnableNodes(completedNodeIds: string[]): RunnableNode[] {
+    return this.getRunnableNodeIds(completedNodeIds).map((nodeId) => {
+      const node = this.nodeById.get(nodeId);
+      if (!node) {
+        throw new Error(`workflow.node_not_found: ${nodeId}`);
+      }
+
+      return {
+        id: node.id,
+        task: node.task,
+        ...(node.agent ? { agent: node.agent } : {}),
+        dependsOn: sortedUnique(node.dependsOn ?? []),
+        ...(node.phase ? { phase: node.phase } : {})
+      };
+    });
+  }
+
+  isComplete(completedNodeIds: string[]): boolean {
+    const completed = new Set(sortedUnique(completedNodeIds));
+    return this.nodeIds.every((nodeId) => completed.has(nodeId));
+  }
+}

--- a/control-plane/workflows/workflow-loader.ts
+++ b/control-plane/workflows/workflow-loader.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { ValidatedWorkflowDefinition, WorkflowDefinition, WorkflowNode } from './workflow-types.ts';
+import { validateWorkflowDefinition } from './workflow-validator.ts';
+
+const DEFAULT_WORKFLOWS_DIR = 'control-plane/workflows/definitions';
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function sortNodes(nodes: WorkflowNode[]): WorkflowNode[] {
+  return [...nodes].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function normalizeWorkflowDefinition(workflow: WorkflowDefinition): ValidatedWorkflowDefinition {
+  return {
+    workflowId: workflow.workflowId,
+    nodes: sortNodes(workflow.nodes).map((node) => ({
+      id: node.id,
+      task: node.task,
+      ...(node.agent ? { agent: node.agent } : {}),
+      ...(node.phase ? { phase: node.phase } : {}),
+      dependsOn: sortedUnique(node.dependsOn ?? [])
+    }))
+  };
+}
+
+export function loadWorkflowDefinition(input: unknown): ValidatedWorkflowDefinition {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('workflow.load_failed: workflow definition must be an object');
+  }
+
+  const workflow = input as WorkflowDefinition;
+  const result = validateWorkflowDefinition(workflow);
+
+  if (!result.valid) {
+    throw new Error(`workflow.validation_failed: ${result.errors.join('; ')}`);
+  }
+
+  return normalizeWorkflowDefinition(workflow);
+}
+
+export function loadWorkflowFromFile(filePath: string): ValidatedWorkflowDefinition {
+  const resolvedPath = path.resolve(filePath);
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+
+  return loadWorkflowDefinition(parsed);
+}
+
+export function loadWorkflowDefinitionById(workflowId: string, dir: string = DEFAULT_WORKFLOWS_DIR): ValidatedWorkflowDefinition {
+  const filePath = path.join(dir, `${workflowId}.json`);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`workflow.definition_not_found: ${workflowId}`);
+  }
+
+  return loadWorkflowFromFile(filePath);
+}

--- a/control-plane/workflows/workflow-runner.ts
+++ b/control-plane/workflows/workflow-runner.ts
@@ -1,0 +1,127 @@
+import { WorkflowDag } from './workflow-dag.ts';
+import type { ValidatedWorkflowDefinition, WorkflowNodeExecutionResult, WorkflowRunResult } from './workflow-types.ts';
+import type { SwarmRunner } from '../swarm/swarm-runner.ts';
+
+export interface WorkflowTaskExecutor {
+  execute(input: {
+    missionId: string;
+    workflowId: string;
+    workflowNodeId: string;
+    task: string;
+    agent?: string;
+    previousOutputs: Record<string, unknown>;
+  }): Promise<unknown> | unknown;
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function buildPreviousOutputs(
+  allOutputs: Record<string, unknown>,
+  dependencyNodeIds: string[]
+): Record<string, unknown> {
+  const dependencies = sortedUnique(dependencyNodeIds);
+  const entries = dependencies
+    .filter((dependency) => Object.prototype.hasOwnProperty.call(allOutputs, dependency))
+    .map((dependency) => [dependency, allOutputs[dependency]] as const);
+
+  return Object.fromEntries(entries);
+}
+
+export async function runWorkflow(input: {
+  missionId: string;
+  workflow: ValidatedWorkflowDefinition;
+  executor: WorkflowTaskExecutor;
+}): Promise<WorkflowRunResult> {
+  const dag = new WorkflowDag(input.workflow);
+  const completedNodeIds: string[] = [];
+  const outputsByNodeId: Record<string, unknown> = {};
+  const nodeResults: WorkflowNodeExecutionResult[] = [];
+
+  while (!dag.isComplete(completedNodeIds)) {
+    const runnableNodes = dag.getRunnableNodes(completedNodeIds);
+
+    if (runnableNodes.length === 0) {
+      throw new Error(`workflow.execution_stalled: workflowId=${input.workflow.workflowId}`);
+    }
+
+    const nextNode = runnableNodes[0];
+    const previousOutputs = buildPreviousOutputs(outputsByNodeId, nextNode.dependsOn);
+
+    try {
+      const output = await input.executor.execute({
+        missionId: input.missionId,
+        workflowId: input.workflow.workflowId,
+        workflowNodeId: nextNode.id,
+        task: nextNode.task,
+        ...(nextNode.agent ? { agent: nextNode.agent } : {}),
+        previousOutputs
+      });
+
+      outputsByNodeId[nextNode.id] = output;
+      completedNodeIds.push(nextNode.id);
+      completedNodeIds.sort((left, right) => left.localeCompare(right));
+
+      nodeResults.push({
+        workflowNodeId: nextNode.id,
+        task: nextNode.task,
+        ...(nextNode.agent ? { agentId: nextNode.agent } : {}),
+        output
+      });
+    } catch (error) {
+      const reason = error instanceof Error && error.message.trim().length > 0
+        ? error.message
+        : 'workflow_node_execution_failed';
+      throw new Error(
+        `workflow.execution_failed: workflowId=${input.workflow.workflowId} workflowNodeId=${nextNode.id} reason=${reason}`
+      );
+    }
+  }
+
+  return {
+    missionId: input.missionId,
+    workflowId: input.workflow.workflowId,
+    executionOrder: nodeResults.map((result) => result.workflowNodeId),
+    nodeResults
+  };
+}
+
+export function createSwarmWorkflowExecutor(input: {
+  swarmRunner: SwarmRunner;
+  projectId: string;
+}): WorkflowTaskExecutor {
+  return {
+    async execute(params) {
+      const created = input.swarmRunner.createSwarmRun({
+        projectId: input.projectId,
+        kind: 'mission',
+        entrypoint: `workflow:${params.workflowId}:${params.workflowNodeId}`,
+        missionId: params.missionId,
+        initialMemory: {
+          workflowNodeId: params.workflowNodeId,
+          task: params.task,
+          previousOutputs: params.previousOutputs
+        },
+        metadata: {
+          missionId: params.missionId,
+          workflowId: params.workflowId,
+          workflowNodeId: params.workflowNodeId,
+          task: params.task,
+          ...(params.agent ? { agentId: params.agent } : {}),
+          adapterId: params.task
+        }
+      });
+
+      const completed = await input.swarmRunner.executeSwarmRun({ runId: created.runId });
+
+      return {
+        runId: completed.runId,
+        status: completed.status,
+        currentPhase: completed.currentPhase,
+        completedPhases: completed.completedPhases,
+        eventCount: completed.eventCount
+      };
+    }
+  };
+}

--- a/control-plane/workflows/workflow-types.ts
+++ b/control-plane/workflows/workflow-types.ts
@@ -1,0 +1,63 @@
+export interface WorkflowDefinition {
+  workflowId: string;
+  nodes: WorkflowNode[];
+}
+
+export interface WorkflowNode {
+  id: string;
+  task: string;
+  agent?: string;
+  dependsOn?: string[];
+  phase?: string;
+}
+
+export interface ValidatedWorkflowDefinition {
+  workflowId: string;
+  nodes: WorkflowNode[];
+}
+
+export interface WorkflowValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface WorkflowExecutionContext {
+  missionId: string;
+  workflowId: string;
+  workflowNodeId: string;
+  previousOutputs: Record<string, unknown>;
+}
+
+export interface WorkflowNodeExecutionResult {
+  workflowNodeId: string;
+  task: string;
+  agentId?: string;
+  output: unknown;
+}
+
+export interface WorkflowRunResult {
+  missionId: string;
+  workflowId: string;
+  executionOrder: string[];
+  nodeResults: WorkflowNodeExecutionResult[];
+}
+
+export interface RunnableNode {
+  id: string;
+  task: string;
+  agent?: string;
+  dependsOn: string[];
+  phase?: string;
+}
+
+export interface WorkflowInspectResult {
+  workflowId: string;
+  nodes: Array<{
+    id: string;
+    task: string;
+    agent?: string;
+    phase?: string;
+    dependsOn: string[];
+  }>;
+  executionOrder: string[];
+}

--- a/control-plane/workflows/workflow-validator.ts
+++ b/control-plane/workflows/workflow-validator.ts
@@ -1,0 +1,214 @@
+import type { WorkflowDefinition, WorkflowNode, WorkflowValidationResult } from './workflow-types.ts';
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function sortNodes(nodes: WorkflowNode[]): WorkflowNode[] {
+  return [...nodes].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function normalizeDependsOn(dependsOn: string[] | undefined): string[] {
+  if (!dependsOn) {
+    return [];
+  }
+
+  return sortedUnique(dependsOn);
+}
+
+function findCycle(nodeIds: string[], adjacency: Map<string, string[]>): string[] | null {
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+  const indexByNode = new Map<string, number>();
+
+  const visit = (nodeId: string): string[] | null => {
+    if (visited.has(nodeId)) {
+      return null;
+    }
+
+    visiting.add(nodeId);
+    indexByNode.set(nodeId, stack.length);
+    stack.push(nodeId);
+
+    const neighbors = adjacency.get(nodeId) ?? [];
+    for (const neighbor of neighbors) {
+      if (visiting.has(neighbor)) {
+        const cycleStart = indexByNode.get(neighbor) ?? 0;
+        return stack.slice(cycleStart);
+      }
+
+      const nested = visit(neighbor);
+      if (nested) {
+        return nested;
+      }
+    }
+
+    stack.pop();
+    indexByNode.delete(nodeId);
+    visiting.delete(nodeId);
+    visited.add(nodeId);
+
+    return null;
+  };
+
+  for (const nodeId of nodeIds) {
+    if (visited.has(nodeId)) {
+      continue;
+    }
+
+    const cycle = visit(nodeId);
+    if (cycle) {
+      if (cycle.length === 0) {
+        return cycle;
+      }
+
+      let minIndex = 0;
+      for (let index = 1; index < cycle.length; index += 1) {
+        if (cycle[index].localeCompare(cycle[minIndex]) < 0) {
+          minIndex = index;
+        }
+      }
+
+      return [...cycle.slice(minIndex), ...cycle.slice(0, minIndex)];
+    }
+  }
+
+  return null;
+}
+
+export function validateWorkflowDefinition(input: WorkflowDefinition): WorkflowValidationResult {
+  const errors: string[] = [];
+
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return {
+      valid: false,
+      errors: ['workflow.schema_invalid: root must be an object']
+    };
+  }
+
+  if (!isNonEmptyString(input.workflowId)) {
+    errors.push('workflow.schema_invalid: workflowId must be a non-empty string');
+  }
+
+  if (!Array.isArray(input.nodes)) {
+    errors.push('workflow.schema_invalid: nodes must be a non-empty array');
+    return {
+      valid: false,
+      errors: sortedUnique(errors)
+    };
+  }
+
+  if (input.nodes.length === 0) {
+    errors.push('workflow.schema_invalid: nodes must be a non-empty array');
+  }
+
+  const validatedNodes: WorkflowNode[] = [];
+  const nodeIds: string[] = [];
+
+  for (let index = 0; index < input.nodes.length; index += 1) {
+    const node = input.nodes[index] as WorkflowNode;
+
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+      errors.push(`workflow.schema_invalid: nodes[${index}] must be an object`);
+      continue;
+    }
+
+    if (!isNonEmptyString(node.id)) {
+      errors.push(`workflow.schema_invalid: nodes[${index}].id must be a non-empty string`);
+    }
+
+    if (!isNonEmptyString(node.task)) {
+      errors.push(`workflow.schema_invalid: nodes[${index}].task must be a non-empty string`);
+    }
+
+    if (node.agent !== undefined && !isNonEmptyString(node.agent)) {
+      errors.push(`workflow.schema_invalid: nodes[${index}].agent must be a non-empty string when provided`);
+    }
+
+    if (node.phase !== undefined && !isNonEmptyString(node.phase)) {
+      errors.push(`workflow.schema_invalid: nodes[${index}].phase must be a non-empty string when provided`);
+    }
+
+    if (
+      node.dependsOn !== undefined &&
+      (!Array.isArray(node.dependsOn) || !node.dependsOn.every((dep) => isNonEmptyString(dep)))
+    ) {
+      errors.push(`workflow.schema_invalid: nodes[${index}].dependsOn must be an array of non-empty strings`);
+    }
+
+    if (
+      isNonEmptyString(node.id) &&
+      isNonEmptyString(node.task) &&
+      (node.agent === undefined || isNonEmptyString(node.agent)) &&
+      (node.phase === undefined || isNonEmptyString(node.phase)) &&
+      (node.dependsOn === undefined || (Array.isArray(node.dependsOn) && node.dependsOn.every((dep) => isNonEmptyString(dep))))
+    ) {
+      validatedNodes.push({
+        id: node.id,
+        task: node.task,
+        ...(node.agent ? { agent: node.agent } : {}),
+        ...(node.phase ? { phase: node.phase } : {}),
+        dependsOn: normalizeDependsOn(node.dependsOn)
+      });
+      nodeIds.push(node.id);
+    }
+  }
+
+  const duplicates = nodeIds.filter((nodeId, index) => nodeIds.indexOf(nodeId) !== index);
+  for (const duplicate of sortedUnique(duplicates)) {
+    errors.push(`workflow.duplicate_node_id: ${duplicate}`);
+  }
+
+  const sortedNodes = sortNodes(validatedNodes);
+  const nodeSet = new Set(sortedNodes.map((node) => node.id));
+
+  for (const node of sortedNodes) {
+    const dependencies = normalizeDependsOn(node.dependsOn);
+    for (const dependency of dependencies) {
+      if (dependency === node.id) {
+        errors.push(`workflow.self_dependency: node=${node.id}`);
+      }
+
+      if (!nodeSet.has(dependency)) {
+        errors.push(`workflow.missing_dependency: node=${node.id} dependsOn=${dependency}`);
+      }
+    }
+  }
+
+  const adjacency = new Map<string, string[]>();
+  for (const node of sortedNodes) {
+    adjacency.set(node.id, []);
+  }
+
+  for (const node of sortedNodes) {
+    const dependencies = normalizeDependsOn(node.dependsOn);
+    for (const dependency of dependencies) {
+      if (!nodeSet.has(dependency)) {
+        continue;
+      }
+
+      const neighbors = adjacency.get(dependency) ?? [];
+      neighbors.push(node.id);
+      adjacency.set(dependency, sortedUnique(neighbors));
+    }
+  }
+
+  const cycle = findCycle(
+    sortedNodes.map((node) => node.id),
+    adjacency
+  );
+
+  if (cycle && cycle.length > 0) {
+    errors.push(`workflow.cycle_detected: ${cycle.join('->')}`);
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors: sortedUnique(errors)
+  };
+}

--- a/docs/architecture/workflow-engine.md
+++ b/docs/architecture/workflow-engine.md
@@ -1,0 +1,92 @@
+# Workflow Engine (Sprint 68)
+
+## Purpose
+
+The workflow engine adds a deterministic DAG orchestration layer between mission/team/agent definitions and runtime task execution.
+
+It upgrades execution from flat or phase-only sequencing to explicit node dependency orchestration while preserving existing runtime and governance invariants.
+
+## Placement in Architecture
+
+Workflow execution flow:
+
+1. Mission selects `workflowId`
+2. Workflow loader resolves and validates workflow definition
+3. Workflow DAG computes deterministic execution order
+4. Workflow runner executes nodes sequentially through an executor seam
+5. Executor delegates into existing runtime layers (swarm/agent/task)
+
+The engine does not replace swarm runtime or agent runtime. It only orchestrates node scheduling.
+
+## Model
+
+A workflow definition contains:
+
+- `workflowId`
+- `nodes[]`
+
+Each node contains:
+
+- `id` (unique)
+- `task`
+- optional `agent`
+- optional `dependsOn[]`
+- optional `phase`
+
+Dependencies create a DAG where edges are `dependency -> dependent`.
+
+## Validation Rules
+
+Validation enforces:
+
+- root schema integrity (`workflowId`, `nodes`)
+- node schema integrity (`id`, `task`, optional fields)
+- unique node IDs
+- valid dependency references
+- no self-dependency
+- no cycles
+
+Errors are emitted in deterministic sorted order.
+
+## Determinism Guarantees
+
+The subsystem is deterministic by design:
+
+- node IDs and dependencies are sorted lexicographically
+- tie-breaks use lexicographic node ID ordering
+- topological order is stable for equivalent DAGs
+- serialized CLI output uses canonical stringification
+- no randomness/timestamps in identity or ordering
+
+## Execution Semantics (Sprint 68)
+
+Execution is sequential-only in Sprint 68:
+
+- runner queries runnable nodes each loop
+- if multiple nodes are runnable, it picks the first lexicographically
+- one node executes at a time
+
+Parallel execution is intentionally deferred.
+
+## Context Propagation
+
+Each node execution receives:
+
+- `missionId`
+- `workflowId`
+- `workflowNodeId`
+- `task`
+- optional `agent`
+- `previousOutputs`
+
+`previousOutputs` is a dependency-keyed map of upstream node outputs for downstream consumption.
+
+## Runtime Integration
+
+Primary contract is an injected executor interface (`WorkflowTaskExecutor`).
+
+A thin adapter (`createSwarmWorkflowExecutor`) maps workflow node execution to existing swarm runtime semantics by carrying workflow metadata in run entrypoint/metadata/initial memory without rewriting swarm internals.
+
+## Future Extension
+
+Parallelism can be added later by executing the full runnable set in batches while preserving deterministic batch ordering and output collation rules.

--- a/docs/runbooks/workflows.md
+++ b/docs/runbooks/workflows.md
@@ -1,0 +1,85 @@
+# Workflows Runbook
+
+## Authoring a Workflow
+
+Create JSON workflow definitions in:
+
+- `control-plane/workflows/definitions/<workflow-id>.json`
+
+Required fields:
+
+- `workflowId`: non-empty string
+- `nodes`: non-empty array
+
+Node fields:
+
+- `id`: non-empty string, unique within workflow
+- `task`: non-empty string
+- `agent` (optional): agent binding passed to runtime executor
+- `dependsOn` (optional): array of node IDs
+- `phase` (optional): descriptive phase label
+
+`dependsOn` defaults to `[]` when omitted.
+
+## Dependency Rules
+
+- dependency IDs must exist in `nodes`
+- self-dependency is rejected
+- cycles are rejected
+- execution order is deterministic with lexicographic tie-breaks
+
+## previousOutputs Behavior
+
+A node receives `previousOutputs` keyed by dependency node ID.
+
+Example for a node depending on `market-research` and `regulatory-scan`:
+
+```json
+{
+  "market-research": { "...": "..." },
+  "regulatory-scan": { "...": "..." }
+}
+```
+
+Only declared upstream dependencies are propagated.
+
+## Validate a Workflow
+
+```bash
+npm run workflow:validate -- --workflow rwa-market-analysis
+```
+
+Success output (JSON):
+
+```json
+{"valid":true,"workflowId":"rwa-market-analysis"}
+```
+
+Failure output (JSON) includes deterministic error text and exits non-zero.
+
+## Inspect a Workflow
+
+```bash
+npm run workflow:inspect -- --workflow rwa-market-analysis
+```
+
+Output includes:
+
+- `workflowId`
+- normalized nodes
+- dependencies
+- deterministic `executionOrder`
+
+## Common Authoring Errors
+
+- duplicate node IDs
+- dependency references missing node IDs
+- self-dependency
+- dependency cycles
+- missing required node fields (`id`, `task`)
+
+## Determinism Checklist
+
+- keep node IDs stable
+- avoid semantic duplicates in dependency lists
+- rely on inspect output to verify final deterministic order

--- a/entities/projects/control-plane.json
+++ b/entities/projects/control-plane.json
@@ -12,6 +12,7 @@
     "control-plane/entities/",
     "control-plane/governance/",
     "control-plane/missions/",
+    "control-plane/workflows/",
     "control-plane/projects/",
     "control-plane/teams/",
     "control-plane/tasks/",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "mission:run": "node --experimental-strip-types control-plane/cli/mission-run.ts",
     "mission:inspect": "node --experimental-strip-types control-plane/cli/mission-inspect.ts",
     "mission:agents": "node --experimental-strip-types control-plane/cli/mission-agents.ts",
+    "workflow:inspect": "node --experimental-strip-types control-plane/cli/workflow-inspect.ts",
+    "workflow:validate": "node --experimental-strip-types control-plane/cli/workflow-validate.ts",
     "agent:inspect": "node --experimental-strip-types control-plane/cli/agent-inspect.ts",
     "team:inspect": "node --experimental-strip-types control-plane/cli/team-inspect.ts",
     "governance:generate": "node --experimental-strip-types control-plane/cli/governance-generate.ts",


### PR DESCRIPTION
tier-3

```evidence
Sprint 68 implemented a deterministic declarative workflow DAG engine under control-plane/workflows/.

Validation:
- Added workflow validator with duplicate ID, missing dependency, self-dependency, and cycle rejection.
- Added deterministic DAG ordering with lexicographic tie-breaks.
- Added workflow loader and sequential workflow runner with previousOutputs propagation.
- Added agent binding pass-through and thin runtime adapter seam.
- Added CLI commands:
  - npm run workflow:validate -- --workflow rwa-market-analysis
  - npm run workflow:inspect -- --workflow rwa-market-analysis
- Added docs:
  - docs/architecture/workflow-engine.md
  - docs/runbooks/workflows.md
- Registered control-plane/workflows/ ownership in entities/projects/control-plane.json

Verification run:
- npx vitest run control-plane/workflows/tests/workflow-dag.test.ts control-plane/workflows/tests/workflow-runner.test.ts
- npm run workflow:validate -- --workflow rwa-market-analysis
- npm run workflow:inspect -- --workflow rwa-market-analysis
- npm run typecheck
- npm test
- npm run governance:preflight

Results:
- Workflow DAG and runner tests passed.
- CLI commands returned deterministic JSON output.
- Typecheck passed.
- Full test suite passed.
- Governance preflight passed.
```
