### PR TITLE
Sprint 78: Multi-Provider Gateway + Research Adapter Foundation

### DIFF
--- a/control-plane/llm/models.json
+++ b/control-plane/llm/models.json
@@ -1,0 +1,10 @@
+{
+  "defaultModelByProvider": {
+    "ollama": "llama3.1:8b",
+    "groq": "llama-3.1-8b-instant",
+    "openrouter": "meta-llama/llama-3.1-8b-instruct",
+    "google": "gemini-2.5-flash",
+    "openai": "gpt-4o-mini",
+    "anthropic": "claude-3-5-haiku-latest"
+  }
+}

--- a/control-plane/llm/policy.json
+++ b/control-plane/llm/policy.json
@@ -1,0 +1,8 @@
+{
+  "default": "ollama",
+  "summarization": "groq",
+  "extract": "ollama",
+  "analysis": "google",
+  "comparison": "openrouter",
+  "premium": "openai"
+}

--- a/control-plane/tasks/adapter-registry.ts
+++ b/control-plane/tasks/adapter-registry.ts
@@ -1,8 +1,8 @@
 import type { AgentTaskAdapter } from './adapter-interface.ts';
-import { llmTaskAdapter, repoTaskAdapter, shellTaskAdapter } from './adapters/index.ts';
+import { llmTaskAdapter, repoTaskAdapter, runtimeTaskAdapters, shellTaskAdapter } from './adapters/index.ts';
 import type { TaskType } from './task-types.ts';
 
-const ADAPTERS: readonly AgentTaskAdapter[] = [llmTaskAdapter, shellTaskAdapter, repoTaskAdapter] as const;
+const ADAPTERS: readonly AgentTaskAdapter[] = [llmTaskAdapter, shellTaskAdapter, repoTaskAdapter, ...runtimeTaskAdapters] as const;
 
 const adapterRegistry = new Map<TaskType, AgentTaskAdapter>(
   ADAPTERS.map((adapter) => [adapter.type, adapter])

--- a/control-plane/tasks/adapters/index.ts
+++ b/control-plane/tasks/adapters/index.ts
@@ -1,3 +1,4 @@
 export { llmTaskAdapter } from './llm-task.ts';
 export { shellTaskAdapter } from './shell-task.ts';
 export { repoTaskAdapter } from './repo-task.ts';
+export { runtimeTaskAdapters } from './runtime-task.ts';

--- a/control-plane/tasks/adapters/runtime-task.ts
+++ b/control-plane/tasks/adapters/runtime-task.ts
@@ -1,0 +1,107 @@
+import { executeRuntimeTask, type RuntimeTaskType } from '../../../runtime/runtime-task-executor.ts';
+import { createLLMGateway } from '../../../runtime/llm/gateway.ts';
+import { ArtifactWriter, type DeclaredArtifact } from '../../../runtime/output/artifact-writer.ts';
+import type { AgentTaskAdapter } from '../adapter-interface.ts';
+import type { TaskContext } from '../task-context.ts';
+import type { TaskResult } from '../task-result.ts';
+
+const RUNTIME_TASK_TYPES: RuntimeTaskType[] = [
+  'llm.generate',
+  'tool.web_search',
+  'tool.page_fetch',
+  'tool.reader_extract',
+  'output.write_csv',
+  'output.write_xlsx',
+  'output.write_artifact'
+];
+
+const ARTIFACTS_BASE_DIR = 'runtime-data/artifacts';
+
+function toDeclaredArtifacts(input: unknown): DeclaredArtifact[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => entry as Record<string, unknown>)
+    .flatMap((entry) => {
+      const artifactId = typeof entry.artifactId === 'string' ? entry.artifactId.trim() : '';
+      const format = entry.format;
+      if (
+        artifactId.length === 0
+        || (format !== 'csv' && format !== 'xlsx' && format !== 'artifact')
+      ) {
+        return [];
+      }
+      return [{ artifactId, format } as DeclaredArtifact];
+    })
+    .sort((left, right) => left.artifactId.localeCompare(right.artifactId));
+}
+
+function splitError(message: string): { errorCode: string; errorMessage: string } {
+  const matched = message.match(/^(ERR_[A-Z0-9_]+|LLM_[A-Z0-9_]+):\s*(.*)$/);
+  if (!matched) {
+    return {
+      errorCode: 'ERR_RUNTIME_TASK_EXECUTION',
+      errorMessage: message
+    };
+  }
+
+  return {
+    errorCode: matched[1],
+    errorMessage: matched[2] || matched[1]
+  };
+}
+
+async function execute(context: TaskContext, taskType: RuntimeTaskType): Promise<TaskResult> {
+  const artifactWriter = new ArtifactWriter(
+    ARTIFACTS_BASE_DIR,
+    toDeclaredArtifacts(context.executionContext.memory.declaredArtifacts)
+  );
+
+  try {
+    const result = await executeRuntimeTask({
+      taskType,
+      payload: context.inputs,
+      missionId: context.executionContext.missionId ?? 'unknown-mission',
+      runId: context.runId,
+      workflowNodeId: context.taskId,
+      missionContextMemory: context.executionContext.memory,
+      llmGateway: createLLMGateway(),
+      artifactWriter
+    });
+
+    return {
+      status: 'success',
+      outputs: result,
+      artifacts: typeof result.filePath === 'string'
+        ? [{ path: result.filePath }]
+        : [],
+      logs: ['RUNTIME_TASK_EXECUTED']
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const parsed = splitError(message);
+
+    return {
+      status: 'failed',
+      outputs: {},
+      artifacts: [],
+      logs: ['RUNTIME_TASK_FAILED'],
+      errorCode: parsed.errorCode,
+      errorMessage: parsed.errorMessage
+    };
+  }
+}
+
+function makeRuntimeAdapter(type: RuntimeTaskType): AgentTaskAdapter {
+  return {
+    type,
+    async execute(context: TaskContext) {
+      return execute(context, type);
+    }
+  };
+}
+
+export const runtimeTaskAdapters: AgentTaskAdapter[] = RUNTIME_TASK_TYPES.map((type) => makeRuntimeAdapter(type));

--- a/control-plane/tasks/task-types.ts
+++ b/control-plane/tasks/task-types.ts
@@ -1,4 +1,15 @@
-export const TASK_TYPES = ['llm', 'shell', 'repo'] as const;
+export const TASK_TYPES = [
+  'llm',
+  'shell',
+  'repo',
+  'llm.generate',
+  'tool.web_search',
+  'tool.page_fetch',
+  'tool.reader_extract',
+  'output.write_csv',
+  'output.write_xlsx',
+  'output.write_artifact'
+] as const;
 
 export type TaskType = (typeof TASK_TYPES)[number];
 

--- a/control-plane/tasks/tests/adapter-registry.test.ts
+++ b/control-plane/tasks/tests/adapter-registry.test.ts
@@ -16,11 +16,26 @@ describe('task adapter registry', () => {
     expect(getAdapter('repo')).toBe(repoTaskAdapter);
   });
 
+  it('returns runtime adapter for llm.generate task type', () => {
+    expect(getAdapter('llm.generate').type).toBe('llm.generate');
+  });
+
   it('throws deterministic error for unknown adapter type', () => {
     expect(() => getAdapter('unknown' as 'llm')).toThrow('ERR_TASK_ADAPTER_NOT_FOUND: unknown');
   });
 
   it('lists adapters in stable deterministic order', () => {
-    expect(listRegisteredAdapters().map((entry) => entry.type)).toEqual(['llm', 'repo', 'shell']);
+    expect(listRegisteredAdapters().map((entry) => entry.type)).toEqual([
+      'llm',
+      'llm.generate',
+      'output.write_artifact',
+      'output.write_csv',
+      'output.write_xlsx',
+      'repo',
+      'shell',
+      'tool.page_fetch',
+      'tool.reader_extract',
+      'tool.web_search'
+    ]);
   });
 });

--- a/docs/architecture/multi-provider-gateway.md
+++ b/docs/architecture/multi-provider-gateway.md
@@ -1,0 +1,76 @@
+# Multi-Provider Gateway (Sprint 78)
+
+## Overview
+Sprint 78 introduces a runtime capability layer for low-cost, deterministic research workflows:
+
+Mission -> web search -> page fetch -> reader extract -> LLM summarize/structure -> CSV/XLSX artifact
+
+Control-plane determinism is preserved by stable routing resolution, canonical response hashing, stable artifact naming, and deterministic ordering in adapters and writers.
+
+## Gateway Abstraction
+`runtime/llm/gateway.ts` is the normalized entry point.
+
+It performs:
+- policy-driven provider routing
+- provider adapter invocation
+- output-mode normalization (`text`, `json`, `best-effort-json`)
+- deterministic response hashing: `sha256(canonicalStringify(responseWithoutHash))`
+- structured logging hook
+
+Provider implementations are isolated under `runtime/llm/providers/` and only expose a stable invoke contract upward.
+
+## Cheap-First Routing
+Routing policy is externalized to:
+- `control-plane/llm/policy.json`
+- `control-plane/llm/models.json`
+
+Routing precedence:
+1. `providerPreference`
+2. `routeHint`
+3. `taskType` mapping
+4. `default`
+
+This keeps premium providers available but non-default.
+
+## Provider Swapability
+No provider is hardcoded in gateway control flow.
+
+Provider adapters are registered by provider id, and model selection is resolved from external config.
+Replacing providers is a config + adapter registration change, not a workflow refactor.
+
+## Output Modes
+- `text`: raw provider content
+- `json`: strict object JSON parse (fails on invalid/non-object)
+- `best-effort-json`: extracts first JSON object candidate and parses when possible
+
+This allows strict workflows where required and tolerant parsing where practical.
+
+## Tool Layering
+`runtime/tools/` provides normalized adapters:
+- `web_search`
+- `page_fetch`
+- `reader_extract`
+
+Adapters are deterministic by construction:
+- stable rank/ordering
+- normalized whitespace/encodings
+- fixed response shapes
+
+## Output Layer
+`runtime/output/` provides deterministic artifact emission:
+- `ArtifactWriter` enforces declared artifacts and deterministic paths
+- `csv-writer` enforces deterministic column/row ordering and newline normalization
+- `xlsx-writer` emits minimal deterministic workbook zip contents with stable sheet ordering
+- `source-registry` deduplicates sources and sorts lexicographically
+
+## Runtime Hooks
+`runtime/runtime-task-executor.ts` adds callable task hooks for workflow DAG nodes:
+- `llm.generate`
+- `tool.web_search`
+- `tool.page_fetch`
+- `tool.reader_extract`
+- `output.write_csv`
+- `output.write_xlsx`
+- `output.write_artifact`
+
+These hooks are additive and can be bound as workflow executor logic without changing core workflow DAG semantics.

--- a/docs/runbooks/cheap-research-missions.md
+++ b/docs/runbooks/cheap-research-missions.md
@@ -1,0 +1,49 @@
+# Cheap Research Missions Runbook
+
+## Goal
+Run deterministic public-web research missions at low cost using configurable providers and runtime adapters.
+
+## Required Environment Variables
+Set only the providers you plan to use.
+
+- `OLLAMA_BASE_URL` (optional, default `http://127.0.0.1:11434`)
+- `GROQ_API_KEY`
+- `OPENROUTER_API_KEY`
+- `GOOGLE_API_KEY`
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+If a selected provider is not configured/reachable, runtime fails fast with deterministic explicit errors.
+
+## Config Files
+- `control-plane/llm/policy.json`
+- `control-plane/llm/models.json`
+
+Edit these files to control cheap-first routing and default model selection by provider.
+
+## Ollama-Only Mode
+1. Ensure Ollama is running locally.
+2. Set routing policy defaults/tasks to `ollama`.
+3. Ensure `models.json` has an `ollama` default model.
+4. Run mission workflow using task hooks (`tool.*`, `llm.generate`, `output.*`).
+
+## Enabling Groq / OpenRouter / Google
+1. Set provider API key env vars.
+2. Update `policy.json` mappings (`summarization`, `analysis`, etc.) to desired providers.
+3. Ensure each mapped provider has a default model in `models.json`.
+4. Re-run mission workflow.
+
+## Running Cheap Research Missions
+Typical deterministic DAG sequence:
+1. `tool.web_search`
+2. `tool.page_fetch`
+3. `tool.reader_extract`
+4. `llm.generate` (usually `json` or `best-effort-json`)
+5. `output.write_csv` and/or `output.write_xlsx`
+
+## Verification Checklist
+- Routing follows policy precedence.
+- Outputs are deterministic across repeated runs with same inputs.
+- Artifacts are written only if declared.
+- Source registry contains deduplicated lexicographically sorted source list.
+- Tests pass for `runtime/llm`, `runtime/tools`, `runtime/output`, and integration flow.

--- a/runtime/__tests__/research-workflow.integration.test.ts
+++ b/runtime/__tests__/research-workflow.integration.test.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createLLMGateway } from '../llm/gateway.ts';
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from '../llm/providers/provider.ts';
+import { ArtifactWriter } from '../output/artifact-writer.ts';
+import { SourceRegistry } from '../output/source-registry.ts';
+import { executeRuntimeTask } from '../runtime-task-executor.ts';
+
+const tmpRoot = path.join('runtime', '__tests__', 'tmp-sprint-78');
+
+class SummaryProvider implements LLMProvider {
+  readonly providerId = 'ollama';
+
+  async invoke(_request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+    return {
+      model: 'llama3.1:8b',
+      content: '{"summary":"Deterministic summary","confidence":"high"}',
+      usage: { inputTokens: 10, outputTokens: 5 }
+    };
+  }
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('sprint 78 integration simulation', () => {
+  it('T-I1 executes search->fetch->extract->summarize->write-csv deterministically', async () => {
+    const fetchCalls: string[] = [];
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (url: string | URL) => {
+      const textUrl = String(url);
+      fetchCalls.push(textUrl);
+
+      if (textUrl.startsWith('https://duckduckgo.com/html/')) {
+        return {
+          ok: true,
+          status: 200,
+          url: textUrl,
+          headers: { get: () => 'text/html' },
+          text: async () => '<html><body><div class="result"><a href="https://example.com/source">Example Source</a></div></body></html>'
+        } as Response;
+      }
+
+      if (textUrl === 'https://example.com/source') {
+        return {
+          ok: true,
+          status: 200,
+          url: textUrl,
+          headers: { get: () => 'text/html; charset=utf-8' },
+          text: async () => '<html><head><title>Example</title></head><body><nav>menu</nav><main><p>Alpha data point</p></main></body></html>'
+        } as Response;
+      }
+
+      throw new Error(`unexpected fetch: ${textUrl}`);
+    }) as typeof fetch;
+
+    try {
+      const artifactWriter = new ArtifactWriter(tmpRoot, [{ artifactId: 'research_csv', format: 'csv' }]);
+      const gateway = createLLMGateway({
+        policy: { default: 'ollama' },
+        models: { defaultModelByProvider: { ollama: 'llama3.1:8b' } },
+        providers: { ollama: new SummaryProvider() },
+        checkProviderReachability: false
+      });
+
+      const missionId = 'mission-s78';
+      const runId = 'run-s78';
+      const sourceRegistry = new SourceRegistry();
+
+      const search = await executeRuntimeTask({
+        taskType: 'tool.web_search',
+        payload: { query: 'example source' },
+        missionId,
+        runId,
+        workflowNodeId: 'search',
+        llmGateway: gateway,
+        artifactWriter
+      });
+
+      const resultRows = search.results as Array<{ url: string; domain: string; rank: number; title: string }>;
+      expect(resultRows.length).toBe(1);
+      sourceRegistry.add({ url: resultRows[0].url, firstSeenStep: 'search' });
+
+      const fetched = await executeRuntimeTask({
+        taskType: 'tool.page_fetch',
+        payload: { url: resultRows[0].url },
+        missionId,
+        runId,
+        workflowNodeId: 'fetch',
+        llmGateway: gateway,
+        artifactWriter
+      });
+
+      const extracted = await executeRuntimeTask({
+        taskType: 'tool.reader_extract',
+        payload: { html: fetched.html },
+        missionId,
+        runId,
+        workflowNodeId: 'extract',
+        llmGateway: gateway,
+        artifactWriter
+      });
+
+      const summarized = await executeRuntimeTask({
+        taskType: 'llm.generate',
+        payload: {
+          taskType: 'summarization',
+          outputMode: 'json',
+          inputs: {
+            title: extracted.title,
+            body: extracted.body
+          },
+          constraints: ['deterministic'],
+          requestedArtifacts: ['research_csv'],
+          outputInstructions: 'Return summary JSON object'
+        },
+        missionId,
+        runId,
+        workflowNodeId: 'summarize',
+        llmGateway: gateway,
+        artifactWriter,
+        missionContextMemory: {
+          teamId: 'team-r',
+          agentId: 'agent-r'
+        }
+      });
+
+      expect(summarized.parsedJson).toEqual({ summary: 'Deterministic summary', confidence: 'high' });
+
+      const write = await executeRuntimeTask({
+        taskType: 'output.write_csv',
+        payload: {
+          artifactId: 'research_csv',
+          rows: [{
+            domain: resultRows[0].domain,
+            title: extracted.title,
+            summary: (summarized.parsedJson as Record<string, unknown>).summary
+          }]
+        },
+        missionId,
+        runId,
+        workflowNodeId: 'write',
+        llmGateway: gateway,
+        artifactWriter
+      });
+
+      const csvPath = write.filePath as string;
+      const csv = fs.readFileSync(csvPath, 'utf8');
+
+      expect(fs.existsSync(csvPath)).toBe(true);
+      expect(csv).toBe([
+        'domain,summary,title',
+        'example.com,Deterministic summary,Example',
+        ''
+      ].join('\n'));
+
+      expect(sourceRegistry.list()).toEqual([
+        {
+          url: 'https://example.com/source',
+          domain: 'example.com',
+          firstSeenStep: 'search'
+        }
+      ]);
+
+      expect(fetchCalls).toEqual([
+        'https://duckduckgo.com/html/?q=example+source',
+        'https://example.com/source'
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/runtime/llm/__tests__/gateway.test.ts
+++ b/runtime/llm/__tests__/gateway.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalStringify, sha256 } from '../../../control-plane/finance/determinism.ts';
+import { createLLMGateway } from '../gateway.ts';
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from '../providers/provider.ts';
+import type { LLMRequest } from '../types.ts';
+
+class StubProvider implements LLMProvider {
+  constructor(
+    public readonly providerId: string,
+    private readonly content: string,
+    private readonly usage: ProviderInvokeResponse['usage'] = { inputTokens: 1, outputTokens: 2 }
+  ) {}
+
+  async invoke(_request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+    return {
+      model: `${this.providerId}-model`,
+      content: this.content,
+      usage: this.usage
+    };
+  }
+}
+
+function makeRequest(overrides: Partial<LLMRequest> = {}): LLMRequest {
+  return {
+    taskType: 'summarization',
+    outputMode: 'text',
+    promptEnvelope: {
+      missionId: 'mission-1',
+      runId: 'run-1',
+      workflowNodeId: 'node-1',
+      teamId: 'team-1',
+      agentId: 'agent-1',
+      taskType: 'summarization',
+      inputs: { text: 'abc' },
+      constraints: ['deterministic'],
+      requestedArtifacts: ['report.csv'],
+      outputInstructions: 'Summarize'
+    },
+    ...overrides
+  };
+}
+
+describe('runtime llm gateway', () => {
+  it('T-L1 routes by preference > routeHint > taskType > default', async () => {
+    const gateway = createLLMGateway({
+      policy: {
+        default: 'ollama',
+        summarization: 'groq',
+        extract: 'ollama',
+        analysis: 'google',
+        comparison: 'openrouter',
+        premium: 'openai',
+        fastlane: 'anthropic'
+      },
+      models: {
+        defaultModelByProvider: {
+          ollama: 'o-model',
+          groq: 'g-model',
+          google: 'go-model',
+          openrouter: 'or-model',
+          openai: 'oa-model',
+          anthropic: 'a-model'
+        }
+      },
+      providers: {
+        ollama: new StubProvider('ollama', 'ollama-out'),
+        groq: new StubProvider('groq', 'groq-out'),
+        google: new StubProvider('google', 'google-out'),
+        openrouter: new StubProvider('openrouter', 'openrouter-out'),
+        openai: new StubProvider('openai', 'openai-out'),
+        anthropic: new StubProvider('anthropic', 'anthropic-out')
+      },
+      env: {
+        GROQ_API_KEY: 'k',
+        OPENROUTER_API_KEY: 'k',
+        GOOGLE_API_KEY: 'k',
+        OPENAI_API_KEY: 'k',
+        ANTHROPIC_API_KEY: 'k'
+      },
+      checkProviderReachability: false
+    });
+
+    const preferred = await gateway.invoke(makeRequest({ providerPreference: 'openai' }));
+    expect(preferred.provider).toBe('openai');
+
+    const hinted = await gateway.invoke(makeRequest({ providerPreference: null, routeHint: 'fastlane' }));
+    expect(hinted.provider).toBe('anthropic');
+
+    const taskMapped = await gateway.invoke(makeRequest({ providerPreference: null, routeHint: undefined }));
+    expect(taskMapped.provider).toBe('groq');
+
+    const fallbackDefault = await gateway.invoke(makeRequest({ taskType: 'unknown-task', providerPreference: null }));
+    expect(fallbackDefault.provider).toBe('ollama');
+  });
+
+  it('T-L2 fails clearly when provider is unavailable', async () => {
+    const gateway = createLLMGateway({
+      policy: { default: 'groq' },
+      models: { defaultModelByProvider: { groq: 'g-model' } },
+      providers: {
+        groq: new StubProvider('groq', 'x')
+      },
+      env: {},
+      checkProviderReachability: false
+    });
+
+    await expect(gateway.invoke(makeRequest({ taskType: 'unknown-task' }))).rejects.toThrow(
+      'LLM_PROVIDER_UNAVAILABLE: provider=groq'
+    );
+  });
+
+  it('T-L3 parses best-effort-json using extraction', async () => {
+    const gateway = createLLMGateway({
+      policy: { default: 'ollama' },
+      models: { defaultModelByProvider: { ollama: 'o-model' } },
+      providers: {
+        ollama: new StubProvider('ollama', 'prefix text {"a":1,"b":"x"} suffix text')
+      },
+      checkProviderReachability: false
+    });
+
+    const response = await gateway.invoke(makeRequest({ outputMode: 'best-effort-json' }));
+    expect(response.parsedJson).toEqual({ a: 1, b: 'x' });
+  });
+
+  it('T-L4 computes deterministic response hash from canonical response object', async () => {
+    const gateway = createLLMGateway({
+      policy: { default: 'ollama' },
+      models: { defaultModelByProvider: { ollama: 'o-model' } },
+      providers: {
+        ollama: new StubProvider('ollama', 'plain text', { inputTokens: null, outputTokens: null })
+      },
+      checkProviderReachability: false
+    });
+
+    const response = await gateway.invoke(makeRequest({ outputMode: 'text' }));
+
+    const expected = sha256(canonicalStringify({
+      provider: 'ollama',
+      model: 'ollama-model',
+      outputMode: 'text',
+      content: 'plain text',
+      parsedJson: undefined,
+      usage: { inputTokens: null, outputTokens: null }
+    }));
+
+    expect(response.responseHash).toBe(expected);
+  });
+
+  it('T-L5 enforces strict object json mode', async () => {
+    const gateway = createLLMGateway({
+      policy: { default: 'ollama' },
+      models: { defaultModelByProvider: { ollama: 'o-model' } },
+      providers: {
+        ollama: new StubProvider('ollama', '"not-an-object"')
+      },
+      checkProviderReachability: false
+    });
+
+    await expect(gateway.invoke(makeRequest({ outputMode: 'json' }))).rejects.toThrow(
+      'LLM_INVALID_JSON: strict json mode requires object JSON output'
+    );
+  });
+});

--- a/runtime/llm/__tests__/provider-status.test.ts
+++ b/runtime/llm/__tests__/provider-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProviderStatus } from '../provider-status.ts';
+
+describe('runtime llm provider status', () => {
+  it('T-L6 returns unavailable when required env is missing', async () => {
+    const status = await getProviderStatus({ providerId: 'openai', env: {}, checkReachability: false });
+    expect(status).toBe('unavailable');
+  });
+
+  it('T-L7 returns configured for keyed providers when env exists', async () => {
+    const status = await getProviderStatus({
+      providerId: 'google',
+      env: { GOOGLE_API_KEY: 'x' },
+      checkReachability: false
+    });
+    expect(status).toBe('configured');
+  });
+
+  it('T-L8 returns reachable for ollama on successful tags call', async () => {
+    const status = await getProviderStatus({
+      providerId: 'ollama',
+      env: { OLLAMA_BASE_URL: 'http://ollama.local' },
+      fetchImpl: async () => ({ ok: true } as Response)
+    });
+    expect(status).toBe('reachable');
+  });
+});

--- a/runtime/llm/gateway.ts
+++ b/runtime/llm/gateway.ts
@@ -1,0 +1,194 @@
+import { canonicalStringify, sha256 } from '../../control-plane/finance/determinism.ts';
+import { assertProviderAvailable } from './provider-status.ts';
+import { loadProviderModels, loadProviderPolicy, resolveModelForProvider, resolveProviderForRequest, type ProviderModels, type ProviderPolicy } from './policy.ts';
+import { createAnthropicProvider } from './providers/anthropic.ts';
+import { createGoogleProvider } from './providers/google.ts';
+import { createGroqProvider } from './providers/groq.ts';
+import { createOllamaProvider } from './providers/ollama.ts';
+import { createOpenAIProvider } from './providers/openai.ts';
+import { createOpenRouterProvider } from './providers/openrouter.ts';
+import type { LLMProvider } from './providers/provider.ts';
+import type { LLMRequest, LLMResponse } from './types.ts';
+
+type ParsedMode = Record<string, unknown> | null;
+
+function parseStrictObjectJson(content: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error('LLM_INVALID_JSON: strict json mode parse failed');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('LLM_INVALID_JSON: strict json mode requires object JSON output');
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+function extractJsonObjectCandidate(content: string): string | null {
+  const start = content.indexOf('{');
+  if (start < 0) {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+  for (let i = start; i < content.length; i += 1) {
+    const ch = content[i];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (ch === '\\') {
+        escaping = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth += 1;
+    } else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return content.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function tryParseBestEffortJson(content: string): ParsedMode {
+  const candidate = extractJsonObjectCandidate(content);
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(candidate) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeOutput(input: {
+  outputMode: LLMRequest['outputMode'];
+  content: string;
+}): { content: string; parsedJson?: Record<string, unknown> | null } {
+  const content = input.content;
+
+  if (input.outputMode === 'text') {
+    return { content };
+  }
+
+  if (input.outputMode === 'json') {
+    return {
+      content,
+      parsedJson: parseStrictObjectJson(content)
+    };
+  }
+
+  return {
+    content,
+    parsedJson: tryParseBestEffortJson(content)
+  };
+}
+
+function defaultProviders(): Record<string, LLMProvider> {
+  return {
+    ollama: createOllamaProvider(),
+    groq: createGroqProvider(),
+    openrouter: createOpenRouterProvider(),
+    google: createGoogleProvider(),
+    openai: createOpenAIProvider(),
+    anthropic: createAnthropicProvider()
+  };
+}
+
+export interface LLMGateway {
+  invoke(request: LLMRequest): Promise<LLMResponse>;
+}
+
+export function createLLMGateway(input: {
+  policy?: ProviderPolicy;
+  models?: ProviderModels;
+  providers?: Record<string, LLMProvider>;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  checkProviderReachability?: boolean;
+  onLog?: (event: Record<string, unknown>) => void;
+} = {}): LLMGateway {
+  const policy = input.policy ?? loadProviderPolicy();
+  const models = input.models ?? loadProviderModels();
+  const providers = input.providers ?? defaultProviders();
+
+  return {
+    async invoke(request: LLMRequest): Promise<LLMResponse> {
+      const providerId = resolveProviderForRequest(request, policy);
+      const provider = providers[providerId];
+      if (!provider) {
+        throw new Error(`LLM_PROVIDER_UNAVAILABLE: provider=${providerId}`);
+      }
+
+      await assertProviderAvailable({
+        provider,
+        env: input.env,
+        fetchImpl: input.fetchImpl,
+        checkReachability: input.checkProviderReachability
+      });
+
+      const model = resolveModelForProvider(providerId, models);
+      const raw = await provider.invoke({
+        model,
+        outputMode: request.outputMode,
+        promptEnvelope: request.promptEnvelope,
+        maxTokens: request.maxTokens
+      });
+
+      const normalized = normalizeOutput({
+        outputMode: request.outputMode,
+        content: raw.content
+      });
+
+      const responseWithoutHash = {
+        provider: providerId,
+        model: raw.model,
+        outputMode: request.outputMode,
+        content: normalized.content,
+        parsedJson: normalized.parsedJson,
+        usage: raw.usage
+      };
+
+      const responseHash = sha256(canonicalStringify(responseWithoutHash));
+      const response: LLMResponse = {
+        ...responseWithoutHash,
+        responseHash
+      };
+
+      input.onLog?.({
+        event: 'llm.gateway.invoke',
+        provider: providerId,
+        model: raw.model,
+        outputMode: request.outputMode,
+        responseHash,
+        taskType: request.taskType,
+        routeHint: request.routeHint ?? null
+      });
+
+      return response;
+    }
+  };
+}

--- a/runtime/llm/policy.ts
+++ b/runtime/llm/policy.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { LLMRequest } from './types.ts';
+
+export interface ProviderPolicy {
+  default: string;
+  [taskType: string]: string;
+}
+
+export interface ProviderModels {
+  defaultModelByProvider: Record<string, string>;
+}
+
+const DEFAULT_POLICY_PATH = 'control-plane/llm/policy.json';
+const DEFAULT_MODELS_PATH = 'control-plane/llm/models.json';
+
+function resolveConfigPath(filePath: string): string {
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+
+  let current = process.cwd();
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(current, filePath);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return path.resolve(filePath);
+}
+
+function readJson(filePath: string): unknown {
+  const resolved = resolveConfigPath(filePath);
+  return JSON.parse(fs.readFileSync(resolved, 'utf8')) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toProviderPolicy(value: unknown): ProviderPolicy {
+  if (!isRecord(value)) {
+    throw new Error('LLM_POLICY_INVALID: policy must be an object');
+  }
+
+  const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+  const parsed: Record<string, string> = {};
+  for (const [key, provider] of entries) {
+    if (typeof provider !== 'string' || provider.trim().length === 0) {
+      throw new Error(`LLM_POLICY_INVALID: invalid provider mapping for key=${key}`);
+    }
+    parsed[key] = provider;
+  }
+
+  if (typeof parsed.default !== 'string' || parsed.default.length === 0) {
+    throw new Error('LLM_POLICY_INVALID: missing default provider');
+  }
+
+  return parsed as ProviderPolicy;
+}
+
+function toProviderModels(value: unknown): ProviderModels {
+  if (!isRecord(value)) {
+    throw new Error('LLM_MODELS_INVALID: models must be an object');
+  }
+
+  const rawMap = value.defaultModelByProvider;
+  if (!isRecord(rawMap)) {
+    throw new Error('LLM_MODELS_INVALID: missing defaultModelByProvider');
+  }
+
+  const entries = Object.entries(rawMap)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([provider, model]) => {
+      if (typeof model !== 'string' || model.trim().length === 0) {
+        throw new Error(`LLM_MODELS_INVALID: invalid model for provider=${provider}`);
+      }
+      return [provider, model] as const;
+    });
+
+  return {
+    defaultModelByProvider: Object.fromEntries(entries)
+  };
+}
+
+export function loadProviderPolicy(filePath = DEFAULT_POLICY_PATH): ProviderPolicy {
+  return toProviderPolicy(readJson(filePath));
+}
+
+export function loadProviderModels(filePath = DEFAULT_MODELS_PATH): ProviderModels {
+  return toProviderModels(readJson(filePath));
+}
+
+export function resolveProviderForRequest(request: LLMRequest, policy: ProviderPolicy): string {
+  if (typeof request.providerPreference === 'string' && request.providerPreference.trim().length > 0) {
+    return request.providerPreference;
+  }
+
+  if (typeof request.routeHint === 'string' && request.routeHint.trim().length > 0 && typeof policy[request.routeHint] === 'string') {
+    return policy[request.routeHint];
+  }
+
+  if (typeof policy[request.taskType] === 'string') {
+    return policy[request.taskType];
+  }
+
+  return policy.default;
+}
+
+export function resolveModelForProvider(provider: string, models: ProviderModels): string {
+  const model = models.defaultModelByProvider[provider];
+  if (!model) {
+    throw new Error(`LLM_MODEL_NOT_FOUND: provider=${provider}`);
+  }
+  return model;
+}

--- a/runtime/llm/provider-status.ts
+++ b/runtime/llm/provider-status.ts
@@ -1,0 +1,75 @@
+import type { LLMProvider } from './providers/provider.ts';
+
+export type ProviderStatus = 'configured' | 'reachable' | 'unavailable';
+
+function requireEnv(key: string, env: NodeJS.ProcessEnv): boolean {
+  return typeof env[key] === 'string' && env[key]!.trim().length > 0;
+}
+
+function isConfigured(providerId: string, env: NodeJS.ProcessEnv): boolean {
+  if (providerId === 'ollama') {
+    return true;
+  }
+
+  const envMap: Record<string, string> = {
+    groq: 'GROQ_API_KEY',
+    openrouter: 'OPENROUTER_API_KEY',
+    google: 'GOOGLE_API_KEY',
+    openai: 'OPENAI_API_KEY',
+    anthropic: 'ANTHROPIC_API_KEY'
+  };
+
+  const key = envMap[providerId];
+  return key ? requireEnv(key, env) : false;
+}
+
+async function isReachable(providerId: string, env: NodeJS.ProcessEnv, fetchImpl: typeof fetch): Promise<boolean> {
+  if (providerId !== 'ollama') {
+    return isConfigured(providerId, env);
+  }
+
+  const baseUrl = env.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434';
+  try {
+    const response = await fetchImpl(`${baseUrl.replace(/\/$/, '')}/api/tags`, { method: 'GET' });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function getProviderStatus(input: {
+  providerId: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  checkReachability?: boolean;
+}): Promise<ProviderStatus> {
+  const env = input.env ?? process.env;
+  if (!isConfigured(input.providerId, env)) {
+    return 'unavailable';
+  }
+
+  if (input.checkReachability === false) {
+    return 'configured';
+  }
+
+  const reachable = await isReachable(input.providerId, env, input.fetchImpl ?? fetch);
+  return reachable ? 'reachable' : 'unavailable';
+}
+
+export async function assertProviderAvailable(input: {
+  provider: LLMProvider;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  checkReachability?: boolean;
+}): Promise<void> {
+  const status = await getProviderStatus({
+    providerId: input.provider.providerId,
+    env: input.env,
+    fetchImpl: input.fetchImpl,
+    checkReachability: input.checkReachability
+  });
+
+  if (status === 'unavailable') {
+    throw new Error(`LLM_PROVIDER_UNAVAILABLE: provider=${input.provider.providerId}`);
+  }
+}

--- a/runtime/llm/providers/anthropic.ts
+++ b/runtime/llm/providers/anthropic.ts
@@ -1,0 +1,62 @@
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from './provider.ts';
+
+export function createAnthropicProvider(input: {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+} = {}): LLMProvider {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  return {
+    providerId: 'anthropic',
+    async invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+      const apiKey = env.ANTHROPIC_API_KEY;
+      if (!apiKey) {
+        throw new Error('LLM_PROVIDER_UNAVAILABLE: provider=anthropic missing=ANTHROPIC_API_KEY');
+      }
+
+      const response = await fetchImpl('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: request.model,
+          system: request.promptEnvelope.outputInstructions,
+          max_tokens: request.maxTokens ?? 1024,
+          messages: [
+            {
+              role: 'user',
+              content: JSON.stringify(request.promptEnvelope)
+            }
+          ]
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM_PROVIDER_ERROR: provider=anthropic status=${response.status}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const contentBlocks = Array.isArray(payload.content) ? payload.content : [];
+      const content = contentBlocks
+        .map((entry) => (entry && typeof entry === 'object' && typeof (entry as Record<string, unknown>).text === 'string')
+          ? (entry as Record<string, unknown>).text as string
+          : '')
+        .join('\n')
+        .trim();
+
+      const usage = payload.usage as Record<string, unknown> | undefined;
+      return {
+        model: request.model,
+        content,
+        usage: {
+          inputTokens: typeof usage?.input_tokens === 'number' ? usage.input_tokens : null,
+          outputTokens: typeof usage?.output_tokens === 'number' ? usage.output_tokens : null
+        }
+      };
+    }
+  };
+}

--- a/runtime/llm/providers/google.ts
+++ b/runtime/llm/providers/google.ts
@@ -1,0 +1,64 @@
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from './provider.ts';
+
+function toContents(request: ProviderInvokeRequest): Array<{ role: 'user'; parts: Array<{ text: string }> }> {
+  return [{ role: 'user', parts: [{ text: JSON.stringify(request.promptEnvelope) }] }];
+}
+
+export function createGoogleProvider(input: {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+} = {}): LLMProvider {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  return {
+    providerId: 'google',
+    async invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+      const apiKey = env.GOOGLE_API_KEY;
+      if (!apiKey) {
+        throw new Error('LLM_PROVIDER_UNAVAILABLE: provider=google missing=GOOGLE_API_KEY');
+      }
+
+      const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(request.model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+      const response = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          systemInstruction: {
+            parts: [{ text: request.promptEnvelope.outputInstructions }]
+          },
+          contents: toContents(request),
+          generationConfig: request.maxTokens ? { maxOutputTokens: request.maxTokens } : undefined
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM_PROVIDER_ERROR: provider=google status=${response.status}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+      const first = candidates[0] as Record<string, unknown> | undefined;
+      const contentObj = first && typeof first === 'object' ? first.content as Record<string, unknown> : undefined;
+      const parts = contentObj && Array.isArray(contentObj.parts) ? contentObj.parts : [];
+      const content = parts
+        .map((part) => (part && typeof part === 'object' && typeof (part as Record<string, unknown>).text === 'string')
+          ? (part as Record<string, unknown>).text as string
+          : '')
+        .join('\n')
+        .trim();
+
+      const usage = payload.usageMetadata as Record<string, unknown> | undefined;
+      return {
+        model: request.model,
+        content,
+        usage: {
+          inputTokens: typeof usage?.promptTokenCount === 'number' ? usage.promptTokenCount : null,
+          outputTokens: typeof usage?.candidatesTokenCount === 'number' ? usage.candidatesTokenCount : null
+        }
+      };
+    }
+  };
+}

--- a/runtime/llm/providers/groq.ts
+++ b/runtime/llm/providers/groq.ts
@@ -1,0 +1,65 @@
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from './provider.ts';
+
+function toMessages(request: ProviderInvokeRequest): Array<{ role: 'system' | 'user'; content: string }> {
+  return [
+    {
+      role: 'system',
+      content: request.promptEnvelope.outputInstructions
+    },
+    {
+      role: 'user',
+      content: JSON.stringify(request.promptEnvelope)
+    }
+  ];
+}
+
+export function createGroqProvider(input: {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+} = {}): LLMProvider {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  return {
+    providerId: 'groq',
+    async invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+      const apiKey = env.GROQ_API_KEY;
+      if (!apiKey) {
+        throw new Error('LLM_PROVIDER_UNAVAILABLE: provider=groq missing=GROQ_API_KEY');
+      }
+
+      const response = await fetchImpl('https://api.groq.com/openai/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: request.model,
+          messages: toMessages(request),
+          max_tokens: request.maxTokens
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM_PROVIDER_ERROR: provider=groq status=${response.status}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const choices = Array.isArray(payload.choices) ? payload.choices : [];
+      const first = choices[0] as Record<string, unknown> | undefined;
+      const message = first && typeof first === 'object' ? first.message as Record<string, unknown> : undefined;
+      const content = message && typeof message.content === 'string' ? message.content : '';
+      const usage = payload.usage as Record<string, unknown> | undefined;
+
+      return {
+        model: request.model,
+        content,
+        usage: {
+          inputTokens: typeof usage?.prompt_tokens === 'number' ? usage.prompt_tokens : null,
+          outputTokens: typeof usage?.completion_tokens === 'number' ? usage.completion_tokens : null
+        }
+      };
+    }
+  };
+}

--- a/runtime/llm/providers/ollama.ts
+++ b/runtime/llm/providers/ollama.ts
@@ -1,0 +1,54 @@
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from './provider.ts';
+
+function toPrompt(request: ProviderInvokeRequest): string {
+  return [
+    `taskType=${request.promptEnvelope.taskType}`,
+    `constraints=${request.promptEnvelope.constraints.join(' | ')}`,
+    `requestedArtifacts=${request.promptEnvelope.requestedArtifacts.join(',')}`,
+    `outputInstructions=${request.promptEnvelope.outputInstructions}`,
+    `inputs=${JSON.stringify(request.promptEnvelope.inputs)}`
+  ].join('\n');
+}
+
+export function createOllamaProvider(input: {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+} = {}): LLMProvider {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  return {
+    providerId: 'ollama',
+    async invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+      const baseUrl = env.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434';
+      const response = await fetchImpl(`${baseUrl.replace(/\/$/, '')}/api/generate`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: request.model,
+          prompt: toPrompt(request),
+          stream: false,
+          options: request.maxTokens ? { num_predict: request.maxTokens } : undefined
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM_PROVIDER_ERROR: provider=ollama status=${response.status}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const content = typeof payload.response === 'string' ? payload.response : '';
+
+      return {
+        model: request.model,
+        content,
+        usage: {
+          inputTokens: typeof payload.prompt_eval_count === 'number' ? payload.prompt_eval_count : null,
+          outputTokens: typeof payload.eval_count === 'number' ? payload.eval_count : null
+        }
+      };
+    }
+  };
+}

--- a/runtime/llm/providers/openai.ts
+++ b/runtime/llm/providers/openai.ts
@@ -1,0 +1,59 @@
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from './provider.ts';
+
+function toMessages(request: ProviderInvokeRequest): Array<{ role: 'system' | 'user'; content: string }> {
+  return [
+    { role: 'system', content: request.promptEnvelope.outputInstructions },
+    { role: 'user', content: JSON.stringify(request.promptEnvelope) }
+  ];
+}
+
+export function createOpenAIProvider(input: {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+} = {}): LLMProvider {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  return {
+    providerId: 'openai',
+    async invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+      const apiKey = env.OPENAI_API_KEY;
+      if (!apiKey) {
+        throw new Error('LLM_PROVIDER_UNAVAILABLE: provider=openai missing=OPENAI_API_KEY');
+      }
+
+      const response = await fetchImpl('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: request.model,
+          messages: toMessages(request),
+          max_tokens: request.maxTokens
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM_PROVIDER_ERROR: provider=openai status=${response.status}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const choices = Array.isArray(payload.choices) ? payload.choices : [];
+      const first = choices[0] as Record<string, unknown> | undefined;
+      const message = first && typeof first === 'object' ? first.message as Record<string, unknown> : undefined;
+      const content = message && typeof message.content === 'string' ? message.content : '';
+      const usage = payload.usage as Record<string, unknown> | undefined;
+
+      return {
+        model: request.model,
+        content,
+        usage: {
+          inputTokens: typeof usage?.prompt_tokens === 'number' ? usage.prompt_tokens : null,
+          outputTokens: typeof usage?.completion_tokens === 'number' ? usage.completion_tokens : null
+        }
+      };
+    }
+  };
+}

--- a/runtime/llm/providers/openrouter.ts
+++ b/runtime/llm/providers/openrouter.ts
@@ -1,0 +1,59 @@
+import type { LLMProvider, ProviderInvokeRequest, ProviderInvokeResponse } from './provider.ts';
+
+function toMessages(request: ProviderInvokeRequest): Array<{ role: 'system' | 'user'; content: string }> {
+  return [
+    { role: 'system', content: request.promptEnvelope.outputInstructions },
+    { role: 'user', content: JSON.stringify(request.promptEnvelope) }
+  ];
+}
+
+export function createOpenRouterProvider(input: {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+} = {}): LLMProvider {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  return {
+    providerId: 'openrouter',
+    async invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse> {
+      const apiKey = env.OPENROUTER_API_KEY;
+      if (!apiKey) {
+        throw new Error('LLM_PROVIDER_UNAVAILABLE: provider=openrouter missing=OPENROUTER_API_KEY');
+      }
+
+      const response = await fetchImpl('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: request.model,
+          messages: toMessages(request),
+          max_tokens: request.maxTokens
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM_PROVIDER_ERROR: provider=openrouter status=${response.status}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const choices = Array.isArray(payload.choices) ? payload.choices : [];
+      const first = choices[0] as Record<string, unknown> | undefined;
+      const message = first && typeof first === 'object' ? first.message as Record<string, unknown> : undefined;
+      const content = message && typeof message.content === 'string' ? message.content : '';
+      const usage = payload.usage as Record<string, unknown> | undefined;
+
+      return {
+        model: request.model,
+        content,
+        usage: {
+          inputTokens: typeof usage?.prompt_tokens === 'number' ? usage.prompt_tokens : null,
+          outputTokens: typeof usage?.completion_tokens === 'number' ? usage.completion_tokens : null
+        }
+      };
+    }
+  };
+}

--- a/runtime/llm/providers/provider.ts
+++ b/runtime/llm/providers/provider.ts
@@ -1,0 +1,22 @@
+import type { LLMPromptEnvelope, LLMRequest } from '../types.ts';
+
+export interface ProviderInvokeRequest {
+  model: string;
+  outputMode: LLMRequest['outputMode'];
+  promptEnvelope: LLMPromptEnvelope;
+  maxTokens?: number;
+}
+
+export interface ProviderInvokeResponse {
+  model: string;
+  content: string;
+  usage?: {
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+  };
+}
+
+export interface LLMProvider {
+  providerId: string;
+  invoke(request: ProviderInvokeRequest): Promise<ProviderInvokeResponse>;
+}

--- a/runtime/llm/types.ts
+++ b/runtime/llm/types.ts
@@ -1,0 +1,34 @@
+export interface LLMPromptEnvelope {
+  missionId: string;
+  runId: string;
+  workflowNodeId: string;
+  teamId: string;
+  agentId: string;
+  taskType: string;
+  inputs: Record<string, unknown>;
+  constraints: string[];
+  requestedArtifacts: string[];
+  outputInstructions: string;
+}
+
+export interface LLMRequest {
+  taskType: string;
+  routeHint?: string;
+  providerPreference?: string | null;
+  outputMode: 'text' | 'json' | 'best-effort-json';
+  promptEnvelope: LLMPromptEnvelope;
+  maxTokens?: number;
+}
+
+export interface LLMResponse {
+  provider: string;
+  model: string;
+  outputMode: 'text' | 'json' | 'best-effort-json';
+  content: string;
+  parsedJson?: Record<string, unknown> | null;
+  usage?: {
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+  };
+  responseHash: string;
+}

--- a/runtime/output/__tests__/writers.test.ts
+++ b/runtime/output/__tests__/writers.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ArtifactWriter } from '../artifact-writer.ts';
+import { writeCsv } from '../csv-writer.ts';
+import { SourceRegistry } from '../source-registry.ts';
+import { writeXlsx } from '../xlsx-writer.ts';
+
+const tmpRoot = path.join('runtime', 'output', '__tests__', 'tmp-output');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('runtime output writers', () => {
+  it('T-E1 writes CSV with deterministic column and row ordering', () => {
+    const csv = writeCsv({
+      rows: [
+        { b: '2', a: 'x' },
+        { b: '1', a: 'z' }
+      ]
+    });
+
+    expect(csv).toBe([
+      'a,b',
+      'x,2',
+      'z,1',
+      ''
+    ].join('\n'));
+  });
+
+  it('T-E2 writes deterministic XLSX bytes independent of input sheet order', () => {
+    const first = writeXlsx({
+      sheets: [
+        { name: 'B', rows: [{ b: 2 }] },
+        { name: 'A', rows: [{ a: 1 }] }
+      ]
+    });
+
+    const second = writeXlsx({
+      sheets: [
+        { name: 'A', rows: [{ a: 1 }] },
+        { name: 'B', rows: [{ b: 2 }] }
+      ]
+    });
+
+    expect(Buffer.from(first).equals(Buffer.from(second))).toBe(true);
+    expect(Buffer.from(first).toString('utf8')).toContain('sheet name="A"');
+    expect(Buffer.from(first).toString('utf8')).toContain('sheet name="B"');
+  });
+
+  it('T-E3 source registry deduplicates and sorts lexicographically', () => {
+    const registry = new SourceRegistry();
+    registry.add({ url: 'https://b.example/x', firstSeenStep: 'step-2' });
+    registry.add({ url: 'https://a.example/x', firstSeenStep: 'step-5' });
+    registry.add({ url: 'https://b.example/x', firstSeenStep: 'step-1' });
+
+    expect(registry.list()).toEqual([
+      { url: 'https://a.example/x', domain: 'a.example', firstSeenStep: 'step-5' },
+      { url: 'https://b.example/x', domain: 'b.example', firstSeenStep: 'step-1' }
+    ]);
+  });
+
+  it('T-E4 artifact writer enforces declaration and deterministic naming', () => {
+    const writer = new ArtifactWriter(tmpRoot, [
+      { artifactId: 'report_csv', format: 'csv' },
+      { artifactId: 'report_xlsx', format: 'xlsx' },
+      { artifactId: 'manifest', format: 'artifact' }
+    ]);
+
+    const csvPath = writer.writeCsv({
+      missionId: 'mission',
+      runId: 'run',
+      artifactId: 'report_csv',
+      rows: [{ a: 1 }]
+    });
+
+    expect(csvPath).toBe(path.join(tmpRoot, 'mission', 'run', 'report_csv.csv'));
+    expect(fs.existsSync(csvPath)).toBe(true);
+
+    expect(() => writer.writeArtifact({
+      missionId: 'mission',
+      runId: 'run',
+      artifactId: 'unknown',
+      payload: { ok: true }
+    })).toThrow('ERR_ARTIFACT_UNDECLARED: unknown');
+  });
+});

--- a/runtime/output/artifact-writer.ts
+++ b/runtime/output/artifact-writer.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { writeCsv } from './csv-writer.ts';
+import { writeXlsx } from './xlsx-writer.ts';
+
+export type ArtifactFormat = 'csv' | 'xlsx' | 'artifact';
+
+export interface DeclaredArtifact {
+  artifactId: string;
+  format: ArtifactFormat;
+}
+
+function ensureRelativePath(value: string): string {
+  const normalized = value.replace(/\\/g, '/').replace(/^\/+/, '');
+  if (normalized.includes('..')) {
+    throw new Error(`ERR_ARTIFACT_PATH: invalid relative path ${value}`);
+  }
+  return normalized;
+}
+
+function extensionForFormat(format: ArtifactFormat): string {
+  if (format === 'csv') return 'csv';
+  if (format === 'xlsx') return 'xlsx';
+  return 'json';
+}
+
+export class ArtifactWriter {
+  private readonly declared = new Map<string, DeclaredArtifact>();
+
+  constructor(
+    private readonly baseDir: string,
+    declaredArtifacts: DeclaredArtifact[]
+  ) {
+    for (const artifact of [...declaredArtifacts].sort((left, right) => left.artifactId.localeCompare(right.artifactId))) {
+      this.declared.set(artifact.artifactId, artifact);
+    }
+  }
+
+  resolveArtifactPath(input: {
+    missionId: string;
+    runId: string;
+    artifactId: string;
+  }): string {
+    const declared = this.declared.get(input.artifactId);
+    if (!declared) {
+      throw new Error(`ERR_ARTIFACT_UNDECLARED: ${input.artifactId}`);
+    }
+
+    const ext = extensionForFormat(declared.format);
+    const relative = ensureRelativePath(path.join(input.missionId, input.runId, `${input.artifactId}.${ext}`));
+    return path.join(this.baseDir, relative);
+  }
+
+  writeCsv(input: {
+    missionId: string;
+    runId: string;
+    artifactId: string;
+    rows: Array<Record<string, unknown>>;
+    columns?: string[];
+  }): string {
+    const declared = this.declared.get(input.artifactId);
+    if (!declared || declared.format !== 'csv') {
+      throw new Error(`ERR_ARTIFACT_UNDECLARED: ${input.artifactId}`);
+    }
+
+    const filePath = this.resolveArtifactPath(input);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, writeCsv({ rows: input.rows, columns: input.columns }), 'utf8');
+    return filePath;
+  }
+
+  writeXlsx(input: {
+    missionId: string;
+    runId: string;
+    artifactId: string;
+    sheets: Array<{ name: string; rows: Array<Record<string, unknown>>; columns?: string[] }>;
+  }): string {
+    const declared = this.declared.get(input.artifactId);
+    if (!declared || declared.format !== 'xlsx') {
+      throw new Error(`ERR_ARTIFACT_UNDECLARED: ${input.artifactId}`);
+    }
+
+    const filePath = this.resolveArtifactPath(input);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, writeXlsx({ sheets: input.sheets }));
+    return filePath;
+  }
+
+  writeArtifact(input: {
+    missionId: string;
+    runId: string;
+    artifactId: string;
+    payload: Record<string, unknown>;
+  }): string {
+    const declared = this.declared.get(input.artifactId);
+    if (!declared) {
+      throw new Error(`ERR_ARTIFACT_UNDECLARED: ${input.artifactId}`);
+    }
+
+    const filePath = this.resolveArtifactPath(input);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(input.payload, null, 2)}\n`, 'utf8');
+    return filePath;
+  }
+}

--- a/runtime/output/csv-writer.ts
+++ b/runtime/output/csv-writer.ts
@@ -1,0 +1,54 @@
+function normalizeCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.replace(/\r\n?/g, '\n');
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function escapeCsv(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function collectColumns(rows: Array<Record<string, unknown>>): string[] {
+  const all = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      all.add(key);
+    }
+  }
+  return [...all].sort((left, right) => left.localeCompare(right));
+}
+
+function stableRowSort(rows: Array<Record<string, unknown>>, columns: string[]): Array<Record<string, unknown>> {
+  return [...rows].sort((left, right) => {
+    const leftKey = columns.map((column) => normalizeCell(left[column])).join('\u0001');
+    const rightKey = columns.map((column) => normalizeCell(right[column])).join('\u0001');
+    return leftKey.localeCompare(rightKey);
+  });
+}
+
+export function writeCsv(input: {
+  rows: Array<Record<string, unknown>>;
+  columns?: string[];
+}): string {
+  const columns = input.columns && input.columns.length > 0
+    ? [...new Set(input.columns)].sort((left, right) => left.localeCompare(right))
+    : collectColumns(input.rows);
+
+  const sortedRows = stableRowSort(input.rows, columns);
+  const lines = [
+    columns.map(escapeCsv).join(','),
+    ...sortedRows.map((row) => columns.map((column) => escapeCsv(normalizeCell(row[column]))).join(','))
+  ];
+
+  return `${lines.join('\n')}\n`;
+}

--- a/runtime/output/source-registry.ts
+++ b/runtime/output/source-registry.ts
@@ -1,0 +1,54 @@
+function toDomain(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+export interface SourceEntry {
+  url: string;
+  domain: string;
+  firstSeenStep: string;
+}
+
+export class SourceRegistry {
+  private readonly byUrl = new Map<string, SourceEntry>();
+
+  add(input: { url: string; firstSeenStep: string }): void {
+    const url = input.url.trim();
+    if (url.length === 0) {
+      return;
+    }
+
+    const next: SourceEntry = {
+      url,
+      domain: toDomain(url),
+      firstSeenStep: input.firstSeenStep
+    };
+
+    const previous = this.byUrl.get(url);
+    if (!previous) {
+      this.byUrl.set(url, next);
+      return;
+    }
+
+    if (next.firstSeenStep.localeCompare(previous.firstSeenStep) < 0) {
+      this.byUrl.set(url, next);
+    }
+  }
+
+  list(): SourceEntry[] {
+    return [...this.byUrl.values()].sort((left, right) => {
+      const urlCompare = left.url.localeCompare(right.url);
+      if (urlCompare !== 0) {
+        return urlCompare;
+      }
+      const domainCompare = left.domain.localeCompare(right.domain);
+      if (domainCompare !== 0) {
+        return domainCompare;
+      }
+      return left.firstSeenStep.localeCompare(right.firstSeenStep);
+    });
+  }
+}

--- a/runtime/output/xlsx-writer.ts
+++ b/runtime/output/xlsx-writer.ts
@@ -1,0 +1,258 @@
+import { TextEncoder } from 'node:util';
+
+type Sheet = {
+  name: string;
+  rows: Array<Record<string, unknown>>;
+  columns?: string[];
+};
+
+const encoder = new TextEncoder();
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function normalizeCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function columnName(index: number): string {
+  let n = index + 1;
+  let name = '';
+  while (n > 0) {
+    const mod = (n - 1) % 26;
+    name = String.fromCharCode(65 + mod) + name;
+    n = Math.floor((n - mod) / 26);
+  }
+  return name;
+}
+
+function collectColumns(rows: Array<Record<string, unknown>>, explicit?: string[]): string[] {
+  if (explicit && explicit.length > 0) {
+    return [...new Set(explicit)].sort((left, right) => left.localeCompare(right));
+  }
+
+  const keys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      keys.add(key);
+    }
+  }
+
+  return [...keys].sort((left, right) => left.localeCompare(right));
+}
+
+function sortRows(rows: Array<Record<string, unknown>>, columns: string[]): Array<Record<string, unknown>> {
+  return [...rows].sort((left, right) => {
+    const leftKey = columns.map((column) => normalizeCell(left[column])).join('\u0001');
+    const rightKey = columns.map((column) => normalizeCell(right[column])).join('\u0001');
+    return leftKey.localeCompare(rightKey);
+  });
+}
+
+function buildSheetXml(rows: Array<Record<string, unknown>>, columns: string[]): string {
+  const sortedRows = sortRows(rows, columns);
+  const allRows = [
+    Object.fromEntries(columns.map((column) => [column, column])),
+    ...sortedRows
+  ];
+
+  const sheetRows = allRows
+    .map((row, rowIndex) => {
+      const r = rowIndex + 1;
+      const cells = columns
+        .map((column, columnIndex) => {
+          const ref = `${columnName(columnIndex)}${r}`;
+          const value = escapeXml(normalizeCell(row[column]));
+          return `<c r="${ref}" t="inlineStr"><is><t>${value}</t></is></c>`;
+        })
+        .join('');
+      return `<row r="${r}">${cells}</row>`;
+    })
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>${sheetRows}</sheetData></worksheet>`;
+}
+
+function crc32(buffer: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i += 1) {
+    crc ^= buffer[i];
+    for (let j = 0; j < 8; j += 1) {
+      const mask = -(crc & 1);
+      crc = (crc >>> 1) ^ (0xedb88320 & mask);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(): { date: number; time: number } {
+  const year = 1980;
+  const month = 1;
+  const day = 1;
+  const hours = 0;
+  const minutes = 0;
+  const seconds = 0;
+
+  const date = ((year - 1980) << 9) | (month << 5) | day;
+  const time = (hours << 11) | (minutes << 5) | Math.floor(seconds / 2);
+  return { date, time };
+}
+
+function makeZip(entries: Array<{ name: string; data: Uint8Array }>): Uint8Array {
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  const dt = dosDateTime();
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = encoder.encode(entry.name);
+    const data = entry.data;
+    const crc = crc32(data);
+
+    const local = new Uint8Array(30 + nameBytes.length + data.length);
+    const localView = new DataView(local.buffer);
+    localView.setUint32(0, 0x04034b50, true);
+    localView.setUint16(4, 20, true);
+    localView.setUint16(6, 0, true);
+    localView.setUint16(8, 0, true);
+    localView.setUint16(10, dt.time, true);
+    localView.setUint16(12, dt.date, true);
+    localView.setUint32(14, crc, true);
+    localView.setUint32(18, data.length, true);
+    localView.setUint32(22, data.length, true);
+    localView.setUint16(26, nameBytes.length, true);
+    localView.setUint16(28, 0, true);
+    local.set(nameBytes, 30);
+    local.set(data, 30 + nameBytes.length);
+    localParts.push(local);
+
+    const central = new Uint8Array(46 + nameBytes.length);
+    const centralView = new DataView(central.buffer);
+    centralView.setUint32(0, 0x02014b50, true);
+    centralView.setUint16(4, 20, true);
+    centralView.setUint16(6, 20, true);
+    centralView.setUint16(8, 0, true);
+    centralView.setUint16(10, 0, true);
+    centralView.setUint16(12, dt.time, true);
+    centralView.setUint16(14, dt.date, true);
+    centralView.setUint32(16, crc, true);
+    centralView.setUint32(20, data.length, true);
+    centralView.setUint32(24, data.length, true);
+    centralView.setUint16(28, nameBytes.length, true);
+    centralView.setUint16(30, 0, true);
+    centralView.setUint16(32, 0, true);
+    centralView.setUint16(34, 0, true);
+    centralView.setUint16(36, 0, true);
+    centralView.setUint32(38, 0, true);
+    centralView.setUint32(42, offset, true);
+    central.set(nameBytes, 46);
+    centralParts.push(central);
+
+    offset += local.length;
+  }
+
+  const centralSize = centralParts.reduce((sum, part) => sum + part.length, 0);
+  const centralOffset = offset;
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(4, 0, true);
+  endView.setUint16(6, 0, true);
+  endView.setUint16(8, entries.length, true);
+  endView.setUint16(10, entries.length, true);
+  endView.setUint32(12, centralSize, true);
+  endView.setUint32(16, centralOffset, true);
+  endView.setUint16(20, 0, true);
+
+  const total = offset + centralSize + end.length;
+  const out = new Uint8Array(total);
+  let cursor = 0;
+  for (const part of localParts) {
+    out.set(part, cursor);
+    cursor += part.length;
+  }
+  for (const part of centralParts) {
+    out.set(part, cursor);
+    cursor += part.length;
+  }
+  out.set(end, cursor);
+
+  return out;
+}
+
+export function writeXlsx(input: {
+  sheets: Sheet[];
+}): Uint8Array {
+  const orderedSheets = [...input.sheets].sort((left, right) => left.name.localeCompare(right.name));
+
+  const workbookXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">`
+    + `<sheets>${orderedSheets.map((sheet, index) => `<sheet name="${escapeXml(sheet.name)}" sheetId="${index + 1}" r:id="rId${index + 1}"/>`).join('')}</sheets>`
+    + `</workbook>`;
+
+  const workbookRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`
+    + orderedSheets.map((_, index) => `<Relationship Id="rId${index + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${index + 1}.xml"/>`).join('')
+    + `<Relationship Id="rId${orderedSheets.length + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`
+    + `</Relationships>`;
+
+  const rootRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">`
+    + `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>`
+    + `</Relationships>`;
+
+  const stylesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">`
+    + `<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>`
+    + `<fills count="1"><fill><patternFill patternType="none"/></fill></fills>`
+    + `<borders count="1"><border/></borders>`
+    + `<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>`
+    + `<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>`
+    + `</styleSheet>`;
+
+  const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">`
+    + `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>`
+    + `<Default Extension="xml" ContentType="application/xml"/>`
+    + `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>`
+    + `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>`
+    + orderedSheets.map((_, index) => `<Override PartName="/xl/worksheets/sheet${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`).join('')
+    + `</Types>`;
+
+  const entries: Array<{ name: string; data: Uint8Array }> = [
+    { name: '[Content_Types].xml', data: encoder.encode(contentTypes) },
+    { name: '_rels/.rels', data: encoder.encode(rootRelsXml) },
+    { name: 'xl/workbook.xml', data: encoder.encode(workbookXml) },
+    { name: 'xl/_rels/workbook.xml.rels', data: encoder.encode(workbookRelsXml) },
+    { name: 'xl/styles.xml', data: encoder.encode(stylesXml) }
+  ];
+
+  for (let i = 0; i < orderedSheets.length; i += 1) {
+    const sheet = orderedSheets[i];
+    const columns = collectColumns(sheet.rows, sheet.columns);
+    const xml = buildSheetXml(sheet.rows, columns);
+    entries.push({
+      name: `xl/worksheets/sheet${i + 1}.xml`,
+      data: encoder.encode(xml)
+    });
+  }
+
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  return makeZip(entries);
+}

--- a/runtime/runtime-task-executor.ts
+++ b/runtime/runtime-task-executor.ts
@@ -1,0 +1,212 @@
+import type { WorkflowTaskExecutor } from '../control-plane/workflows/workflow-runner.ts';
+import { createLLMGateway, type LLMGateway } from './llm/gateway.ts';
+import type { LLMRequest } from './llm/types.ts';
+import { ArtifactWriter } from './output/artifact-writer.ts';
+import { executeTool } from './tools/tool-registry.ts';
+
+export type RuntimeTaskType =
+  | 'llm.generate'
+  | 'tool.web_search'
+  | 'tool.page_fetch'
+  | 'tool.reader_extract'
+  | 'output.write_csv'
+  | 'output.write_xlsx'
+  | 'output.write_artifact';
+
+function ensureRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item) => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function toPromptEnvelope(input: {
+  missionId: string;
+  runId: string;
+  workflowNodeId: string;
+  taskType: string;
+  payload: Record<string, unknown>;
+  missionContextMemory?: Record<string, unknown>;
+}): LLMRequest['promptEnvelope'] {
+  const memory = ensureRecord(input.missionContextMemory);
+  const teamId = typeof memory.teamId === 'string' ? memory.teamId : 'unknown-team';
+  const agentId = typeof memory.agentId === 'string' ? memory.agentId : 'unknown-agent';
+
+  return {
+    missionId: input.missionId,
+    runId: input.runId,
+    workflowNodeId: input.workflowNodeId,
+    teamId,
+    agentId,
+    taskType: input.taskType,
+    inputs: ensureRecord(input.payload.inputs),
+    constraints: asStringArray(input.payload.constraints),
+    requestedArtifacts: asStringArray(input.payload.requestedArtifacts),
+    outputInstructions: typeof input.payload.outputInstructions === 'string'
+      ? input.payload.outputInstructions
+      : ''
+  };
+}
+
+export async function executeRuntimeTask(input: {
+  taskType: RuntimeTaskType;
+  payload: Record<string, unknown>;
+  missionId: string;
+  runId: string;
+  workflowNodeId: string;
+  missionContextMemory?: Record<string, unknown>;
+  llmGateway: LLMGateway;
+  artifactWriter: ArtifactWriter;
+}): Promise<Record<string, unknown>> {
+  if (input.taskType === 'llm.generate') {
+    const request: LLMRequest = {
+      taskType: typeof input.payload.taskType === 'string' ? input.payload.taskType : 'default',
+      routeHint: typeof input.payload.routeHint === 'string' ? input.payload.routeHint : undefined,
+      providerPreference: typeof input.payload.providerPreference === 'string'
+        ? input.payload.providerPreference
+        : null,
+      outputMode: input.payload.outputMode === 'json' || input.payload.outputMode === 'best-effort-json'
+        ? input.payload.outputMode
+        : 'text',
+      maxTokens: typeof input.payload.maxTokens === 'number' ? input.payload.maxTokens : undefined,
+      promptEnvelope: toPromptEnvelope({
+        missionId: input.missionId,
+        runId: input.runId,
+        workflowNodeId: input.workflowNodeId,
+        taskType: typeof input.payload.taskType === 'string' ? input.payload.taskType : 'default',
+        payload: input.payload,
+        missionContextMemory: input.missionContextMemory
+      })
+    };
+
+    return input.llmGateway.invoke(request) as unknown as Record<string, unknown>;
+  }
+
+  if (input.taskType === 'tool.web_search') {
+    const response = await executeTool({
+      toolId: 'web_search',
+      action: 'search',
+      input: input.payload
+    });
+    if (!response.ok) {
+      throw new Error(response.errors.join('; '));
+    }
+    return ensureRecord(response.data);
+  }
+
+  if (input.taskType === 'tool.page_fetch') {
+    const response = await executeTool({
+      toolId: 'page_fetch',
+      action: 'fetch',
+      input: input.payload
+    });
+    if (!response.ok) {
+      throw new Error(response.errors.join('; '));
+    }
+    return ensureRecord(response.data);
+  }
+
+  if (input.taskType === 'tool.reader_extract') {
+    const response = await executeTool({
+      toolId: 'reader_extract',
+      action: 'extract',
+      input: input.payload
+    });
+    if (!response.ok) {
+      throw new Error(response.errors.join('; '));
+    }
+    return ensureRecord(response.data);
+  }
+
+  if (input.taskType === 'output.write_csv') {
+    const artifactId = typeof input.payload.artifactId === 'string' ? input.payload.artifactId : '';
+    const rows = Array.isArray(input.payload.rows) ? input.payload.rows as Array<Record<string, unknown>> : [];
+    const columns = Array.isArray(input.payload.columns)
+      ? input.payload.columns.filter((entry): entry is string => typeof entry === 'string')
+      : undefined;
+
+    const filePath = input.artifactWriter.writeCsv({
+      missionId: input.missionId,
+      runId: input.runId,
+      artifactId,
+      rows,
+      columns
+    });
+    return { filePath };
+  }
+
+  if (input.taskType === 'output.write_xlsx') {
+    const artifactId = typeof input.payload.artifactId === 'string' ? input.payload.artifactId : '';
+    const rawSheets = Array.isArray(input.payload.sheets) ? input.payload.sheets : [];
+    const sheets = rawSheets
+      .filter((entry) => entry && typeof entry === 'object')
+      .map((entry) => {
+        const sheet = entry as Record<string, unknown>;
+        const name = typeof sheet.name === 'string' ? sheet.name : 'Sheet1';
+        const rows = Array.isArray(sheet.rows) ? sheet.rows as Array<Record<string, unknown>> : [];
+        const columns = Array.isArray(sheet.columns)
+          ? sheet.columns.filter((column): column is string => typeof column === 'string')
+          : undefined;
+        return { name, rows, columns };
+      });
+
+    const filePath = input.artifactWriter.writeXlsx({
+      missionId: input.missionId,
+      runId: input.runId,
+      artifactId,
+      sheets
+    });
+    return { filePath };
+  }
+
+  if (input.taskType === 'output.write_artifact') {
+    const artifactId = typeof input.payload.artifactId === 'string' ? input.payload.artifactId : '';
+    const payload = ensureRecord(input.payload.payload);
+    const filePath = input.artifactWriter.writeArtifact({
+      missionId: input.missionId,
+      runId: input.runId,
+      artifactId,
+      payload
+    });
+
+    return { filePath };
+  }
+
+  throw new Error(`ERR_RUNTIME_TASK_UNSUPPORTED: ${input.taskType}`);
+}
+
+export function createWorkflowDagTaskExecutor(input: {
+  runId: string;
+  llmGateway?: LLMGateway;
+  artifactWriter: ArtifactWriter;
+}): WorkflowTaskExecutor {
+  const llmGateway = input.llmGateway ?? createLLMGateway();
+
+  return {
+    async execute(context) {
+      const taskInputsByNode = ensureRecord(context.missionContextMemory?.taskInputsByNode);
+      const payload = ensureRecord(taskInputsByNode[context.workflowNodeId]);
+      return executeRuntimeTask({
+        taskType: context.task as RuntimeTaskType,
+        payload,
+        missionId: context.missionId,
+        runId: input.runId,
+        workflowNodeId: context.workflowNodeId,
+        missionContextMemory: context.missionContextMemory,
+        llmGateway,
+        artifactWriter: input.artifactWriter
+      });
+    }
+  };
+}

--- a/runtime/tools/__tests__/adapters.test.ts
+++ b/runtime/tools/__tests__/adapters.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { pageFetch } from '../adapters/page-fetch.ts';
+import { readerExtract } from '../adapters/reader-extract.ts';
+import { normalizeWebSearchResults, webSearch } from '../adapters/web-search.ts';
+
+describe('runtime tools adapters', () => {
+  it('T-T1 normalizes web search results with stable rank ordering', () => {
+    const normalized = normalizeWebSearchResults({
+      query: 'smart funds',
+      candidates: [
+        { title: ' B ', url: 'https://b.example/path', snippet: ' second ' },
+        { title: ' A ', url: 'https://a.example/path', snippet: ' first ' }
+      ]
+    });
+
+    expect(normalized.query).toBe('smart funds');
+    expect(normalized.results.map((entry) => entry.rank)).toEqual([1, 2]);
+    expect(normalized.results[0].domain).toBe('b.example');
+    expect(normalized.results[1].domain).toBe('a.example');
+  });
+
+  it('T-T2 returns stable shape for page fetch', async () => {
+    const result = await pageFetch({
+      url: 'https://example.com',
+      fetchImpl: async () => ({
+        status: 200,
+        url: 'https://example.com/final',
+        headers: { get: () => 'text/html; charset=utf-8' },
+        text: async () => '<html>\r\n<body>x</body>\r\n</html>'
+      } as unknown as Response)
+    });
+
+    expect(result).toEqual({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      finalUrl: 'https://example.com/final',
+      html: '<html>\n<body>x</body>\n</html>'
+    });
+  });
+
+  it('T-T3 cleans reader extraction output by removing nav/scripts and normalizing whitespace', () => {
+    const result = readerExtract({
+      html: [
+        '<html><head><title>  Demo Title </title><script>bad()</script></head>',
+        '<body><nav>menu</nav><main><p>Hello   world</p><p>Next line</p></main></body></html>'
+      ].join('')
+    });
+
+    expect(result).toEqual({
+      title: 'Demo Title',
+      body: 'Hello world\nNext line'
+    });
+  });
+
+  it('T-T4 web search adapter output is deterministic with mocked network', async () => {
+    const html = [
+      '<html><body>',
+      '<div class="result"><a href="https://z.example/1">Zed</a></div>',
+      '<div class="result"><a href="https://a.example/1">Alpha</a></div>',
+      '</body></html>'
+    ].join('');
+
+    const result = await webSearch({
+      query: 'q',
+      fetchImpl: async () => ({
+        text: async () => html
+      } as unknown as Response)
+    });
+
+    const rows = (result.results as Array<{ rank: number; title: string; url: string }>);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((entry) => entry.rank)).toEqual([1, 2]);
+    expect(rows[0].url).toBe('https://z.example/1');
+    expect(rows[1].url).toBe('https://a.example/1');
+  });
+});

--- a/runtime/tools/__tests__/tool-registry.test.ts
+++ b/runtime/tools/__tests__/tool-registry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { executeTool, listToolAdapters } from '../tool-registry.ts';
+
+describe('runtime tool registry', () => {
+  it('T-T5 keeps adapters listed in stable sorted order', () => {
+    const keys = listToolAdapters().map((entry) => `${entry.toolId}:${entry.action}`);
+    expect(keys).toEqual([
+      'page_fetch:fetch',
+      'reader_extract:extract',
+      'web_search:search'
+    ]);
+  });
+
+  it('T-T6 returns deterministic error when adapter is missing', async () => {
+    const response = await executeTool({
+      toolId: 'missing',
+      action: 'x',
+      input: {}
+    });
+
+    expect(response).toEqual({
+      toolId: 'missing',
+      action: 'x',
+      ok: false,
+      data: null,
+      errors: ['ERR_TOOL_NOT_FOUND: missing:x']
+    });
+  });
+});

--- a/runtime/tools/adapters/page-fetch.ts
+++ b/runtime/tools/adapters/page-fetch.ts
@@ -1,0 +1,24 @@
+function normalizeHtml(value: string): string {
+  return value.replace(/\r\n?/g, '\n');
+}
+
+export async function pageFetch(input: {
+  url: string;
+  fetchImpl?: typeof fetch;
+}): Promise<Record<string, unknown>> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(input.url, {
+    method: 'GET',
+    headers: {
+      'user-agent': 'smartfunds-runtime-tools/1.0'
+    }
+  });
+
+  const html = normalizeHtml(await response.text());
+  return {
+    status: response.status,
+    contentType: response.headers.get('content-type') ?? '',
+    finalUrl: response.url || input.url,
+    html
+  };
+}

--- a/runtime/tools/adapters/reader-extract.ts
+++ b/runtime/tools/adapters/reader-extract.ts
@@ -1,0 +1,48 @@
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function normalizeWhitespace(value: string): string {
+  return value
+    .replace(/\r\n?/g, '\n')
+    .replace(/[\t ]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+function extractTitle(html: string): string {
+  const matched = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return matched ? normalizeWhitespace(decodeHtmlEntities(matched[1].replace(/<[^>]+>/g, ' '))) : '';
+}
+
+export function readerExtract(input: { html: string }): Record<string, unknown> {
+  const withoutBlocked = input.html
+    .replace(/<head[\s\S]*?<\/head>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<nav[\s\S]*?<\/nav>/gi, ' ')
+    .replace(/<header[\s\S]*?<\/header>/gi, ' ')
+    .replace(/<footer[\s\S]*?<\/footer>/gi, ' ')
+    .replace(/<aside[\s\S]*?<\/aside>/gi, ' ');
+
+  const bodyRaw = withoutBlocked
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\s*\/p\s*>/gi, '\n')
+    .replace(/<\s*\/div\s*>/gi, '\n')
+    .replace(/<\s*\/li\s*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+
+  return {
+    title: extractTitle(input.html),
+    body: normalizeWhitespace(decodeHtmlEntities(bodyRaw))
+  };
+}

--- a/runtime/tools/adapters/web-search.ts
+++ b/runtime/tools/adapters/web-search.ts
@@ -1,0 +1,113 @@
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function toDomain(urlString: string): string {
+  try {
+    return new URL(urlString).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+function stripTags(value: string): string {
+  return normalizeWhitespace(value.replace(/<[^>]+>/g, ' '));
+}
+
+function extractCandidatesFromHtml(html: string): Array<{ title: string; url: string; snippet: string }> {
+  const resultBlockRegex = /<div[^>]*class=["'][^"']*result[^"']*["'][^>]*>([\s\S]*?)<\/div>/gi;
+  const blocks = [...html.matchAll(resultBlockRegex)].map((match) => match[1]);
+
+  const candidates = blocks.map((block) => {
+    const urlMatch = block.match(/<a[^>]*href=["']([^"']+)["'][^>]*>/i);
+    const titleMatch = block.match(/<a[^>]*>([\s\S]*?)<\/a>/i);
+    const snippetMatch = block.match(/<a[^>]*>([\s\S]*?)<\/a>[\s\S]*?<\/a>[\s\S]*?<a[^>]*>([\s\S]*?)<\/a>/i);
+
+    return {
+      title: stripTags(titleMatch?.[1] ?? ''),
+      url: normalizeWhitespace(urlMatch?.[1] ?? ''),
+      snippet: stripTags(snippetMatch?.[2] ?? '')
+    };
+  });
+
+  const fallbackAnchors = [...html.matchAll(/<a[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi)]
+    .map((entry) => ({
+      title: stripTags(entry[2] ?? ''),
+      url: normalizeWhitespace(entry[1] ?? ''),
+      snippet: ''
+    }));
+
+  return (candidates.length > 0 ? candidates : fallbackAnchors)
+    .filter((entry) => entry.url.length > 0 && entry.title.length > 0);
+}
+
+export function normalizeWebSearchResults(input: {
+  query: string;
+  candidates: Array<{ title: string; url: string; snippet: string }>;
+  limit?: number;
+}): {
+  query: string;
+  results: Array<{
+    rank: number;
+    title: string;
+    url: string;
+    snippet: string;
+    domain: string;
+  }>;
+} {
+  const normalized = input.candidates
+    .map((candidate) => ({
+      title: normalizeWhitespace(candidate.title),
+      url: normalizeWhitespace(candidate.url),
+      snippet: normalizeWhitespace(candidate.snippet),
+      domain: toDomain(candidate.url)
+    }))
+    .filter((candidate) => candidate.url.length > 0 && candidate.title.length > 0)
+    .map((candidate, index) => ({
+      rank: index + 1,
+      ...candidate
+    }));
+
+  const limited = typeof input.limit === 'number' && input.limit > 0
+    ? normalized.slice(0, input.limit)
+    : normalized;
+
+  const stable = [...limited].sort((left, right) => left.rank - right.rank);
+
+  return {
+    query: input.query,
+    results: stable
+  };
+}
+
+export async function webSearch(input: {
+  query: string;
+  region?: string;
+  safeMode?: boolean;
+  limit?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<Record<string, unknown>> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const endpoint = new URL('https://duckduckgo.com/html/');
+  endpoint.searchParams.set('q', input.query);
+  if (input.region) {
+    endpoint.searchParams.set('kl', input.region);
+  }
+  if (input.safeMode) {
+    endpoint.searchParams.set('kp', '1');
+  }
+
+  const response = await fetchImpl(endpoint.toString(), {
+    method: 'GET',
+    headers: {
+      'user-agent': 'smartfunds-runtime-tools/1.0'
+    }
+  });
+
+  const html = await response.text();
+  return normalizeWebSearchResults({
+    query: input.query,
+    candidates: extractCandidatesFromHtml(html),
+    limit: input.limit
+  }) as unknown as Record<string, unknown>;
+}

--- a/runtime/tools/tool-registry.ts
+++ b/runtime/tools/tool-registry.ts
@@ -1,0 +1,91 @@
+import type { ToolAdapter, ToolRequest, ToolResponse } from './types.ts';
+import { pageFetch } from './adapters/page-fetch.ts';
+import { readerExtract } from './adapters/reader-extract.ts';
+import { webSearch } from './adapters/web-search.ts';
+
+const adapters: readonly ToolAdapter[] = [
+  {
+    toolId: 'web_search',
+    action: 'search',
+    async execute(input) {
+      const query = typeof input.query === 'string' ? input.query : '';
+      if (query.trim().length === 0) {
+        throw new Error('ERR_TOOL_INPUT: web_search query is required');
+      }
+
+      return webSearch({
+        query,
+        region: typeof input.region === 'string' ? input.region : undefined,
+        safeMode: input.safeMode === true,
+        limit: typeof input.limit === 'number' ? input.limit : undefined
+      });
+    }
+  },
+  {
+    toolId: 'page_fetch',
+    action: 'fetch',
+    async execute(input) {
+      const url = typeof input.url === 'string' ? input.url : '';
+      if (url.trim().length === 0) {
+        throw new Error('ERR_TOOL_INPUT: page_fetch url is required');
+      }
+      return pageFetch({ url });
+    }
+  },
+  {
+    toolId: 'reader_extract',
+    action: 'extract',
+    async execute(input) {
+      const html = typeof input.html === 'string' ? input.html : '';
+      if (html.trim().length === 0) {
+        throw new Error('ERR_TOOL_INPUT: reader_extract html is required');
+      }
+      return readerExtract({ html });
+    }
+  }
+] as const;
+
+const registry = new Map<string, ToolAdapter>(
+  adapters.map((adapter) => [`${adapter.toolId}:${adapter.action}`, adapter])
+);
+
+export function listToolAdapters(): ToolAdapter[] {
+  return [...adapters].sort((left, right) => {
+    const keyLeft = `${left.toolId}:${left.action}`;
+    const keyRight = `${right.toolId}:${right.action}`;
+    return keyLeft.localeCompare(keyRight);
+  });
+}
+
+export async function executeTool(request: ToolRequest): Promise<ToolResponse> {
+  const key = `${request.toolId}:${request.action}`;
+  const adapter = registry.get(key);
+  if (!adapter) {
+    return {
+      toolId: request.toolId,
+      action: request.action,
+      ok: false,
+      data: null,
+      errors: [`ERR_TOOL_NOT_FOUND: ${key}`]
+    };
+  }
+
+  try {
+    const data = await adapter.execute(request.input);
+    return {
+      toolId: request.toolId,
+      action: request.action,
+      ok: true,
+      data,
+      errors: []
+    };
+  } catch (error) {
+    return {
+      toolId: request.toolId,
+      action: request.action,
+      ok: false,
+      data: null,
+      errors: [error instanceof Error ? error.message : String(error)]
+    };
+  }
+}

--- a/runtime/tools/types.ts
+++ b/runtime/tools/types.ts
@@ -1,0 +1,19 @@
+export interface ToolRequest {
+  toolId: string;
+  action: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResponse {
+  toolId: string;
+  action: string;
+  ok: boolean;
+  data: Record<string, unknown> | null;
+  errors: string[];
+}
+
+export interface ToolAdapter {
+  toolId: string;
+  action: string;
+  execute(input: Record<string, unknown>): Promise<Record<string, unknown>>;
+}


### PR DESCRIPTION
tier-3

```evidence
Risk Tier: 3
Justification: Adds deterministic multi-provider LLM gateway foundation, public-web research adapters, deterministic CSV/XLSX output writers, and wires new runtime task types into the live control-plane adapter dispatch path.
Affected Paths: control-plane/llm/**, control-plane/tasks/**, runtime/**, docs/architecture/multi-provider-gateway.md, docs/runbooks/cheap-research-missions.md
Tests Added: runtime/llm/__tests__/gateway.test.ts, runtime/llm/__tests__/provider-status.test.ts, runtime/tools/__tests__/adapters.test.ts, runtime/tools/__tests__/tool-registry.test.ts, runtime/output/__tests__/writers.test.ts, runtime/__tests__/research-workflow.integration.test.ts, control-plane/tasks/tests/adapter-registry.test.ts
Determinism Statement: Uses canonicalStringify + sha256 for stable hashing, preserves stable ordering/normalization, keeps tests hermetic with mocked network behavior, and introduces only additive runtime/control-plane wiring.
```