### PR TITLE
Sprint 72: Operator Control Surface

### DIFF
--- a/control-plane/missions/definitions/rwa-market-analysis.json
+++ b/control-plane/missions/definitions/rwa-market-analysis.json
@@ -17,6 +17,27 @@
     "opportunity-list",
     "regulatory-notes"
   ],
+  "parameterSchema": {
+    "allowed": [
+      "asset",
+      "horizon",
+      "market",
+      "risk-level"
+    ],
+    "required": [
+      "market"
+    ],
+    "defaults": {
+      "horizon": "30d",
+      "risk-level": "medium"
+    },
+    "descriptions": {
+      "asset": "Focus asset class for mission analysis.",
+      "horizon": "Time horizon for thesis framing.",
+      "market": "Primary market under review.",
+      "risk-level": "Operator-declared risk appetite."
+    }
+  },
   "initialContext": {
     "sector": "RWA",
     "targetAssets": [

--- a/control-plane/missions/mission-types.ts
+++ b/control-plane/missions/mission-types.ts
@@ -1,5 +1,12 @@
 export type MissionPriority = 'low' | 'medium' | 'high' | 'critical';
 
+export type MissionParameterSchema = {
+  allowed?: string[];
+  required?: string[];
+  defaults?: Record<string, string>;
+  descriptions?: Record<string, string>;
+};
+
 export type MissionDefinition = {
   missionId: string;
   name?: string;
@@ -10,6 +17,7 @@ export type MissionDefinition = {
   successCriteria: string[];
   deliverables: string[];
   initialContext: Record<string, unknown>;
+  parameterSchema?: MissionParameterSchema;
   description?: string;
   priority?: MissionPriority;
   constraints?: string[];

--- a/control-plane/missions/mission-validator.test.ts
+++ b/control-plane/missions/mission-validator.test.ts
@@ -36,4 +36,24 @@ describe('mission-validator', () => {
       /workflowId must be a non-empty string/
     );
   });
+
+  it('T-M10 validates optional parameter schema with deterministic ordering', () => {
+    const mission = validateMissionDefinition(validMission({
+      parameterSchema: {
+        allowed: ['risk-level', 'market'],
+        required: ['market'],
+        defaults: {
+          'risk-level': 'medium'
+        }
+      }
+    }));
+
+    expect(mission.parameterSchema).toEqual({
+      allowed: ['market', 'risk-level'],
+      required: ['market'],
+      defaults: {
+        'risk-level': 'medium'
+      }
+    });
+  });
 });

--- a/control-plane/missions/mission-validator.ts
+++ b/control-plane/missions/mission-validator.ts
@@ -49,6 +49,55 @@ function parseInitialContext(value: unknown, missionId: string): Record<string, 
   return Object.fromEntries(entries);
 }
 
+function parseStringRecord(value: unknown, label: string): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object of string values.`);
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  for (const [, entryValue] of entries) {
+    if (!isNonEmptyString(entryValue)) {
+      throw new Error(`${label} must be an object of string values.`);
+    }
+  }
+
+  return Object.fromEntries(
+    entries
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entryValue]) => [key, entryValue as string])
+  );
+}
+
+function parseParameterSchema(value: unknown, missionId: string): MissionDefinition['parameterSchema'] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Mission ${missionId} parameterSchema must be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const allowed = record.allowed === undefined
+    ? undefined
+    : sortedUnique(ensureStringArray(record.allowed, `Mission ${missionId} parameterSchema.allowed`));
+  const required = record.required === undefined
+    ? undefined
+    : sortedUnique(ensureStringArray(record.required, `Mission ${missionId} parameterSchema.required`));
+  const defaults = record.defaults === undefined
+    ? undefined
+    : parseStringRecord(record.defaults, `Mission ${missionId} parameterSchema.defaults`);
+  const descriptions = record.descriptions === undefined
+    ? undefined
+    : parseStringRecord(record.descriptions, `Mission ${missionId} parameterSchema.descriptions`);
+
+  return {
+    ...(allowed ? { allowed } : {}),
+    ...(required ? { required } : {}),
+    ...(defaults ? { defaults } : {}),
+    ...(descriptions ? { descriptions } : {})
+  };
+}
+
 export function validateMissionDefinition(value: unknown): MissionDefinition {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('Mission definition must be an object.');
@@ -71,6 +120,7 @@ export function validateMissionDefinition(value: unknown): MissionDefinition {
     : ensureStringArray(record.deliverables, `Mission ${record.missionId} deliverables`);
 
   const priority = parsePriority(record.priority, record.missionId);
+  const parameterSchema = parseParameterSchema(record.parameterSchema, record.missionId);
 
   return {
     missionId: record.missionId,
@@ -82,6 +132,7 @@ export function validateMissionDefinition(value: unknown): MissionDefinition {
     successCriteria: sortedUnique(successCriteria),
     deliverables: sortedUnique(deliverables),
     initialContext: parseInitialContext(record.initialContext, record.missionId),
+    ...(parameterSchema ? { parameterSchema } : {}),
     ...(isNonEmptyString(record.description) ? { description: record.description } : {}),
     ...(priority ? { priority } : {}),
     ...(record.constraints !== undefined

--- a/control-plane/operator/cli.ts
+++ b/control-plane/operator/cli.ts
@@ -1,0 +1,36 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createOperatorCommandRouter } from './command-router.ts';
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const router = createOperatorCommandRouter();
+  const result = await router.route({
+    source: 'cli',
+    argv
+  });
+
+  printJson(result);
+  return result.success ? 0 : 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    printJson({
+      success: false,
+      command: {
+        name: 'unknown',
+        source: 'cli'
+      },
+      error: {
+        code: 'UNEXPECTED_RUNTIME_ERROR',
+        message: 'unexpected_runtime_error'
+      }
+    });
+    process.exit(2);
+  });
+}

--- a/control-plane/operator/command-router.test.ts
+++ b/control-plane/operator/command-router.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createOperatorCommandRouter } from './command-router.ts';
+
+describe('operator command router', () => {
+  it('T-OPR1 routes mission:list through mission service', async () => {
+    const missionList = vi.fn(() => [{ missionId: 'rwa-market-analysis', status: 'running' }]);
+
+    const router = createOperatorCommandRouter({
+      services: {
+        mission: {
+          startMission: vi.fn(),
+          listMissions: missionList,
+          inspectMission: vi.fn(),
+          cancelMission: vi.fn()
+        },
+        workflow: {
+          listWorkflows: vi.fn(),
+          inspectWorkflow: vi.fn(),
+          traceWorkflow: vi.fn()
+        },
+        runtime: {
+          retryWorkflowNode: vi.fn(),
+          resumeWorkflow: vi.fn(),
+          cancelWorkflow: vi.fn()
+        }
+      }
+    });
+
+    const result = await router.route({
+      source: 'cli',
+      argv: ['mission:list']
+    });
+
+    expect(result).toEqual({
+      success: true,
+      command: {
+        name: 'mission:list',
+        source: 'cli'
+      },
+      payload: [{ missionId: 'rwa-market-analysis', status: 'running' }]
+    });
+    expect(missionList).toHaveBeenCalledTimes(1);
+  });
+
+  it('T-OPR2 returns deterministic structured errors for parser failures', async () => {
+    const router = createOperatorCommandRouter({
+      services: {
+        mission: {
+          startMission: vi.fn(),
+          listMissions: vi.fn(),
+          inspectMission: vi.fn(),
+          cancelMission: vi.fn()
+        },
+        workflow: {
+          listWorkflows: vi.fn(),
+          inspectWorkflow: vi.fn(),
+          traceWorkflow: vi.fn()
+        },
+        runtime: {
+          retryWorkflowNode: vi.fn(),
+          resumeWorkflow: vi.fn(),
+          cancelWorkflow: vi.fn()
+        }
+      }
+    });
+
+    const result = await router.route({
+      source: 'cli',
+      argv: ['workflow:retry', '--run', 'run_1']
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({
+      code: 'MISSING_ARGUMENT',
+      message: 'Missing required --node'
+    });
+  });
+});

--- a/control-plane/operator/command-router.ts
+++ b/control-plane/operator/command-router.ts
@@ -1,0 +1,177 @@
+import { createMissionService } from './mission-service.ts';
+import { createRuntimeService } from './runtime-service.ts';
+import { parseOperatorCommand } from './schema.ts';
+import type {
+  OperatorCommandResult,
+  OperatorRouterRequest,
+  OperatorServices,
+  ParsedOperatorCommand
+} from './types.ts';
+import { createWorkflowService } from './workflow-service.ts';
+
+type CommandRouterOptions = {
+  services?: OperatorServices;
+  rootDir?: string;
+  missionsDir?: string;
+  teamsDir?: string;
+  agentsDir?: string;
+  workflowsDir?: string;
+};
+
+function errorResult(input: {
+  source: OperatorRouterRequest['source'];
+  command: string;
+  error: unknown;
+}): OperatorCommandResult {
+  if (typeof input.error === 'object' && input.error !== null && 'code' in input.error && 'message' in input.error) {
+    const typed = input.error as { code: string; message: string; details?: Record<string, unknown> };
+    return {
+      success: false,
+      command: {
+        name: input.command as OperatorCommandResult['command']['name'],
+        source: input.source
+      },
+      error: {
+        code: typed.code,
+        message: typed.message,
+        ...(typed.details ? { details: typed.details } : {})
+      }
+    };
+  }
+
+  return {
+    success: false,
+    command: {
+      name: input.command as OperatorCommandResult['command']['name'],
+      source: input.source
+    },
+    error: {
+      code: 'COMMAND_FAILED',
+      message: input.error instanceof Error ? input.error.message : 'unknown_error'
+    }
+  };
+}
+
+function createDefaultServices(options: CommandRouterOptions): OperatorServices {
+  const mission = createMissionService({
+    rootDir: options.rootDir,
+    missionsDir: options.missionsDir,
+    teamsDir: options.teamsDir,
+    agentsDir: options.agentsDir,
+    workflowsDir: options.workflowsDir
+  });
+  const workflow = createWorkflowService({
+    rootDir: options.rootDir
+  });
+  const runtime = createRuntimeService({
+    rootDir: options.rootDir,
+    workflowsDir: options.workflowsDir
+  });
+
+  return {
+    mission: {
+      startMission: mission.startMission,
+      listMissions: mission.listMissions,
+      inspectMission: mission.inspectMission,
+      cancelMission: mission.cancelMission
+    },
+    workflow: {
+      listWorkflows: workflow.listWorkflows,
+      inspectWorkflow: workflow.inspectWorkflow,
+      traceWorkflow: workflow.traceWorkflow
+    },
+    runtime: {
+      retryWorkflowNode: runtime.retryWorkflowNode,
+      resumeWorkflow: runtime.resumeWorkflow,
+      cancelWorkflow: runtime.cancelWorkflow
+    }
+  };
+}
+
+async function dispatch(input: {
+  command: ParsedOperatorCommand;
+  services: OperatorServices;
+}): Promise<unknown> {
+  const command = input.command;
+
+  if (command.name === 'mission:start') {
+    return input.services.mission.startMission({
+      missionId: command.missionId,
+      params: command.params
+    });
+  }
+
+  if (command.name === 'mission:list') {
+    return input.services.mission.listMissions();
+  }
+
+  if (command.name === 'mission:inspect') {
+    return input.services.mission.inspectMission({ missionId: command.missionId });
+  }
+
+  if (command.name === 'mission:cancel') {
+    return input.services.mission.cancelMission({ missionId: command.missionId });
+  }
+
+  if (command.name === 'workflow:list') {
+    return input.services.workflow.listWorkflows();
+  }
+
+  if (command.name === 'workflow:inspect') {
+    return input.services.workflow.inspectWorkflow({ runId: command.runId });
+  }
+
+  if (command.name === 'workflow:trace') {
+    return input.services.workflow.traceWorkflow({ runId: command.runId });
+  }
+
+  if (command.name === 'workflow:retry') {
+    return input.services.runtime.retryWorkflowNode({
+      runId: command.runId,
+      nodeId: command.nodeId
+    });
+  }
+
+  if (command.name === 'workflow:resume') {
+    return input.services.runtime.resumeWorkflow({ runId: command.runId });
+  }
+
+  return input.services.runtime.cancelWorkflow({ runId: command.runId });
+}
+
+export function createOperatorCommandRouter(options: CommandRouterOptions = {}) {
+  const services = options.services ?? createDefaultServices(options);
+
+  async function route(request: OperatorRouterRequest): Promise<OperatorCommandResult> {
+    const commandToken = request.argv[0] ?? 'unknown';
+
+    try {
+      const parsed = parseOperatorCommand(request.argv);
+      const payload = await dispatch({
+        command: parsed,
+        services
+      });
+
+      return {
+        success: true,
+        command: {
+          name: parsed.name,
+          source: request.source
+        },
+        payload
+      };
+    } catch (error) {
+      return errorResult({
+        source: request.source,
+        command: commandToken,
+        error
+      });
+    }
+  }
+
+  return {
+    route
+  };
+}
+
+export type OperatorCommandRouter = ReturnType<typeof createOperatorCommandRouter>;

--- a/control-plane/operator/mission-service.ts
+++ b/control-plane/operator/mission-service.ts
@@ -1,0 +1,350 @@
+import { loadAgentProfilesFromDir } from '../agents/agent-profile-loader.ts';
+import type { AgentProfileDefinition } from '../agents/agent-profile-types.ts';
+import type { ExecutionJournal } from '../journal/journal.ts';
+import { createExecutionJournal } from '../journal/journal.ts';
+import { getRunDiagnosticReport } from '../observability/diagnostics.ts';
+import { buildWorkflowNodeRecords } from '../observability/node-record.ts';
+import { buildWorkflowRunRecord, buildWorkflowRunRecords } from '../observability/run-record.ts';
+import type { MissionDefinition, MissionParameterSchema } from '../missions/mission-types.ts';
+import { loadMissionDefinitionById, loadMissionDefinitionsFromDir } from '../missions/mission-loader.ts';
+import { createSwarmRunner } from '../swarm/swarm-runner.ts';
+import { loadTeamDefinitionById } from '../teams/team-loader.ts';
+import type { TeamDefinition } from '../teams/team-types.ts';
+import { loadWorkflowDefinitionById } from '../workflows/workflow-loader.ts';
+import { createSwarmWorkflowExecutor } from '../workflows/workflow-runner.ts';
+import { executeWorkflowRunWithHardening } from '../runtime/hardened-workflow-runtime.ts';
+import { cancelWorkflowRun, reconstructWorkflowStateFromJournal } from '../runtime/recovery-engine.ts';
+
+type MissionServiceOptions = {
+  journal?: ExecutionJournal;
+  rootDir?: string;
+  missionsDir?: string;
+  teamsDir?: string;
+  agentsDir?: string;
+  workflowsDir?: string;
+};
+
+function sortedObject(input: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(input).sort(([left], [right]) => left.localeCompare(right));
+  return Object.fromEntries(entries);
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function mergeMissionContext(input: {
+  initialContext: Record<string, unknown>;
+  missionParameters: Record<string, string>;
+}): Record<string, unknown> {
+  const merged: Record<string, unknown> = {
+    ...input.initialContext,
+    missionParameters: sortedObject(input.missionParameters)
+  };
+
+  return Object.fromEntries(Object.entries(merged).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function resolveAgentRoster(team: TeamDefinition, profiles: AgentProfileDefinition[]): string[] {
+  const profileMap = new Map(profiles.map((profile) => [profile.agentId, profile]));
+  const missing = team.members.filter((member) => !profileMap.has(member));
+  if (missing.length > 0) {
+    throw new Error(`Team ${team.teamId} references unknown agent profiles: ${sortedUnique(missing).join(', ')}.`);
+  }
+
+  return sortedUnique(team.members);
+}
+
+function validateMissionTeamCoherence(mission: MissionDefinition, team: TeamDefinition): void {
+  if (mission.teamId !== team.teamId) {
+    throw new Error(`Mission ${mission.missionId} references mismatched teamId ${mission.teamId}.`);
+  }
+  if (mission.projectId !== team.projectId) {
+    throw new Error(
+      `Mission ${mission.missionId} projectId ${mission.projectId} does not match team ${team.teamId} projectId ${team.projectId}.`
+    );
+  }
+}
+
+function resolveMissionParameters(input: {
+  missionId: string;
+  schema?: MissionParameterSchema;
+  provided: Record<string, string>;
+}): Record<string, string> {
+  const schema = input.schema;
+  const defaults = sortedObject((schema?.defaults ?? {}) as Record<string, string>);
+  const provided = sortedObject(input.provided);
+  const merged = sortedObject({ ...defaults, ...provided });
+
+  if (schema?.allowed && schema.allowed.length > 0) {
+    const allowed = new Set(schema.allowed);
+    const invalid = Object.keys(merged).filter((key) => !allowed.has(key));
+    if (invalid.length > 0) {
+      throw new Error(`MISSION_PARAM_INVALID: ${input.missionId}: ${sortedUnique(invalid).join(', ')}`);
+    }
+  }
+
+  if (schema?.required && schema.required.length > 0) {
+    const missing = schema.required.filter((key) => !Object.prototype.hasOwnProperty.call(merged, key));
+    if (missing.length > 0) {
+      throw new Error(`MISSION_PARAM_MISSING_REQUIRED: ${input.missionId}: ${sortedUnique(missing).join(', ')}`);
+    }
+  }
+
+  return merged;
+}
+
+function mapRunStatusToMissionStatus(status: string): 'created' | 'running' | 'completed' | 'failed' | 'cancelled' {
+  if (status === 'completed') {
+    return 'completed';
+  }
+  if (status === 'failed' || status === 'timeout') {
+    return 'failed';
+  }
+  if (status === 'cancelled') {
+    return 'cancelled';
+  }
+  if (status === 'running') {
+    return 'running';
+  }
+  return 'created';
+}
+
+function buildJournal(options: MissionServiceOptions): ExecutionJournal {
+  return options.journal ?? createExecutionJournal({ rootDir: options.rootDir });
+}
+
+export function createMissionService(options: MissionServiceOptions = {}) {
+  const journal = buildJournal(options);
+
+  async function startMission(input: { missionId: string; params: Record<string, string> }): Promise<Record<string, unknown>> {
+    const profiles = loadAgentProfilesFromDir(options.agentsDir);
+    const mission = loadMissionDefinitionById(input.missionId, options.missionsDir);
+    const team = loadTeamDefinitionById(mission.teamId, options.teamsDir, profiles);
+
+    validateMissionTeamCoherence(mission, team);
+    const agentRoster = resolveAgentRoster(team, profiles);
+    const workflow = loadWorkflowDefinitionById(mission.workflowId, options.workflowsDir);
+    const missionParameters = resolveMissionParameters({
+      missionId: mission.missionId,
+      schema: mission.parameterSchema,
+      provided: input.params
+    });
+
+    const mergedContext = mergeMissionContext({
+      initialContext: mission.initialContext,
+      missionParameters
+    });
+
+    const run = journal.createRun({
+      projectId: mission.projectId,
+      kind: 'mission',
+      entrypoint: `mission:${mission.missionId}`
+    });
+
+    const swarmRunner = createSwarmRunner({ journal });
+    const executor = createSwarmWorkflowExecutor({
+      swarmRunner,
+      projectId: mission.projectId,
+      missionMemory: {
+        missionParameters,
+        missionContext: mergedContext
+      }
+    });
+
+    await executeWorkflowRunWithHardening({
+      journal,
+      runId: run.runId,
+      missionId: mission.missionId,
+      workflow,
+      executor,
+      missionContextMemory: {
+        missionParameters,
+        missionContext: mergedContext
+      }
+    });
+
+    const inspected = journal.inspectRun(run.runId);
+    const runRecord = buildWorkflowRunRecord(inspected);
+
+    return {
+      missionId: mission.missionId,
+      status: mapRunStatusToMissionStatus(runRecord.status),
+      teamId: mission.teamId,
+      workflowId: mission.workflowId,
+      workflowRun: runRecord.runId,
+      missionParameters,
+      contextKeys: Object.keys(mergedContext).sort((left, right) => left.localeCompare(right))
+    };
+  }
+
+  function listMissions(): Array<Record<string, unknown>> {
+    const missions = loadMissionDefinitionsFromDir(options.missionsDir);
+    const runs = journal.listRuns();
+    const runRecords = buildWorkflowRunRecords({
+      runs,
+      inspectRun: (runId) => journal.inspectRun(runId)
+    });
+
+    const missionRows = missions.map((mission) => {
+      const candidates = runRecords
+        .filter((record) => record.missionId === mission.missionId)
+        .sort((left, right) => left.runId.localeCompare(right.runId));
+
+      const latest = candidates.at(-1);
+      return {
+        missionId: mission.missionId,
+        status: latest ? mapRunStatusToMissionStatus(latest.status) : 'created',
+        workflowRun: latest?.runId ?? null,
+        teamId: mission.teamId,
+        workflowId: mission.workflowId
+      };
+    });
+
+    const adHocMissionRows = runs
+      .filter((run) => run.entrypoint.startsWith('mission:'))
+      .map((run) => run.entrypoint.slice('mission:'.length))
+      .filter((missionId) => missionId.length > 0)
+      .filter((missionId) => !missionRows.some((row) => row.missionId === missionId))
+      .sort((left, right) => left.localeCompare(right))
+      .map((missionId) => {
+        const latest = runRecords
+          .filter((record) => record.missionId === missionId)
+          .sort((left, right) => left.runId.localeCompare(right.runId))
+          .at(-1);
+
+        return {
+          missionId,
+          status: latest ? mapRunStatusToMissionStatus(latest.status) : 'created',
+          workflowRun: latest?.runId ?? null,
+          teamId: null,
+          workflowId: null
+        };
+      });
+
+    return [...missionRows, ...adHocMissionRows]
+      .sort((left, right) => left.missionId.localeCompare(right.missionId));
+  }
+
+  function inspectMission(input: { missionId: string }): Record<string, unknown> {
+    const mission = loadMissionDefinitionById(input.missionId, options.missionsDir);
+    const runs = journal.listRuns();
+    const runRecords = buildWorkflowRunRecords({
+      runs,
+      inspectRun: (runId) => journal.inspectRun(runId)
+    });
+
+    const linkedRuns = runRecords
+      .filter((record) => record.missionId === input.missionId)
+      .sort((left, right) => left.runId.localeCompare(right.runId));
+
+    const latest = linkedRuns.at(-1);
+
+    if (!latest) {
+      return {
+        missionId: mission.missionId,
+        status: 'created',
+        teamId: mission.teamId,
+        workflowId: mission.workflowId,
+        workflowRuns: [],
+        nodeStates: [],
+        diagnostics: null
+      };
+    }
+
+    const latestInspected = journal.inspectRun(latest.runId);
+    const nodes = buildWorkflowNodeRecords({
+      runId: latest.runId,
+      workflowId: latest.workflowId,
+      events: latestInspected.events
+    });
+    const diagnostics = getRunDiagnosticReport({
+      run: latest,
+      events: latestInspected.events,
+      nodes
+    });
+
+    return {
+      missionId: mission.missionId,
+      status: mapRunStatusToMissionStatus(latest.status),
+      teamId: mission.teamId,
+      workflowId: mission.workflowId,
+      workflowRuns: linkedRuns.map((record) => ({
+        runId: record.runId,
+        status: record.status,
+        retryCount: record.retryCount,
+        completedNodeCount: record.completedNodeCount,
+        failedNodeCount: record.failedNodeCount,
+        timeoutNodeCount: record.timeoutNodeCount
+      })),
+      nodeStates: nodes.map((node) => ({
+        nodeId: node.nodeId,
+        status: node.status,
+        retryCount: node.retryCount,
+        timeoutType: node.timeoutType
+      })),
+      diagnostics: {
+        failedNodeIds: diagnostics.failedNodeIds,
+        timedOutNodeIds: diagnostics.timedOutNodeIds,
+        recoverable: diagnostics.recoverable,
+        resumed: diagnostics.resumed,
+        cancelled: diagnostics.cancelled,
+        firstInspectTarget: diagnostics.firstInspectTarget,
+        finalContextKeys: diagnostics.finalContextKeys
+      }
+    };
+  }
+
+  function cancelMission(input: { missionId: string }): Record<string, unknown> {
+    const runRecords = buildWorkflowRunRecords({
+      runs: journal.listRuns(),
+      inspectRun: (runId) => journal.inspectRun(runId)
+    }).filter((record) => record.missionId === input.missionId)
+      .sort((left, right) => left.runId.localeCompare(right.runId));
+
+    const active = [...runRecords]
+      .reverse()
+      .find((record) => record.status === 'created' || record.status === 'running');
+
+    if (!active) {
+      throw new Error(`MISSION_NOT_CANCELLABLE: ${input.missionId}`);
+    }
+
+    const inspected = journal.inspectRun(active.runId);
+    const state = reconstructWorkflowStateFromJournal({
+      runId: active.runId,
+      workflowId: active.workflowId,
+      events: inspected.events
+    });
+    const decision = cancelWorkflowRun({ state });
+
+    if (!decision.accepted) {
+      throw new Error('WORKFLOW_ALREADY_TERMINAL');
+    }
+
+    journal.appendEvent({
+      runId: active.runId,
+      type: 'WORKFLOW_CANCELLED',
+      phase: 'implement',
+      payload: {
+        workflowId: active.workflowId,
+        runId: active.runId
+      }
+    });
+
+    return {
+      missionId: input.missionId,
+      runId: active.runId,
+      status: 'cancelled'
+    };
+  }
+
+  return {
+    startMission,
+    listMissions,
+    inspectMission,
+    cancelMission
+  };
+}
+
+export type MissionService = ReturnType<typeof createMissionService>;

--- a/control-plane/operator/operator.integration.test.ts
+++ b/control-plane/operator/operator.integration.test.ts
@@ -1,0 +1,393 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createExecutionJournal } from '../journal/journal.ts';
+import { createOperatorCommandRouter } from './command-router.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-operator');
+const journalRoot = path.join(tmpRoot, 'journal');
+const missionsDir = path.join(tmpRoot, 'missions');
+const teamsDir = path.join(tmpRoot, 'teams');
+const agentsDir = path.join(tmpRoot, 'agents');
+const workflowsDir = path.join(tmpRoot, 'workflows');
+
+function resetTmpDir(): void {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.mkdirSync(journalRoot, { recursive: true });
+  fs.mkdirSync(missionsDir, { recursive: true });
+  fs.mkdirSync(teamsDir, { recursive: true });
+  fs.mkdirSync(agentsDir, { recursive: true });
+  fs.mkdirSync(workflowsDir, { recursive: true });
+}
+
+function writeJson(dir: string, fileName: string, value: unknown): void {
+  fs.writeFileSync(path.join(dir, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeAgentProfile(agentId: string): void {
+  writeJson(agentsDir, `${agentId}.json`, {
+    agentId,
+    displayName: agentId,
+    role: 'analyst',
+    projectId: 'smartfunds-core',
+    adapterType: 'llm',
+    personalityProfile: {
+      tone: 'precise',
+      reasoningStyle: 'structured',
+      temperament: 'calm',
+      collaborationStyle: 'cooperative',
+      communicationStyle: 'concise'
+    },
+    skillsProfile: {
+      coreSkills: ['analysis'],
+      secondarySkills: ['summary'],
+      domains: ['rwa']
+    },
+    backgroundProfile: {
+      professionalArchetype: 'researcher',
+      domainBackground: ['markets'],
+      perspectiveBiases: []
+    },
+    outputProfile: {
+      preferredFormat: 'memo',
+      verbosity: 'medium',
+      citationStyle: 'internal',
+      decisionStyle: 'rank'
+    },
+    constraintsProfile: {
+      mustDo: ['be explicit'],
+      mustNotDo: ['guess']
+    },
+    toolProfile: {
+      allowedAdapters: ['llm', 'repo', 'shell'],
+      preferredTools: ['llm'],
+      forbiddenTools: []
+    }
+  });
+}
+
+function writeFixtures(): void {
+  writeJson(missionsDir, 'rwa-market-analysis.json', {
+    missionId: 'rwa-market-analysis',
+    projectId: 'smartfunds-core',
+    teamId: 'smartfunds-research-team',
+    workflowId: 'research-analysis-workflow',
+    objective: 'Analyze near-term tokenized RWA opportunities.',
+    successCriteria: ['Produce market landscape summary'],
+    deliverables: ['market-summary'],
+    parameterSchema: {
+      allowed: ['market', 'horizon', 'risk-level'],
+      required: ['market'],
+      defaults: {
+        horizon: '30d',
+        'risk-level': 'medium'
+      }
+    },
+    initialContext: {
+      sector: 'RWA'
+    }
+  });
+
+  writeJson(teamsDir, 'smartfunds-research-team.json', {
+    teamId: 'smartfunds-research-team',
+    name: 'SmartFunds Research Team',
+    projectId: 'smartfunds-core',
+    members: ['lead-thesis-architect'],
+    executionMode: 'structured'
+  });
+
+  writeAgentProfile('lead-thesis-architect');
+
+  writeJson(workflowsDir, 'research-analysis-workflow.json', {
+    workflowId: 'research-analysis-workflow',
+    nodes: [
+      {
+        id: 'node-a',
+        task: 'repo'
+      }
+    ]
+  });
+
+  writeJson(workflowsDir, 'wf-failure.json', {
+    workflowId: 'wf-failure',
+    nodes: [
+      {
+        id: 'node-fail',
+        task: 'repo'
+      }
+    ]
+  });
+}
+
+function createRouter() {
+  return createOperatorCommandRouter({
+    rootDir: journalRoot,
+    missionsDir,
+    teamsDir,
+    agentsDir,
+    workflowsDir
+  });
+}
+
+function seedFailedRun(input: { missionId: string }): { runId: string } {
+  const journal = createExecutionJournal({ rootDir: journalRoot });
+  const created = journal.createRun({
+    projectId: 'smartfunds-core',
+    kind: 'mission',
+    entrypoint: `mission:${input.missionId}`
+  });
+
+  journal.appendEvent({
+    runId: created.runId,
+    type: 'TASK_STARTED',
+    phase: 'implement',
+    taskId: 'node-fail',
+    payload: {
+      context_snapshot: {
+        missionId: input.missionId,
+        metadata: {
+          missionId: input.missionId,
+          workflowId: 'wf-failure'
+        },
+        memory: {}
+      }
+    }
+  });
+
+  journal.appendEvent({
+    runId: created.runId,
+    type: 'TASK_FAILED',
+    phase: 'implement',
+    taskId: 'node-fail',
+    payload: {
+      error: 'ADAPTER_EXECUTION_FAILED',
+      context_snapshot: {
+        missionId: input.missionId,
+        metadata: {
+          missionId: input.missionId,
+          workflowId: 'wf-failure'
+        },
+        memory: {}
+      }
+    }
+  });
+
+  return {
+    runId: created.runId
+  };
+}
+
+function seedRunningRun(input: { missionId: string }): { runId: string } {
+  const journal = createExecutionJournal({ rootDir: journalRoot });
+  const created = journal.createRun({
+    projectId: 'smartfunds-core',
+    kind: 'mission',
+    entrypoint: `mission:${input.missionId}`
+  });
+
+  journal.appendEvent({
+    runId: created.runId,
+    type: 'TASK_STARTED',
+    phase: 'implement',
+    taskId: 'node-fail',
+    payload: {
+      context_snapshot: {
+        missionId: input.missionId,
+        metadata: {
+          missionId: input.missionId,
+          workflowId: 'wf-failure'
+        },
+        memory: {}
+      }
+    }
+  });
+
+  return {
+    runId: created.runId
+  };
+}
+
+beforeEach(() => {
+  resetTmpDir();
+  writeFixtures();
+});
+
+describe('operator integration', () => {
+  it('T-OPI1 runs mission:start through hardened runtime and propagates mission parameters', async () => {
+    const router = createRouter();
+
+    const started = await router.route({
+      source: 'cli',
+      argv: ['mission:start', 'rwa-market-analysis', '--market', 'ethereum']
+    });
+
+    expect(started.success).toBe(true);
+    expect(started.payload).toEqual(expect.objectContaining({
+      missionId: 'rwa-market-analysis',
+      missionParameters: {
+        horizon: '30d',
+        market: 'ethereum',
+        'risk-level': 'medium'
+      }
+    }));
+
+    const journal = createExecutionJournal({ rootDir: journalRoot });
+    const runs = journal.listRuns();
+    const missionRun = runs.find((run) => run.entrypoint === 'mission:rwa-market-analysis');
+    expect(missionRun).toBeDefined();
+
+    const missionEvents = journal.inspectRun(missionRun!.runId).events;
+    expect(missionEvents.some((event) => event.type === 'RUN_COMPLETED')).toBe(true);
+
+    const taskStarted = missionEvents.find((event) => event.type === 'TASK_STARTED');
+    expect(taskStarted?.payload.context_snapshot).toMatchObject({
+      memory: {
+        missionParameters: {
+          horizon: '30d',
+          market: 'ethereum',
+          'risk-level': 'medium'
+        }
+      }
+    });
+
+    const childRun = runs.find((run) => run.entrypoint.startsWith('workflow:research-analysis-workflow:node-a'));
+    expect(childRun).toBeDefined();
+    const childCreated = journal.inspectRun(childRun!.runId).events.find((event) => event.type === 'RUN_CREATED');
+    expect(childCreated?.payload.context_snapshot).toMatchObject({
+      memory: {
+        missionParameters: {
+          horizon: '30d',
+          market: 'ethereum',
+          'risk-level': 'medium'
+        }
+      }
+    });
+  });
+
+  it('T-OPI2 returns deterministic mission/workflow inspection payloads', async () => {
+    const router = createRouter();
+
+    const started = await router.route({
+      source: 'cli',
+      argv: ['mission:start', 'rwa-market-analysis', '--market', 'ethereum']
+    });
+
+    const missionList = await router.route({
+      source: 'cli',
+      argv: ['mission:list']
+    });
+    const missionInspect = await router.route({
+      source: 'cli',
+      argv: ['mission:inspect', 'rwa-market-analysis']
+    });
+
+    expect(missionList.success).toBe(true);
+    expect(missionInspect.success).toBe(true);
+
+    const workflowRun = (started.payload as Record<string, unknown>).workflowRun as string;
+
+    const workflowList = await router.route({
+      source: 'cli',
+      argv: ['workflow:list']
+    });
+    const workflowInspect = await router.route({
+      source: 'cli',
+      argv: ['workflow:inspect', workflowRun]
+    });
+    const workflowTrace = await router.route({
+      source: 'cli',
+      argv: ['workflow:trace', workflowRun]
+    });
+
+    expect(workflowList.success).toBe(true);
+    expect(workflowInspect.success).toBe(true);
+    expect(workflowTrace.success).toBe(true);
+    expect((workflowTrace.payload as Record<string, unknown>).executionOrder).toEqual(['node-a']);
+  });
+
+  it('T-OPI3 routes runtime controls through recovery paths', async () => {
+    const router = createRouter();
+
+    const failed = seedFailedRun({ missionId: 'retry-mission' });
+    const retry = await router.route({
+      source: 'cli',
+      argv: ['workflow:retry', '--run', failed.runId, '--node', 'node-fail']
+    });
+    expect(retry.success).toBe(true);
+
+    const failedForResume = seedFailedRun({ missionId: 'resume-mission' });
+    const resume = await router.route({
+      source: 'cli',
+      argv: ['workflow:resume', '--run', failedForResume.runId]
+    });
+    expect(resume.success).toBe(true);
+
+    const runningForCancel = seedRunningRun({ missionId: 'cancel-workflow-mission' });
+    const cancel = await router.route({
+      source: 'cli',
+      argv: ['workflow:cancel', '--run', runningForCancel.runId]
+    });
+    expect(cancel).toEqual({
+      success: true,
+      command: {
+        name: 'workflow:cancel',
+        source: 'cli'
+      },
+      payload: {
+        runId: runningForCancel.runId,
+        workflowId: 'wf-failure',
+        status: 'cancelled'
+      }
+    });
+
+    const runningForMissionCancel = seedRunningRun({ missionId: 'cancel-me' });
+    const missionCancel = await router.route({
+      source: 'cli',
+      argv: ['mission:cancel', 'cancel-me']
+    });
+    expect(missionCancel.success).toBe(true);
+    expect(missionCancel.payload).toEqual({
+      missionId: 'cancel-me',
+      runId: runningForMissionCancel.runId,
+      status: 'cancelled'
+    });
+
+    const validation = await router.route({
+      source: 'cli',
+      argv: ['workflow:retry', '--run', failed.runId]
+    });
+    expect(validation).toEqual({
+      success: false,
+      command: {
+        name: 'workflow:retry',
+        source: 'cli'
+      },
+      error: {
+        code: 'MISSING_ARGUMENT',
+        message: 'Missing required --node'
+      }
+    });
+  });
+
+  it('T-OPI4 validates mission parameter requirements deterministically', async () => {
+    const router = createRouter();
+    const result = await router.route({
+      source: 'cli',
+      argv: ['mission:start', 'rwa-market-analysis']
+    });
+
+    expect(result).toEqual({
+      success: false,
+      command: {
+        name: 'mission:start',
+        source: 'cli'
+      },
+      error: {
+        code: 'COMMAND_FAILED',
+        message: 'MISSION_PARAM_MISSING_REQUIRED: rwa-market-analysis: market'
+      }
+    });
+  });
+});

--- a/control-plane/operator/runtime-service.ts
+++ b/control-plane/operator/runtime-service.ts
@@ -1,0 +1,251 @@
+import type { ExecutionJournal } from '../journal/journal.ts';
+import { createExecutionJournal } from '../journal/journal.ts';
+import { buildWorkflowNodeRecords } from '../observability/node-record.ts';
+import { buildWorkflowRunRecord, buildWorkflowRunRecords } from '../observability/run-record.ts';
+import {
+  cancelWorkflowRun,
+  deriveRetryEligibilityFromEvents,
+  resumeWorkflowRun
+} from '../runtime/recovery-engine.ts';
+import { deriveResumeStateFromJournal, executeWorkflowRunWithHardening } from '../runtime/hardened-workflow-runtime.ts';
+import { createSwarmRunner } from '../swarm/swarm-runner.ts';
+import { loadWorkflowDefinitionById } from '../workflows/workflow-loader.ts';
+import { createSwarmWorkflowExecutor } from '../workflows/workflow-runner.ts';
+
+type RuntimeServiceOptions = {
+  journal?: ExecutionJournal;
+  rootDir?: string;
+  workflowsDir?: string;
+};
+
+function buildJournal(options: RuntimeServiceOptions): ExecutionJournal {
+  return options.journal ?? createExecutionJournal({ rootDir: options.rootDir });
+}
+
+export function createRuntimeService(options: RuntimeServiceOptions = {}) {
+  const journal = buildJournal(options);
+
+  async function retryWorkflowNode(input: { runId: string; nodeId: string }): Promise<Record<string, unknown>> {
+    const inspected = journal.inspectRun(input.runId);
+    const runRecord = buildWorkflowRunRecord(inspected);
+
+    const nodes = buildWorkflowNodeRecords({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: inspected.events
+    });
+
+    const node = nodes.find((entry) => entry.nodeId === input.nodeId);
+    if (!node) {
+      throw new Error(`NODE_NOT_FOUND: ${input.nodeId}`);
+    }
+    if (node.status !== 'failed' && node.status !== 'timeout') {
+      throw new Error('NODE_NOT_RETRYABLE_STATE');
+    }
+
+    const decision = deriveRetryEligibilityFromEvents({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      nodeId: input.nodeId,
+      events: inspected.events
+    });
+
+    if (!decision.accepted) {
+      throw new Error(`RETRY_INELIGIBLE: ${decision.reason}`);
+    }
+
+    const workflow = loadWorkflowDefinitionById(runRecord.workflowId, options.workflowsDir);
+    journal.appendEvent({
+      runId: runRecord.runId,
+      type: 'NODE_RETRY_SCHEDULED',
+      phase: 'implement',
+      taskId: input.nodeId,
+      payload: {
+        retryAttempt: decision.retryAttempt,
+        tickDelay: decision.tickDelay,
+        workflowId: runRecord.workflowId,
+        runId: runRecord.runId
+      }
+    });
+
+    const refreshed = journal.inspectRun(runRecord.runId);
+    const derived = deriveResumeStateFromJournal({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: refreshed.events
+    });
+
+    const scheduledTick = (derived.initialState.currentTick ?? 0) + (decision.tickDelay ?? 0);
+    const missionId = runRecord.missionId ?? `recovery:${runRecord.runId}`;
+    const swarmRunner = createSwarmRunner({ journal });
+    const executor = createSwarmWorkflowExecutor({
+      swarmRunner,
+      projectId: refreshed.run.projectId
+    });
+
+    await executeWorkflowRunWithHardening({
+      journal,
+      runId: runRecord.runId,
+      missionId,
+      workflow,
+      executor,
+      hardening: {
+        initialState: {
+          ...derived.initialState,
+          retryQueue: [{
+            nodeId: input.nodeId,
+            retryAttempt: decision.retryAttempt ?? 1,
+            scheduledTick
+          }]
+        }
+      }
+    });
+
+    return {
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      nodeId: input.nodeId,
+      retryAttempt: decision.retryAttempt,
+      tickDelay: decision.tickDelay,
+      scheduled: true,
+      started: (decision.tickDelay ?? 0) === 0
+    };
+  }
+
+  async function resumeWorkflow(input: { runId: string }): Promise<Record<string, unknown>> {
+    const inspected = journal.inspectRun(input.runId);
+    const runRecord = buildWorkflowRunRecord(inspected);
+    const workflow = loadWorkflowDefinitionById(runRecord.workflowId, options.workflowsDir);
+
+    const derived = deriveResumeStateFromJournal({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: inspected.events
+    });
+
+    const decision = resumeWorkflowRun({
+      workflow,
+      state: derived.state
+    });
+
+    if (!decision.accepted) {
+      throw new Error(`WORKFLOW_NOT_RESUMABLE: ${decision.reason}`);
+    }
+
+    journal.appendEvent({
+      runId: runRecord.runId,
+      type: 'WORKFLOW_RECOVERY_STARTED',
+      phase: 'implement',
+      payload: {
+        workflowId: runRecord.workflowId,
+        runId: runRecord.runId,
+        resumeNodeIds: decision.plan.resumeNodeIds,
+        skippedCompletedNodeIds: decision.plan.skippedCompletedNodeIds
+      }
+    });
+
+    journal.appendEvent({
+      runId: runRecord.runId,
+      type: 'WORKFLOW_RECOVERY_RESUMED',
+      phase: 'implement',
+      payload: {
+        workflowId: runRecord.workflowId,
+        runId: runRecord.runId,
+        resumeNodeIds: decision.plan.resumeNodeIds
+      }
+    });
+
+    const missionId = runRecord.missionId ?? `recovery:${runRecord.runId}`;
+    const swarmRunner = createSwarmRunner({ journal });
+    const executor = createSwarmWorkflowExecutor({
+      swarmRunner,
+      projectId: inspected.run.projectId
+    });
+
+    await executeWorkflowRunWithHardening({
+      journal,
+      runId: runRecord.runId,
+      missionId,
+      workflow,
+      executor,
+      hardening: {
+        initialState: derived.initialState
+      }
+    });
+
+    return {
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      resumedNodeIds: decision.plan.resumeNodeIds,
+      skippedCompletedNodeIds: decision.plan.skippedCompletedNodeIds
+    };
+  }
+
+  function cancelWorkflow(input: { runId: string }): Record<string, unknown> {
+    const inspected = journal.inspectRun(input.runId);
+    const runRecord = buildWorkflowRunRecord(inspected);
+
+    const derived = deriveResumeStateFromJournal({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: inspected.events
+    });
+
+    const decision = cancelWorkflowRun({
+      state: derived.state
+    });
+
+    if (!decision.accepted) {
+      throw new Error('WORKFLOW_ALREADY_TERMINAL');
+    }
+
+    journal.appendEvent({
+      runId: runRecord.runId,
+      type: 'WORKFLOW_CANCELLED',
+      phase: 'implement',
+      payload: {
+        workflowId: runRecord.workflowId,
+        runId: runRecord.runId
+      }
+    });
+
+    return {
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      status: 'cancelled'
+    };
+  }
+
+  function cancelMission(input: { missionId: string }): Record<string, unknown> {
+    const runRecords = buildWorkflowRunRecords({
+      runs: journal.listRuns(),
+      inspectRun: (runId) => journal.inspectRun(runId)
+    }).filter((record) => record.missionId === input.missionId)
+      .sort((left, right) => left.runId.localeCompare(right.runId));
+
+    const active = [...runRecords]
+      .reverse()
+      .find((record) => record.status === 'created' || record.status === 'running');
+
+    if (!active) {
+      throw new Error(`MISSION_NOT_CANCELLABLE: ${input.missionId}`);
+    }
+
+    const cancelled = cancelWorkflow({ runId: active.runId });
+    return {
+      missionId: input.missionId,
+      runId: active.runId,
+      status: 'cancelled',
+      workflow: cancelled
+    };
+  }
+
+  return {
+    retryWorkflowNode,
+    resumeWorkflow,
+    cancelWorkflow,
+    cancelMission
+  };
+}
+
+export type RuntimeService = ReturnType<typeof createRuntimeService>;

--- a/control-plane/operator/schema.test.ts
+++ b/control-plane/operator/schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseOperatorCommand } from './schema.ts';
+
+describe('operator schema parser', () => {
+  it('T-OPV1 parses mission:start with deterministic params', () => {
+    const parsed = parseOperatorCommand(['mission:start', 'rwa-market-analysis', '--market', 'ethereum', '--horizon=30d']);
+
+    expect(parsed).toEqual({
+      name: 'mission:start',
+      missionId: 'rwa-market-analysis',
+      params: {
+        horizon: '30d',
+        market: 'ethereum'
+      }
+    });
+  });
+
+  it('T-OPV2 rejects unknown command deterministically', () => {
+    expect(() => parseOperatorCommand(['nope'])).toThrow(/Unknown command: nope/);
+  });
+
+  it('T-OPV3 rejects missing required args', () => {
+    expect(() => parseOperatorCommand(['workflow:resume'])).toThrow(/Missing required --run/);
+  });
+
+  it('T-OPV4 rejects invalid option combinations', () => {
+    expect(() => parseOperatorCommand(['workflow:list', '--run', 'run_1'])).toThrow(/does not accept arguments/);
+  });
+});

--- a/control-plane/operator/schema.ts
+++ b/control-plane/operator/schema.ts
@@ -1,0 +1,324 @@
+import type { OperatorCommandError, ParsedOperatorCommand } from './types.ts';
+
+function sortedObject(input: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(input).sort(([left], [right]) => left.localeCompare(right));
+  return Object.fromEntries(entries);
+}
+
+function toError(code: string, message: string, details?: Record<string, unknown>): OperatorCommandError {
+  return {
+    code,
+    message,
+    ...(details ? { details } : {})
+  };
+}
+
+function parseValueFlag(token: string, name: string): string | null {
+  if (token === name) {
+    return '';
+  }
+  if (token.startsWith(`${name}=`)) {
+    return token.slice(name.length + 1);
+  }
+  return null;
+}
+
+function parseKeyValueArgs(argv: string[]): { params: Record<string, string>; consumed: number } {
+  const params: Record<string, string> = {};
+  let index = 0;
+
+  while (index < argv.length) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      throw toError('INVALID_ARGUMENT', `Unexpected token: ${token}`);
+    }
+
+    const inlineSplit = token.indexOf('=');
+    if (inlineSplit >= 0) {
+      const key = token.slice(2, inlineSplit);
+      const value = token.slice(inlineSplit + 1);
+      if (!key) {
+        throw toError('INVALID_ARGUMENT', `Invalid flag: ${token}`);
+      }
+      params[key] = value;
+      index += 1;
+      continue;
+    }
+
+    const key = token.slice(2);
+    if (!key) {
+      throw toError('INVALID_ARGUMENT', `Invalid flag: ${token}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw toError('MISSING_ARGUMENT', `Missing value for --${key}`);
+    }
+
+    params[key] = value;
+    index += 2;
+  }
+
+  return {
+    params: sortedObject(params),
+    consumed: index
+  };
+}
+
+function parseRunOption(argv: string[]): { runId: string; consumed: number } {
+  let runId: string | null = null;
+  let index = 0;
+
+  while (index < argv.length) {
+    const token = argv[index];
+    const parsed = parseValueFlag(token, '--run');
+    if (parsed === null) {
+      throw toError('INVALID_ARGUMENT', `Unknown argument: ${token}`);
+    }
+
+    if (token === '--run') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw toError('MISSING_ARGUMENT', 'Missing value for --run');
+      }
+      runId = value;
+      index += 2;
+      continue;
+    }
+
+    if (!parsed) {
+      throw toError('MISSING_ARGUMENT', 'Missing value for --run');
+    }
+
+    runId = parsed;
+    index += 1;
+  }
+
+  if (!runId) {
+    throw toError('MISSING_ARGUMENT', 'Missing required --run');
+  }
+
+  return {
+    runId,
+    consumed: index
+  };
+}
+
+function parseRunNodeOptions(argv: string[]): { runId: string; nodeId: string; consumed: number } {
+  let runId: string | null = null;
+  let nodeId: string | null = null;
+  let index = 0;
+
+  while (index < argv.length) {
+    const token = argv[index];
+
+    if (token.startsWith('--run')) {
+      const parsed = parseValueFlag(token, '--run');
+      if (parsed === null) {
+        throw toError('INVALID_ARGUMENT', `Unknown argument: ${token}`);
+      }
+
+      if (token === '--run') {
+        const value = argv[index + 1];
+        if (!value || value.startsWith('--')) {
+          throw toError('MISSING_ARGUMENT', 'Missing value for --run');
+        }
+        runId = value;
+        index += 2;
+        continue;
+      }
+
+      if (!parsed) {
+        throw toError('MISSING_ARGUMENT', 'Missing value for --run');
+      }
+
+      runId = parsed;
+      index += 1;
+      continue;
+    }
+
+    if (token.startsWith('--node')) {
+      const parsed = parseValueFlag(token, '--node');
+      if (parsed === null) {
+        throw toError('INVALID_ARGUMENT', `Unknown argument: ${token}`);
+      }
+
+      if (token === '--node') {
+        const value = argv[index + 1];
+        if (!value || value.startsWith('--')) {
+          throw toError('MISSING_ARGUMENT', 'Missing value for --node');
+        }
+        nodeId = value;
+        index += 2;
+        continue;
+      }
+
+      if (!parsed) {
+        throw toError('MISSING_ARGUMENT', 'Missing value for --node');
+      }
+
+      nodeId = parsed;
+      index += 1;
+      continue;
+    }
+
+    throw toError('INVALID_ARGUMENT', `Unknown argument: ${token}`);
+  }
+
+  if (!runId) {
+    throw toError('MISSING_ARGUMENT', 'Missing required --run');
+  }
+  if (!nodeId) {
+    throw toError('MISSING_ARGUMENT', 'Missing required --node');
+  }
+
+  return {
+    runId,
+    nodeId,
+    consumed: index
+  };
+}
+
+function requireSinglePositional(argv: string[], label: string): string {
+  if (argv.length === 0) {
+    throw toError('MISSING_ARGUMENT', `Missing required ${label}`);
+  }
+  if (argv.length > 1) {
+    throw toError('INVALID_ARGUMENT', `Unexpected arguments after ${label}`);
+  }
+  if (argv[0].startsWith('--')) {
+    throw toError('INVALID_ARGUMENT', `Expected ${label}, received option ${argv[0]}`);
+  }
+  return argv[0];
+}
+
+export function parseOperatorCommand(argv: string[]): ParsedOperatorCommand {
+  if (argv.length === 0) {
+    throw toError('MISSING_COMMAND', 'Missing operator command');
+  }
+
+  const [command, ...rest] = argv;
+
+  if (command === 'mission:list') {
+    if (rest.length > 0) {
+      throw toError('INVALID_ARGUMENT', 'mission:list does not accept arguments');
+    }
+    return { name: 'mission:list' };
+  }
+
+  if (command === 'mission:start') {
+    if (rest.length === 0) {
+      throw toError('MISSING_ARGUMENT', 'Missing required <missionId>');
+    }
+
+    const missionId = rest[0];
+    if (missionId.startsWith('--')) {
+      throw toError('INVALID_ARGUMENT', `Expected missionId, received option ${missionId}`);
+    }
+
+    const { params } = parseKeyValueArgs(rest.slice(1));
+    return {
+      name: 'mission:start',
+      missionId,
+      params
+    };
+  }
+
+  if (command === 'mission:inspect') {
+    return {
+      name: 'mission:inspect',
+      missionId: requireSinglePositional(rest, '<missionId>')
+    };
+  }
+
+  if (command === 'mission:cancel') {
+    return {
+      name: 'mission:cancel',
+      missionId: requireSinglePositional(rest, '<missionId>')
+    };
+  }
+
+  if (command === 'workflow:list') {
+    if (rest.length > 0) {
+      throw toError('INVALID_ARGUMENT', 'workflow:list does not accept arguments');
+    }
+    return { name: 'workflow:list' };
+  }
+
+  if (command === 'workflow:inspect') {
+    if (rest.length === 1 && !rest[0].startsWith('--')) {
+      return {
+        name: 'workflow:inspect',
+        runId: rest[0]
+      };
+    }
+
+    const parsed = parseRunOption(rest);
+    if (parsed.consumed !== rest.length) {
+      throw toError('INVALID_ARGUMENT', 'Invalid workflow:inspect arguments');
+    }
+
+    return {
+      name: 'workflow:inspect',
+      runId: parsed.runId
+    };
+  }
+
+  if (command === 'workflow:trace') {
+    if (rest.length === 1 && !rest[0].startsWith('--')) {
+      return {
+        name: 'workflow:trace',
+        runId: rest[0]
+      };
+    }
+
+    const parsed = parseRunOption(rest);
+    if (parsed.consumed !== rest.length) {
+      throw toError('INVALID_ARGUMENT', 'Invalid workflow:trace arguments');
+    }
+
+    return {
+      name: 'workflow:trace',
+      runId: parsed.runId
+    };
+  }
+
+  if (command === 'workflow:retry') {
+    const parsed = parseRunNodeOptions(rest);
+    if (parsed.consumed !== rest.length) {
+      throw toError('INVALID_ARGUMENT', 'Invalid workflow:retry arguments');
+    }
+
+    return {
+      name: 'workflow:retry',
+      runId: parsed.runId,
+      nodeId: parsed.nodeId
+    };
+  }
+
+  if (command === 'workflow:resume') {
+    const parsed = parseRunOption(rest);
+    if (parsed.consumed !== rest.length) {
+      throw toError('INVALID_ARGUMENT', 'Invalid workflow:resume arguments');
+    }
+
+    return {
+      name: 'workflow:resume',
+      runId: parsed.runId
+    };
+  }
+
+  if (command === 'workflow:cancel') {
+    const parsed = parseRunOption(rest);
+    if (parsed.consumed !== rest.length) {
+      throw toError('INVALID_ARGUMENT', 'Invalid workflow:cancel arguments');
+    }
+
+    return {
+      name: 'workflow:cancel',
+      runId: parsed.runId
+    };
+  }
+
+  throw toError('UNKNOWN_COMMAND', `Unknown command: ${command}`, { command });
+}

--- a/control-plane/operator/slack-router.test.ts
+++ b/control-plane/operator/slack-router.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSlackCommandRouter } from './slack-router.ts';
+
+describe('operator slack router', () => {
+  it('T-OPS1 routes slash mission command through command-router', async () => {
+    const route = vi.fn(async () => ({
+      success: true,
+      command: { name: 'mission:start', source: 'slack' as const },
+      payload: { missionId: 'rwa-market-analysis' }
+    }));
+
+    const slack = createSlackCommandRouter({
+      router: { route }
+    });
+
+    const result = await slack.routeSlackText('/mission start rwa-market-analysis --market ethereum');
+
+    expect(route).toHaveBeenCalledWith({
+      source: 'slack',
+      argv: ['mission:start', 'rwa-market-analysis', '--market', 'ethereum']
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('T-OPS2 rejects invalid slash command deterministically', async () => {
+    const slack = createSlackCommandRouter({
+      router: { route: vi.fn() }
+    });
+
+    const result = await slack.routeSlackText('/unknown test');
+
+    expect(result).toEqual({
+      success: false,
+      command: {
+        name: 'unknown',
+        source: 'slack'
+      },
+      error: {
+        code: 'SLACK_PARSE_ERROR',
+        message: 'UNKNOWN_COMMAND: /unknown'
+      }
+    });
+  });
+});

--- a/control-plane/operator/slack-router.ts
+++ b/control-plane/operator/slack-router.ts
@@ -1,0 +1,115 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createOperatorCommandRouter, type OperatorCommandRouter } from './command-router.ts';
+import type { OperatorCommandResult } from './types.ts';
+
+type SlackRouterOptions = {
+  router?: OperatorCommandRouter;
+};
+
+function tokenize(text: string): string[] {
+  return text
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+}
+
+function toOperatorArgv(tokens: string[]): string[] {
+  if (tokens.length === 0) {
+    throw new Error('MISSING_COMMAND');
+  }
+
+  if (tokens[0] === '/mission') {
+    const [_, action, ...rest] = tokens;
+    if (!action) {
+      throw new Error('MISSING_COMMAND');
+    }
+
+    if (action === 'start') {
+      return ['mission:start', ...rest];
+    }
+    if (action === 'list') {
+      return ['mission:list', ...rest];
+    }
+    if (action === 'inspect') {
+      return ['mission:inspect', ...rest];
+    }
+    if (action === 'cancel') {
+      return ['mission:cancel', ...rest];
+    }
+
+    throw new Error(`UNKNOWN_COMMAND: /mission ${action}`);
+  }
+
+  if (tokens[0] === '/workflow') {
+    const [_, action, ...rest] = tokens;
+    if (!action) {
+      throw new Error('MISSING_COMMAND');
+    }
+
+    if (action === 'list') {
+      return ['workflow:list', ...rest];
+    }
+    if (action === 'inspect') {
+      return ['workflow:inspect', ...rest];
+    }
+    if (action === 'trace') {
+      return ['workflow:trace', ...rest];
+    }
+    if (action === 'retry') {
+      return ['workflow:retry', ...rest];
+    }
+    if (action === 'resume') {
+      return ['workflow:resume', ...rest];
+    }
+    if (action === 'cancel') {
+      return ['workflow:cancel', ...rest];
+    }
+
+    throw new Error(`UNKNOWN_COMMAND: /workflow ${action}`);
+  }
+
+  throw new Error(`UNKNOWN_COMMAND: ${tokens[0]}`);
+}
+
+export function createSlackCommandRouter(options: SlackRouterOptions = {}) {
+  const router = options.router ?? createOperatorCommandRouter();
+
+  async function routeSlackText(text: string): Promise<OperatorCommandResult> {
+    try {
+      const argv = toOperatorArgv(tokenize(text));
+      return router.route({
+        source: 'slack',
+        argv
+      });
+    } catch (error) {
+      return {
+        success: false,
+        command: {
+          name: 'unknown',
+          source: 'slack'
+        },
+        error: {
+          code: 'SLACK_PARSE_ERROR',
+          message: error instanceof Error ? error.message : 'invalid_slack_command'
+        }
+      };
+    }
+  }
+
+  async function toSlackResponse(text: string): Promise<Record<string, unknown>> {
+    const result = await routeSlackText(text);
+    return {
+      response_type: 'ephemeral',
+      ok: result.success,
+      result,
+      text: canonicalStringify(result)
+    };
+  }
+
+  return {
+    routeSlackText,
+    toSlackResponse
+  };
+}
+
+export type SlackCommandRouter = ReturnType<typeof createSlackCommandRouter>;

--- a/control-plane/operator/types.ts
+++ b/control-plane/operator/types.ts
@@ -1,0 +1,115 @@
+export type OperatorCommandSource = 'cli' | 'slack';
+
+export type OperatorCommandName =
+  | 'mission:start'
+  | 'mission:list'
+  | 'mission:inspect'
+  | 'mission:cancel'
+  | 'workflow:list'
+  | 'workflow:inspect'
+  | 'workflow:trace'
+  | 'workflow:retry'
+  | 'workflow:resume'
+  | 'workflow:cancel';
+
+export type OperatorCommandError = {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+};
+
+export type OperatorCommandResult = {
+  success: boolean;
+  command: {
+    name: OperatorCommandName | 'unknown';
+    source: OperatorCommandSource;
+  };
+  payload?: unknown;
+  error?: OperatorCommandError;
+};
+
+export type OperatorRouterRequest = {
+  source: OperatorCommandSource;
+  argv: string[];
+};
+
+export type MissionStartCommand = {
+  name: 'mission:start';
+  missionId: string;
+  params: Record<string, string>;
+};
+
+export type MissionListCommand = {
+  name: 'mission:list';
+};
+
+export type MissionInspectCommand = {
+  name: 'mission:inspect';
+  missionId: string;
+};
+
+export type MissionCancelCommand = {
+  name: 'mission:cancel';
+  missionId: string;
+};
+
+export type WorkflowListCommand = {
+  name: 'workflow:list';
+};
+
+export type WorkflowInspectCommand = {
+  name: 'workflow:inspect';
+  runId: string;
+};
+
+export type WorkflowTraceCommand = {
+  name: 'workflow:trace';
+  runId: string;
+};
+
+export type WorkflowRetryCommand = {
+  name: 'workflow:retry';
+  runId: string;
+  nodeId: string;
+};
+
+export type WorkflowResumeCommand = {
+  name: 'workflow:resume';
+  runId: string;
+};
+
+export type WorkflowCancelCommand = {
+  name: 'workflow:cancel';
+  runId: string;
+};
+
+export type ParsedOperatorCommand =
+  | MissionStartCommand
+  | MissionListCommand
+  | MissionInspectCommand
+  | MissionCancelCommand
+  | WorkflowListCommand
+  | WorkflowInspectCommand
+  | WorkflowTraceCommand
+  | WorkflowRetryCommand
+  | WorkflowResumeCommand
+  | WorkflowCancelCommand;
+
+export type OperatorServices = {
+  mission: {
+    startMission: (input: { missionId: string; params: Record<string, string> }) => Promise<unknown>;
+    listMissions: () => unknown;
+    inspectMission: (input: { missionId: string }) => unknown;
+    cancelMission: (input: { missionId: string }) => unknown;
+  };
+  workflow: {
+    listWorkflows: () => unknown;
+    inspectWorkflow: (input: { runId: string }) => unknown;
+    traceWorkflow: (input: { runId: string }) => unknown;
+  };
+  runtime: {
+    retryWorkflowNode: (input: { runId: string; nodeId: string }) => Promise<unknown>;
+    resumeWorkflow: (input: { runId: string }) => Promise<unknown>;
+    cancelWorkflow: (input: { runId: string }) => unknown;
+  };
+};

--- a/control-plane/operator/workflow-service.ts
+++ b/control-plane/operator/workflow-service.ts
@@ -1,0 +1,123 @@
+import type { ExecutionJournal } from '../journal/journal.ts';
+import { createExecutionJournal } from '../journal/journal.ts';
+import { getRunDiagnosticReport } from '../observability/diagnostics.ts';
+import { buildWorkflowNodeRecords } from '../observability/node-record.ts';
+import { buildWorkflowRunRecord, buildWorkflowRunRecords } from '../observability/run-record.ts';
+import { buildWorkflowTrace } from '../observability/trace-builder.ts';
+
+type WorkflowServiceOptions = {
+  journal?: ExecutionJournal;
+  rootDir?: string;
+};
+
+function buildJournal(options: WorkflowServiceOptions): ExecutionJournal {
+  return options.journal ?? createExecutionJournal({ rootDir: options.rootDir });
+}
+
+export function createWorkflowService(options: WorkflowServiceOptions = {}) {
+  const journal = buildJournal(options);
+
+  function listWorkflows(): Array<Record<string, unknown>> {
+    const records = buildWorkflowRunRecords({
+      runs: journal.listRuns(),
+      inspectRun: (runId) => journal.inspectRun(runId)
+    });
+
+    return records.map((record) => ({
+      runId: record.runId,
+      workflowId: record.workflowId,
+      missionId: record.missionId,
+      status: record.status,
+      completedNodeCount: record.completedNodeCount,
+      failedNodeCount: record.failedNodeCount,
+      timeoutNodeCount: record.timeoutNodeCount,
+      retryCount: record.retryCount
+    }));
+  }
+
+  function inspectWorkflow(input: { runId: string }): Record<string, unknown> {
+    const inspected = journal.inspectRun(input.runId);
+    const runRecord = buildWorkflowRunRecord(inspected);
+    const nodeRecords = buildWorkflowNodeRecords({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: inspected.events
+    });
+    const diagnostics = getRunDiagnosticReport({
+      run: runRecord,
+      events: inspected.events,
+      nodes: nodeRecords
+    });
+
+    return {
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      missionId: runRecord.missionId,
+      status: runRecord.status,
+      summary: runRecord.summary,
+      nodeStates: nodeRecords.map((node) => ({
+        nodeId: node.nodeId,
+        status: node.status,
+        retryCount: node.retryCount,
+        timeoutType: node.timeoutType,
+        sequenceStarted: node.sequenceStarted,
+        sequenceCompleted: node.sequenceCompleted,
+        agentId: node.agentId,
+        adapterId: node.adapterId
+      })),
+      diagnostics: {
+        failedNodeIds: diagnostics.failedNodeIds,
+        timedOutNodeIds: diagnostics.timedOutNodeIds,
+        recoverable: diagnostics.recoverable,
+        resumed: diagnostics.resumed,
+        cancelled: diagnostics.cancelled,
+        safetyViolationNodeIds: diagnostics.safetyViolationNodeIds,
+        firstInspectTarget: diagnostics.firstInspectTarget,
+        finalContextKeys: diagnostics.finalContextKeys
+      }
+    };
+  }
+
+  function traceWorkflow(input: { runId: string }): Record<string, unknown> {
+    const inspected = journal.inspectRun(input.runId);
+    const runRecord = buildWorkflowRunRecord(inspected);
+    const nodeRecords = buildWorkflowNodeRecords({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: inspected.events
+    });
+
+    const trace = buildWorkflowTrace({
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      events: inspected.events,
+      nodeRecords
+    });
+
+    const executionOrder = trace
+      .filter((entry) => entry.type === 'NODE_STARTED')
+      .map((entry) => entry.nodeId)
+      .filter((value): value is string => typeof value === 'string');
+
+    const retries = trace.filter((entry) => entry.type === 'NODE_RETRY_SCHEDULED' || entry.type === 'NODE_RETRY_STARTED');
+    const failures = trace.filter((entry) => entry.type === 'TASK_FAILED' || entry.type === 'NODE_TIMEOUT' || entry.type === 'ADAPTER_TIMEOUT');
+
+    return {
+      runId: runRecord.runId,
+      workflowId: runRecord.workflowId,
+      status: runRecord.status,
+      executionOrder,
+      retries,
+      failures,
+      trace
+    };
+  }
+
+  return {
+    listWorkflows,
+    inspectWorkflow,
+    traceWorkflow
+  };
+}
+
+export type WorkflowService = ReturnType<typeof createWorkflowService>;

--- a/control-plane/runtime/hardened-workflow-runtime.ts
+++ b/control-plane/runtime/hardened-workflow-runtime.ts
@@ -87,6 +87,7 @@ export async function executeWorkflowRunWithHardening(input: {
   missionId: string;
   workflow: ValidatedWorkflowDefinition;
   executor: WorkflowTaskExecutor;
+  missionContextMemory?: Record<string, unknown>;
   hardening?: WorkflowRuntimeHardeningOptions;
 }): Promise<WorkflowRunResult> {
   const runtimeHooks = input.hardening ?? {};
@@ -96,6 +97,7 @@ export async function executeWorkflowRunWithHardening(input: {
       missionId: input.missionId,
       workflow: input.workflow,
       executor: input.executor,
+      missionContextMemory: input.missionContextMemory,
       hardening: {
         ...runtimeHooks,
         onNodeEvent(event) {
@@ -123,6 +125,7 @@ export async function executeWorkflowRunWithHardening(input: {
                   missionId: input.missionId
                 },
                 memory: {
+                  ...(input.missionContextMemory ?? {}),
                   previousOutputs: event.previousOutputs
                 }
               }
@@ -168,6 +171,9 @@ export async function executeWorkflowRunWithHardening(input: {
             runId: input.runId,
             workflowId: input.workflow.workflowId,
             missionId: input.missionId
+          },
+          memory: {
+            ...(input.missionContextMemory ?? {})
           }
         }
       }

--- a/control-plane/workflows/definitions/research-analysis-workflow.json
+++ b/control-plane/workflows/definitions/research-analysis-workflow.json
@@ -1,0 +1,36 @@
+{
+  "workflowId": "research-analysis-workflow",
+  "nodes": [
+    {
+      "id": "market-research",
+      "agent": "macro-signal-analyst",
+      "task": "research",
+      "phase": "research"
+    },
+    {
+      "id": "regulatory-scan",
+      "agent": "compliance-risk-reviewer",
+      "task": "regulatory-scan",
+      "phase": "analysis"
+    },
+    {
+      "id": "thesis-synthesis",
+      "agent": "lead-thesis-architect",
+      "task": "synthesis",
+      "phase": "synthesis",
+      "dependsOn": [
+        "market-research",
+        "regulatory-scan"
+      ]
+    },
+    {
+      "id": "final-review",
+      "agent": "compliance-risk-reviewer",
+      "task": "review",
+      "phase": "review",
+      "dependsOn": [
+        "thesis-synthesis"
+      ]
+    }
+  ]
+}

--- a/control-plane/workflows/tests/workflow-runner.test.ts
+++ b/control-plane/workflows/tests/workflow-runner.test.ts
@@ -86,6 +86,35 @@ describe('workflow-runner', () => {
     });
   });
 
+  it('T-WR3A propagates mission context memory to executor calls', async () => {
+    const workflow = loadWorkflowDefinition({
+      workflowId: 'wf-mission-context',
+      nodes: [
+        { id: 'a', task: 'task-a' }
+      ]
+    });
+
+    const execute = vi.fn(() => ({ ok: true }));
+    await runWorkflow({
+      missionId: 'mission-ctx',
+      workflow,
+      missionContextMemory: {
+        missionParameters: {
+          market: 'ethereum'
+        }
+      },
+      executor: { execute }
+    });
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      missionContextMemory: {
+        missionParameters: {
+          market: 'ethereum'
+        }
+      }
+    }));
+  });
+
   it('T-WR4 supports fan-in dependencies with both upstream outputs', async () => {
     const workflow = loadWorkflowDefinition({
       workflowId: 'wf-fanin',

--- a/control-plane/workflows/workflow-runner.ts
+++ b/control-plane/workflows/workflow-runner.ts
@@ -30,6 +30,7 @@ export interface WorkflowTaskExecutor {
     task: string;
     agent?: string;
     previousOutputs: Record<string, unknown>;
+    missionContextMemory?: Record<string, unknown>;
   }): Promise<unknown> | unknown;
 }
 
@@ -106,6 +107,7 @@ export async function runWorkflow(input: {
   missionId: string;
   workflow: ValidatedWorkflowDefinition;
   executor: WorkflowTaskExecutor;
+  missionContextMemory?: Record<string, unknown>;
 }): Promise<WorkflowRunResult> {
   return runWorkflowWithHardening(input);
 }
@@ -147,6 +149,7 @@ export async function runWorkflowWithHardening(input: {
   missionId: string;
   workflow: ValidatedWorkflowDefinition;
   executor: WorkflowTaskExecutor;
+  missionContextMemory?: Record<string, unknown>;
   hardening?: WorkflowRuntimeHardeningOptions;
 }): Promise<WorkflowRunResult> {
   const hardening = input.hardening ?? {};
@@ -268,7 +271,8 @@ export async function runWorkflowWithHardening(input: {
         workflowNodeId: nextNode.id,
         task: nextNode.task,
         ...(nextNode.agent ? { agent: nextNode.agent } : {}),
-        previousOutputs
+        previousOutputs,
+        missionContextMemory: input.missionContextMemory
       });
 
       outputsByNodeId[nextNode.id] = output;
@@ -392,6 +396,7 @@ export async function runWorkflowWithHardening(input: {
 export function createSwarmWorkflowExecutor(input: {
   swarmRunner: SwarmRunner;
   projectId: string;
+  missionMemory?: Record<string, unknown>;
 }): WorkflowTaskExecutor {
   return {
     async execute(params) {
@@ -401,9 +406,11 @@ export function createSwarmWorkflowExecutor(input: {
         entrypoint: `workflow:${params.workflowId}:${params.workflowNodeId}`,
         missionId: params.missionId,
         initialMemory: {
+          ...(input.missionMemory ?? {}),
           workflowNodeId: params.workflowNodeId,
           task: params.task,
-          previousOutputs: params.previousOutputs
+          previousOutputs: params.previousOutputs,
+          ...(params.missionContextMemory ? { missionContextMemory: params.missionContextMemory } : {})
         },
         metadata: {
           missionId: params.missionId,

--- a/docs/operator/mission-control.md
+++ b/docs/operator/mission-control.md
@@ -1,0 +1,50 @@
+# Mission Control
+
+Sprint 72 introduces the canonical operator control surface for mission lifecycle management.
+
+## Scope in Sprint 72
+- CLI is canonical for operator runtime control.
+- Slack command bot is an adapter over the same command-router semantics.
+- Web UI remains observability-only in this sprint.
+
+## Mission Lifecycle
+Operator-facing mission lifecycle states:
+- `created`
+- `running`
+- `completed`
+- `failed`
+- `cancelled`
+
+These states are projected from journal + runtime observability and mapped from underlying workflow/run states deterministically.
+
+## CLI Commands
+Use the canonical operator CLI:
+
+```bash
+npm run operator -- mission:start <missionId> [--key value ...]
+npm run operator -- mission:list
+npm run operator -- mission:inspect <missionId>
+npm run operator -- mission:cancel <missionId>
+```
+
+Output is deterministic JSON.
+
+## Mission Parameters
+`mission:start` accepts granular `--key value` parameters.
+
+Parameter behavior:
+- defaults are applied when configured in mission `parameterSchema.defaults`
+- provided values override defaults
+- required keys in `parameterSchema.required` must be present
+- allowed keys in `parameterSchema.allowed` are enforced when configured
+- merged parameter object is key-sorted deterministically
+
+Propagation path:
+- operator command params
+- mission context merge (`initialContext` + `missionParameters`)
+- hardened workflow runtime context snapshot memory
+- per-node execution context memory in workflow node run envelopes
+
+## Runtime Integration
+`mission:start` resolves mission/team/workflow definitions and executes through the hardened workflow runtime path.
+It does not use a stub executor and does not bypass runtime enforcement/recovery modules.

--- a/docs/operator/slack-commands.md
+++ b/docs/operator/slack-commands.md
@@ -1,0 +1,32 @@
+# Slack Commands
+
+Sprint 72 Slack support is command-bot style and adapter-only.
+Slack does not execute runtime controls directly.
+
+## Adapter Flow
+- Slack slash text input
+- Slack adapter parsing
+- operator command-router
+- mission/workflow/runtime services
+- deterministic JSON-backed Slack response payload
+
+## Supported Forms
+- `/mission start <missionId> [--key value ...]`
+- `/mission list`
+- `/mission inspect <missionId>`
+- `/mission cancel <missionId>`
+- `/workflow list`
+- `/workflow inspect <runId>`
+- `/workflow trace <runId>`
+- `/workflow retry --run <runId> --node <nodeId>`
+- `/workflow resume --run <runId>`
+- `/workflow cancel --run <runId>`
+
+## Determinism Notes
+- Slack command payloads are mapped to the same canonical router command argv.
+- Router validation and error semantics are shared with CLI.
+- Response payloads are deterministic JSON-backed structures.
+
+## Sprint Boundary
+Web UI controls are not part of Sprint 72.
+Workflow control remains CLI/Slack-router mediated.

--- a/docs/operator/workflow-navigation.md
+++ b/docs/operator/workflow-navigation.md
@@ -1,0 +1,33 @@
+# Workflow Navigation
+
+Sprint 72 adds mission-aligned workflow inspection and runtime control through the operator command router.
+
+## CLI Commands
+```bash
+npm run operator -- workflow:list
+npm run operator -- workflow:inspect <runId>
+npm run operator -- workflow:trace <runId>
+npm run operator -- workflow:retry --run <runId> --node <nodeId>
+npm run operator -- workflow:resume --run <runId>
+npm run operator -- workflow:cancel --run <runId>
+```
+
+## Inspection Model
+Inspection data is journal-derived and observability-derived only.
+No parallel state store is introduced.
+
+`workflow:inspect` includes:
+- run status
+- node status summary
+- retries/timeouts
+- diagnostics summary
+
+`workflow:trace` includes:
+- deterministic execution order
+- retry events
+- failure events
+- full sequence-ordered trace payload
+
+## Runtime Controls
+`workflow:retry`, `workflow:resume`, and `workflow:cancel` route to the existing recovery/runtime enforcement APIs.
+Commands return success only when runtime accepts and records the action.

--- a/entities/projects/control-plane.json
+++ b/entities/projects/control-plane.json
@@ -29,6 +29,7 @@
     "runtime/",
     "scripts/ci/",
     "scripts/governance/",
+    "control-plane/operator/",
     "control-plane/observability/",
     "control-plane/runtime/"
   ],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "swarm:task": "node --experimental-strip-types control-plane/orchestrator/cli/swarm-task.ts",
     "swarms:execute": "node --experimental-strip-types control-plane/cli/swarms-execute.ts",
     "mission:run": "node --experimental-strip-types control-plane/cli/mission-run.ts",
+    "operator": "node --experimental-strip-types control-plane/operator/cli.ts",
     "mission:inspect": "node --experimental-strip-types control-plane/cli/mission-inspect.ts",
     "mission:agents": "node --experimental-strip-types control-plane/cli/mission-agents.ts",
     "workflow:inspect": "node --experimental-strip-types control-plane/cli/workflow-inspect.ts",


### PR DESCRIPTION
tier-3

```evidence
- Added canonical operator control surface under control-plane/operator/.
- Implemented shared command-router used by both CLI and Slack adapter.
- Added deterministic JSON-first mission/workflow/runtime command handling.
- Wired mission:start through hardened runtime path with param propagation.
- Added mission/workflow inspection and runtime control commands.
- Added operator docs under docs/operator/.
- Updated control-plane ownership mapping for control-plane/operator/.
- Added operator-focused tests and passed targeted verification.
```
