### PR TITLE
Sprint 84: Slack Mission Control Interface

### DIFF
--- a/runtime/__tests__/slack-mission.integration.test.ts
+++ b/runtime/__tests__/slack-mission.integration.test.ts
@@ -1,0 +1,249 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMissionService } from '../../control-plane/operator/mission-service.ts';
+import { createWorkflowService } from '../../control-plane/operator/workflow-service.ts';
+import { createMissionController } from '../mission/mission-controller.ts';
+import { createSlackNotifier } from '../adapters/slack/slack-notifier.ts';
+import { createSlackRouter } from '../adapters/slack/slack-router.ts';
+import { registerSlackEvents } from '../adapters/slack/slack-events.ts';
+
+const tmpRoot = path.join('runtime', '__tests__', 'tmp-s84-slack');
+const journalRoot = path.join(tmpRoot, 'journal');
+const missionsDir = path.join(tmpRoot, 'missions');
+const teamsDir = path.join(tmpRoot, 'teams');
+const agentsDir = path.join(tmpRoot, 'agents');
+const workflowsDir = path.join(tmpRoot, 'workflows');
+const missionId = 's84-slack-research';
+
+function writeJson(dir: string, fileName: string, value: unknown): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function resetFixtures(): void {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+
+  writeJson(missionsDir, `${missionId}.json`, {
+    missionId,
+    projectId: 'smartfunds-core',
+    teamId: 'smartfunds-research-team',
+    workflowId: 's84-slack-workflow',
+    objective: 'Slack integration mission.',
+    successCriteria: ['Run through mission service.'],
+    deliverables: ['report'],
+    initialContext: {
+      topic: 'slack'
+    }
+  });
+
+  writeJson(teamsDir, 'smartfunds-research-team.json', {
+    teamId: 'smartfunds-research-team',
+    name: 'SmartFunds Research Team',
+    projectId: 'smartfunds-core',
+    members: ['lead-thesis-architect'],
+    executionMode: 'structured'
+  });
+
+  writeJson(agentsDir, 'lead-thesis-architect.json', {
+    agentId: 'lead-thesis-architect',
+    displayName: 'lead-thesis-architect',
+    role: 'analyst',
+    projectId: 'smartfunds-core',
+    adapterType: 'llm',
+    personalityProfile: {
+      tone: 'precise',
+      reasoningStyle: 'structured',
+      temperament: 'calm',
+      collaborationStyle: 'cooperative',
+      communicationStyle: 'concise'
+    },
+    skillsProfile: {
+      coreSkills: ['analysis'],
+      secondarySkills: ['summary'],
+      domains: ['rwa']
+    },
+    backgroundProfile: {
+      professionalArchetype: 'researcher',
+      domainBackground: ['markets'],
+      perspectiveBiases: []
+    },
+    outputProfile: {
+      preferredFormat: 'memo',
+      verbosity: 'medium',
+      citationStyle: 'internal',
+      decisionStyle: 'rank'
+    },
+    constraintsProfile: {
+      mustDo: ['be explicit'],
+      mustNotDo: ['guess']
+    },
+    toolProfile: {
+      allowedAdapters: ['llm', 'repo'],
+      preferredTools: ['repo'],
+      forbiddenTools: []
+    }
+  });
+
+  writeJson(workflowsDir, 's84-slack-workflow.json', {
+    workflowId: 's84-slack-workflow',
+    nodes: [
+      {
+        id: 'extract-content',
+        task: 'repo'
+      }
+    ]
+  });
+}
+
+type MissionHandler = (payload: {
+  ack?: () => Promise<void>;
+  command?: Record<string, unknown>;
+  respond?: (response: { response_type: 'ephemeral'; text: string }) => Promise<void>;
+}) => Promise<void>;
+
+function buildAppHarness(): {
+  app: {
+    command: (name: string, handler: MissionHandler) => void;
+  };
+  handler: () => MissionHandler;
+} {
+  const handlers = new Map<string, MissionHandler>();
+  return {
+    app: {
+      command: (name, handler) => {
+        handlers.set(name, handler);
+      }
+    },
+    handler: () => {
+      const handler = handlers.get('/mission');
+      if (!handler) {
+        throw new Error('missing /mission handler');
+      }
+      return handler;
+    }
+  };
+}
+
+beforeEach(() => {
+  resetFixtures();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.rmSync(path.join('artifacts', missionId), { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('slack mission integration', () => {
+  it('T-S84-I1 routes /mission run/status/artifacts through existing mission control path with completion notification', async () => {
+    const missionService = createMissionService({
+      rootDir: journalRoot,
+      missionsDir,
+      teamsDir,
+      agentsDir,
+      workflowsDir
+    });
+    const workflowService = createWorkflowService({
+      rootDir: journalRoot
+    });
+
+    const missionStartSpy = vi.spyOn(missionService, 'startMission');
+    const sendMessage = vi.fn(async () => undefined);
+    const notifier = createSlackNotifier({
+      channel: 'C-OPS',
+      sendMessage
+    });
+
+    const controller = createMissionController({
+      missionService,
+      workflowService,
+      onMissionCompleted: (payload) => notifier.notifyMissionCompleted(payload)
+    });
+    const router = createSlackRouter(controller);
+
+    const harness = buildAppHarness();
+    registerSlackEvents({
+      app: harness.app,
+      router
+    });
+
+    const missionHandler = harness.handler();
+
+    const runResponses: Array<{ response_type: 'ephemeral'; text: string }> = [];
+    await missionHandler({
+      ack: async () => undefined,
+      command: {
+        text: `run ${missionId}`
+      },
+      respond: async (response) => {
+        runResponses.push(response);
+      }
+    });
+
+    expect(missionStartSpy).toHaveBeenCalledWith({ missionId, params: {} });
+    expect(runResponses).toHaveLength(1);
+
+    const runText = runResponses[0].text;
+    expect(runText).toContain('Mission started');
+    const runIdLine = runText.split('\n').find((line) => line.startsWith('runId: '));
+    const runId = runIdLine?.slice('runId: '.length) ?? '';
+    expect(runId).toMatch(/^run_smartfunds-core_/);
+
+    const statusResponses: Array<{ response_type: 'ephemeral'; text: string }> = [];
+    await missionHandler({
+      ack: async () => undefined,
+      command: {
+        text: `status ${runId}`
+      },
+      respond: async (response) => {
+        statusResponses.push(response);
+      }
+    });
+
+    expect(statusResponses[0]?.text).toContain(`runId: ${runId}`);
+    expect(statusResponses[0]?.text).toContain('status: completed');
+
+    const artifactResponses: Array<{ response_type: 'ephemeral'; text: string }> = [];
+    await missionHandler({
+      ack: async () => undefined,
+      command: {
+        text: `artifacts ${runId}`
+      },
+      respond: async (response) => {
+        artifactResponses.push(response);
+      }
+    });
+
+    expect(artifactResponses).toHaveLength(1);
+    expect(artifactResponses[0]?.text).toBe([
+      'Artifacts',
+      '',
+      'dataset.csv',
+      'logs.txt',
+      'report.md',
+      'summary.json'
+    ].join('\n'));
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const completionText = String(sendMessage.mock.calls[0]?.[0]?.text);
+    expect(completionText).toBe([
+      'Mission completed',
+      '',
+      `mission: ${missionId}`,
+      `runId: ${runId}`,
+      '',
+      'Artifacts available',
+      'dataset.csv',
+      'logs.txt',
+      'report.md',
+      'summary.json'
+    ].join('\n'));
+
+    const artifactDir = path.join('artifacts', missionId, runId);
+    expect(fs.existsSync(path.join(artifactDir, 'report.md'))).toBe(true);
+    expect(fs.existsSync(path.join(artifactDir, 'dataset.csv'))).toBe(true);
+  });
+});

--- a/runtime/adapters/slack/slack-client.test.ts
+++ b/runtime/adapters/slack/slack-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSlackApp, initializeSlackClient, validateSlackEnvironment } from './slack-client.ts';
+
+describe('slack adapter client', () => {
+  it('T-S84-C1 fails deterministically when Slack env vars are missing', () => {
+    expect(() => validateSlackEnvironment({})).toThrow(
+      'SLACK_CONFIG_MISSING: SLACK_APP_TOKEN, SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET'
+    );
+  });
+
+  it('T-S84-C2 fails deterministically when @slack/bolt is unavailable', async () => {
+    await expect(createSlackApp({
+      config: {
+        botToken: 'xoxb-test',
+        signingSecret: 'secret',
+        appToken: 'xapp-test'
+      },
+      loadBolt: async () => {
+        throw new Error('module-not-found');
+      }
+    })).rejects.toThrow('SLACK_BOLT_UNAVAILABLE: install @slack/bolt to start Slack mission adapter');
+  });
+
+  it('T-S84-C3 initializes app and registers command handlers explicitly', async () => {
+    const command = vi.fn<(name: string, handler: (payload: {
+      ack?: () => Promise<void>;
+      command?: Record<string, unknown>;
+      respond?: (response: { response_type: 'ephemeral'; text: string }) => Promise<void>;
+    }) => Promise<void>) => void>();
+    const start = vi.fn(async () => undefined);
+    const postMessage = vi.fn(async () => undefined);
+
+    const client = await initializeSlackClient({
+      env: {
+        SLACK_BOT_TOKEN: 'xoxb-test',
+        SLACK_SIGNING_SECRET: 'secret',
+        SLACK_APP_TOKEN: 'xapp-test'
+      },
+      router: {
+        helpText: 'help',
+        routeMissionText: vi.fn(async () => ({ ok: true as const, text: 'ok' }))
+      },
+      loadBolt: async () => ({
+        App: class {
+          command = command;
+          start = start;
+          client = {
+            chat: {
+              postMessage
+            }
+          };
+        }
+      })
+    });
+
+    expect(client.commandsRegistered).toBe(1);
+
+    await client.start();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    await client.sendMessage({ channel: 'C1', text: 'hello' });
+    expect(postMessage).toHaveBeenCalledWith({ channel: 'C1', text: 'hello' });
+  });
+});

--- a/runtime/adapters/slack/slack-client.ts
+++ b/runtime/adapters/slack/slack-client.ts
@@ -1,0 +1,121 @@
+import { registerSlackEvents } from './slack-events.ts';
+import type { SlackRouter } from './slack-router.ts';
+
+export type SlackEnvironmentConfig = {
+  botToken: string;
+  signingSecret: string;
+  appToken: string;
+};
+
+type BoltApp = {
+  command: (
+    name: string,
+    handler: (payload: {
+      ack?: () => Promise<void>;
+      command?: Record<string, unknown>;
+      respond?: (response: { response_type: 'ephemeral'; text: string }) => Promise<void>;
+    }) => Promise<void>
+  ) => void;
+  start: () => Promise<void>;
+  client: {
+    chat: {
+      postMessage: (input: { channel: string; text: string }) => Promise<unknown>;
+    };
+  };
+};
+
+type BoltModule = {
+  App: new (input: {
+    token: string;
+    signingSecret: string;
+    appToken: string;
+    socketMode: true;
+  }) => BoltApp;
+};
+
+export function validateSlackEnvironment(env: NodeJS.ProcessEnv = process.env): SlackEnvironmentConfig {
+  const botToken = env.SLACK_BOT_TOKEN?.trim() ?? '';
+  const signingSecret = env.SLACK_SIGNING_SECRET?.trim() ?? '';
+  const appToken = env.SLACK_APP_TOKEN?.trim() ?? '';
+
+  const missing: string[] = [];
+  if (botToken.length === 0) {
+    missing.push('SLACK_BOT_TOKEN');
+  }
+  if (signingSecret.length === 0) {
+    missing.push('SLACK_SIGNING_SECRET');
+  }
+  if (appToken.length === 0) {
+    missing.push('SLACK_APP_TOKEN');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`SLACK_CONFIG_MISSING: ${missing.sort((left, right) => left.localeCompare(right)).join(', ')}`);
+  }
+
+  return {
+    botToken,
+    signingSecret,
+    appToken
+  };
+}
+
+async function defaultLoadBolt(): Promise<BoltModule> {
+  return import('@slack/bolt') as Promise<BoltModule>;
+}
+
+export async function createSlackApp(input: {
+  config: SlackEnvironmentConfig;
+  loadBolt?: () => Promise<BoltModule>;
+}): Promise<BoltApp> {
+  const loadBolt = input.loadBolt ?? defaultLoadBolt;
+
+  let boltModule: BoltModule;
+  try {
+    boltModule = await loadBolt();
+  } catch {
+    throw new Error('SLACK_BOLT_UNAVAILABLE: install @slack/bolt to start Slack mission adapter');
+  }
+
+  return new boltModule.App({
+    token: input.config.botToken,
+    signingSecret: input.config.signingSecret,
+    appToken: input.config.appToken,
+    socketMode: true
+  });
+}
+
+export async function initializeSlackClient(input: {
+  router: SlackRouter;
+  env?: NodeJS.ProcessEnv;
+  loadBolt?: () => Promise<BoltModule>;
+}) {
+  const config = validateSlackEnvironment(input.env);
+  const app = await createSlackApp({
+    config,
+    loadBolt: input.loadBolt
+  });
+
+  const registration = registerSlackEvents({
+    app,
+    router: input.router
+  });
+
+  async function start(): Promise<void> {
+    await app.start();
+  }
+
+  async function sendMessage(message: { channel: string; text: string }): Promise<void> {
+    await app.client.chat.postMessage(message);
+  }
+
+  return {
+    config,
+    app,
+    commandsRegistered: registration.commandsRegistered,
+    start,
+    sendMessage
+  };
+}
+
+export type SlackClient = Awaited<ReturnType<typeof initializeSlackClient>>;

--- a/runtime/adapters/slack/slack-events.test.ts
+++ b/runtime/adapters/slack/slack-events.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerSlackEvents } from './slack-events.ts';
+
+type MissionHandler = (payload: {
+  ack?: () => Promise<void>;
+  command?: Record<string, unknown>;
+  respond?: (response: { response_type: 'ephemeral'; text: string }) => Promise<void>;
+}) => Promise<void>;
+
+describe('slack adapter events', () => {
+  it('T-S84-E1 registers /mission and routes text through router with ack/respond', async () => {
+    let handler: MissionHandler | null = null;
+    const router = {
+      routeMissionText: vi.fn(async () => ({ ok: true as const, text: 'Mission started\n\nmission: m1\nrunId: run_1' })),
+      helpText: 'help'
+    };
+
+    const registration = registerSlackEvents({
+      app: {
+        command: (name, registered) => {
+          expect(name).toBe('/mission');
+          handler = registered;
+        }
+      },
+      router
+    });
+
+    expect(registration.commandsRegistered).toBe(1);
+    expect(handler).not.toBeNull();
+
+    const ack = vi.fn(async () => undefined);
+    const respond = vi.fn(async () => undefined);
+    await handler?.({
+      ack,
+      command: { text: 'run m1' },
+      respond
+    });
+
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(router.routeMissionText).toHaveBeenCalledWith('run m1');
+    expect(respond).toHaveBeenCalledWith({
+      response_type: 'ephemeral',
+      text: 'Mission started\n\nmission: m1\nrunId: run_1'
+    });
+  });
+});

--- a/runtime/adapters/slack/slack-events.ts
+++ b/runtime/adapters/slack/slack-events.ts
@@ -1,0 +1,42 @@
+import type { SlackRouter } from './slack-router.ts';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function registerSlackEvents(input: {
+  app: {
+    command: (
+      name: string,
+      handler: (payload: {
+        ack?: () => Promise<void>;
+        command?: Record<string, unknown>;
+        respond?: (response: { response_type: 'ephemeral'; text: string }) => Promise<void>;
+      }) => Promise<void>
+    ) => void;
+  };
+  router: SlackRouter;
+}) {
+  input.app.command('/mission', async (payload) => {
+    if (payload.ack) {
+      await payload.ack();
+    }
+
+    const command = asRecord(payload.command);
+    const text = typeof command.text === 'string' ? command.text : '';
+    const routed = await input.router.routeMissionText(text);
+
+    if (payload.respond) {
+      await payload.respond({
+        response_type: 'ephemeral',
+        text: routed.text
+      });
+    }
+  });
+
+  return {
+    commandsRegistered: 1
+  };
+}

--- a/runtime/adapters/slack/slack-notifier.test.ts
+++ b/runtime/adapters/slack/slack-notifier.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSlackNotifier, formatMissionCompletionNotification } from './slack-notifier.ts';
+
+describe('slack adapter notifier', () => {
+  it('T-S84-N1 formats deterministic completion notification text', () => {
+    const text = formatMissionCompletionNotification({
+      missionId: 'research-web-intelligence',
+      runId: 'run_smartfunds-core_0004',
+      artifacts: ['report.md', 'dataset.csv', 'report.md', 'search-results.json']
+    });
+
+    expect(text).toBe([
+      'Mission completed',
+      '',
+      'mission: research-web-intelligence',
+      'runId: run_smartfunds-core_0004',
+      '',
+      'Artifacts available',
+      'dataset.csv',
+      'report.md',
+      'search-results.json'
+    ].join('\n'));
+  });
+
+  it('T-S84-N2 sends notifications only when channel is configured', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const enabledNotifier = createSlackNotifier({
+      channel: 'C-OPS',
+      sendMessage
+    });
+
+    await enabledNotifier.notifyMissionCompleted({
+      missionId: 'research-web-intelligence',
+      runId: 'run_smartfunds-core_0004',
+      artifacts: []
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    const disabledNotifier = createSlackNotifier({
+      channel: null,
+      sendMessage
+    });
+
+    await disabledNotifier.notifyMissionCompleted({
+      missionId: 'research-web-intelligence',
+      runId: 'run_smartfunds-core_0005',
+      artifacts: []
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/runtime/adapters/slack/slack-notifier.ts
+++ b/runtime/adapters/slack/slack-notifier.ts
@@ -1,0 +1,49 @@
+import type { SlackNotificationPayload } from './slack-types.ts';
+
+function formatArtifacts(artifacts: string[]): string[] {
+  return Array.from(new Set(artifacts))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function formatMissionCompletionNotification(payload: SlackNotificationPayload): string {
+  const artifacts = formatArtifacts(payload.artifacts);
+
+  const lines = [
+    'Mission completed',
+    '',
+    `mission: ${payload.missionId}`,
+    `runId: ${payload.runId}`,
+    '',
+    'Artifacts available'
+  ];
+
+  if (artifacts.length === 0) {
+    lines.push('none');
+  } else {
+    lines.push(...artifacts);
+  }
+
+  return lines.join('\n');
+}
+
+export function createSlackNotifier(input: {
+  channel: string | null;
+  sendMessage: (message: { channel: string; text: string }) => Promise<void>;
+}) {
+  async function notifyMissionCompleted(payload: SlackNotificationPayload): Promise<void> {
+    if (!input.channel) {
+      return;
+    }
+
+    await input.sendMessage({
+      channel: input.channel,
+      text: formatMissionCompletionNotification(payload)
+    });
+  }
+
+  return {
+    notifyMissionCompleted
+  };
+}
+
+export type SlackNotifier = ReturnType<typeof createSlackNotifier>;

--- a/runtime/adapters/slack/slack-router.test.ts
+++ b/runtime/adapters/slack/slack-router.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSlackRouter } from './slack-router.ts';
+
+function buildController() {
+  return {
+    startMission: vi.fn(async (missionId: string) => ({
+      missionId,
+      workflowRun: 'run_smartfunds-core_0004'
+    })),
+    getRunStatus: vi.fn((runId: string) => ({
+      runId,
+      status: 'running',
+      phase: 'extract-content'
+    })),
+    getArtifactsByRun: vi.fn((runId: string) => ({
+      runId,
+      missionId: 'research-web-intelligence',
+      artifacts: ['report.md', 'dataset.csv', 'search-results.json', 'research-pages.json']
+    }))
+  };
+}
+
+describe('slack adapter router', () => {
+  it('T-S84-R1 parses /mission run and delegates mission launch', async () => {
+    const controller = buildController();
+    const router = createSlackRouter(controller);
+
+    const result = await router.routeMissionText('run research-web-intelligence');
+
+    expect(result).toEqual({
+      ok: true,
+      text: [
+        'Mission started',
+        '',
+        'mission: research-web-intelligence',
+        'runId: run_smartfunds-core_0004'
+      ].join('\n')
+    });
+    expect(controller.startMission).toHaveBeenCalledWith('research-web-intelligence');
+  });
+
+  it('T-S84-R2 parses /mission status by runId and formats deterministic output', async () => {
+    const controller = buildController();
+    const router = createSlackRouter(controller);
+
+    const result = await router.routeMissionText('status run_smartfunds-core_0004');
+
+    expect(result).toEqual({
+      ok: true,
+      text: [
+        'Mission status',
+        '',
+        'runId: run_smartfunds-core_0004',
+        'status: running',
+        'phase: extract-content'
+      ].join('\n')
+    });
+    expect(controller.getRunStatus).toHaveBeenCalledWith('run_smartfunds-core_0004');
+  });
+
+  it('T-S84-R3 parses /mission artifacts by runId and sorts artifact list deterministically', async () => {
+    const controller = buildController();
+    controller.getArtifactsByRun.mockReturnValueOnce({
+      runId: 'run_smartfunds-core_0004',
+      missionId: 'research-web-intelligence',
+      artifacts: ['search-results.json', 'dataset.csv', 'report.md', 'research-pages.json']
+    });
+
+    const router = createSlackRouter(controller);
+    const result = await router.routeMissionText('artifacts run_smartfunds-core_0004');
+
+    expect(result).toEqual({
+      ok: true,
+      text: [
+        'Artifacts',
+        '',
+        'dataset.csv',
+        'report.md',
+        'research-pages.json',
+        'search-results.json'
+      ].join('\n')
+    });
+    expect(controller.getArtifactsByRun).toHaveBeenCalledWith('run_smartfunds-core_0004');
+  });
+
+  it('T-S84-R4 returns deterministic help text for malformed command input', async () => {
+    const router = createSlackRouter(buildController());
+
+    const result = await router.routeMissionText('run');
+
+    expect(result).toEqual({
+      ok: false,
+      text: [
+        'Error',
+        '',
+        'INVALID_COMMAND: expected exactly 2 arguments',
+        '',
+        'Usage:',
+        '/mission run <missionId>',
+        '/mission status <runId>',
+        '/mission artifacts <runId>'
+      ].join('\n')
+    });
+  });
+
+  it('T-S84-R5 maps missing run errors deterministically', async () => {
+    const controller = buildController();
+    controller.getRunStatus.mockImplementationOnce(() => {
+      throw new Error('Run not found: run_missing_0001');
+    });
+
+    const router = createSlackRouter(controller);
+    const result = await router.routeMissionText('status run_missing_0001');
+
+    expect(result).toEqual({
+      ok: false,
+      text: ['Error', '', 'RUN_NOT_FOUND: run_missing_0001'].join('\n')
+    });
+  });
+});

--- a/runtime/adapters/slack/slack-router.ts
+++ b/runtime/adapters/slack/slack-router.ts
@@ -1,0 +1,143 @@
+import type { MissionController } from '../../mission/mission-controller.ts';
+import type {
+  MissionArtifactsCommand,
+  MissionCommandName,
+  MissionRunCommand,
+  MissionStatusCommand,
+  SlackCommandResult,
+  SlackMissionCommand
+} from './slack-types.ts';
+
+const HELP_TEXT = [
+  'Usage:',
+  '/mission run <missionId>',
+  '/mission status <runId>',
+  '/mission artifacts <runId>'
+].join('\n');
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function normalizeErrorMessage(message: string): string {
+  const runNotFoundMatch = message.match(/^Run not found:\s*(.+)$/);
+  if (runNotFoundMatch) {
+    return `RUN_NOT_FOUND: ${runNotFoundMatch[1]}`;
+  }
+
+  return message;
+}
+
+function parseCommand(text: string): SlackMissionCommand {
+  const tokens = text
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+
+  if (tokens.length !== 2) {
+    throw new Error(`INVALID_COMMAND: expected exactly 2 arguments\n\n${HELP_TEXT}`);
+  }
+
+  const commandName = tokens[0] as MissionCommandName;
+  const value = tokens[1];
+
+  if (commandName === 'run') {
+    return {
+      name: 'run',
+      missionId: value
+    } satisfies MissionRunCommand;
+  }
+
+  if (commandName === 'status') {
+    return {
+      name: 'status',
+      runId: value
+    } satisfies MissionStatusCommand;
+  }
+
+  if (commandName === 'artifacts') {
+    return {
+      name: 'artifacts',
+      runId: value
+    } satisfies MissionArtifactsCommand;
+  }
+
+  throw new Error(`INVALID_COMMAND: unknown subcommand ${tokens[0]}\n\n${HELP_TEXT}`);
+}
+
+export function createSlackRouter(controller: Pick<MissionController, 'startMission' | 'getRunStatus' | 'getArtifactsByRun'>) {
+  async function routeMissionText(text: string): Promise<SlackCommandResult> {
+    try {
+      const command = parseCommand(text);
+
+      if (command.name === 'run') {
+        const started = asRecord(await controller.startMission(command.missionId));
+        const missionId = asString(started.missionId) ?? command.missionId;
+        const runId = asString(started.workflowRun);
+
+        return {
+          ok: true,
+          text: [
+            'Mission started',
+            '',
+            `mission: ${missionId}`,
+            `runId: ${runId ?? 'unknown'}`
+          ].join('\n')
+        };
+      }
+
+      if (command.name === 'status') {
+        const status = asRecord(controller.getRunStatus(command.runId));
+
+        return {
+          ok: true,
+          text: [
+            'Mission status',
+            '',
+            `runId: ${command.runId}`,
+            `status: ${asString(status.status) ?? 'unknown'}`,
+            `phase: ${asString(status.phase) ?? 'none'}`
+          ].join('\n')
+        };
+      }
+
+      const artifactsResponse = asRecord(controller.getArtifactsByRun(command.runId));
+      const artifacts = Array.isArray(artifactsResponse.artifacts)
+        ? (artifactsResponse.artifacts.filter((entry) => typeof entry === 'string') as string[])
+            .sort((left, right) => left.localeCompare(right))
+        : [];
+
+      return {
+        ok: true,
+        text: [
+          'Artifacts',
+          '',
+          ...(artifacts.length > 0 ? artifacts : ['none'])
+        ].join('\n')
+      };
+    } catch (error) {
+      const message = error instanceof Error ? normalizeErrorMessage(error.message) : 'unknown_error';
+      return {
+        ok: false,
+        text: [
+          'Error',
+          '',
+          message
+        ].join('\n')
+      };
+    }
+  }
+
+  return {
+    routeMissionText,
+    helpText: HELP_TEXT
+  };
+}
+
+export type SlackRouter = ReturnType<typeof createSlackRouter>;

--- a/runtime/adapters/slack/slack-types.ts
+++ b/runtime/adapters/slack/slack-types.ts
@@ -1,0 +1,46 @@
+export type MissionCommandName = 'run' | 'status' | 'artifacts';
+
+export type MissionRunCommand = {
+  name: 'run';
+  missionId: string;
+};
+
+export type MissionStatusCommand = {
+  name: 'status';
+  runId: string;
+};
+
+export type MissionArtifactsCommand = {
+  name: 'artifacts';
+  runId: string;
+};
+
+export type SlackMissionCommand = MissionRunCommand | MissionStatusCommand | MissionArtifactsCommand;
+
+export type SlackArtifactSummary = {
+  missionId: string;
+  runId: string;
+  artifacts: string[];
+};
+
+export type SlackMissionStatusSummary = {
+  runId: string;
+  status: string;
+  phase: string | null;
+};
+
+export type SlackNotificationPayload = {
+  missionId: string;
+  runId: string;
+  artifacts: string[];
+};
+
+export type SlackCommandResult =
+  | {
+    ok: true;
+    text: string;
+  }
+  | {
+    ok: false;
+    text: string;
+  };

--- a/runtime/mission/mission-controller.ts
+++ b/runtime/mission/mission-controller.ts
@@ -3,12 +3,14 @@ import path from 'node:path';
 
 import { createMissionService } from '../../control-plane/operator/mission-service.ts';
 import { createWorkflowService } from '../../control-plane/operator/workflow-service.ts';
+import { listArtifactsForRun } from '../output/artifact-listing.ts';
 
 export type MissionControllerOptions = {
   rootDir?: string;
   artifactsDir?: string;
   missionService?: ReturnType<typeof createMissionService>;
   workflowService?: ReturnType<typeof createWorkflowService>;
+  onMissionCompleted?: (input: { missionId: string; runId: string; artifacts: string[] }) => Promise<void> | void;
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -57,7 +59,19 @@ export function createMissionController(options: MissionControllerOptions = {}) 
   const artifactsDir = options.artifactsDir ?? path.join('.', 'artifacts');
 
   async function startMission(missionName: string): Promise<Record<string, unknown>> {
-    return asRecord(await missionService.startMission({ missionId: missionName, params: {} }));
+    const started = asRecord(await missionService.startMission({ missionId: missionName, params: {} }));
+    const runId = asString(started.workflowRun);
+    const missionId = asString(started.missionId) ?? missionName;
+    if (options.onMissionCompleted && runId) {
+      const artifacts = listArtifactsForRun({
+        missionId,
+        runId,
+        artifactsRoot: artifactsDir
+      });
+      await options.onMissionCompleted({ missionId, runId, artifacts });
+    }
+
+    return started;
   }
 
   function getStatus(missionId: string): Record<string, unknown> {
@@ -114,12 +128,44 @@ export function createMissionController(options: MissionControllerOptions = {}) 
     };
   }
 
+  function getRunStatus(runId: string): Record<string, unknown> {
+    const status = asRecord(workflowService.inspectWorkflow({ runId }));
+    const summary = asRecord(status.summary);
+
+    return {
+      runId,
+      missionId: asString(status.missionId),
+      status: asString(status.status) ?? 'unknown',
+      phase: asString(summary.activeNodeId)
+    };
+  }
+
+  function getArtifactsByRun(runId: string): Record<string, unknown> {
+    const status = asRecord(workflowService.inspectWorkflow({ runId }));
+    const missionId = asString(status.missionId);
+    if (!missionId) {
+      throw new Error(`MISSION_NOT_FOUND_FOR_RUN: ${runId}`);
+    }
+
+    return {
+      missionId,
+      runId,
+      artifacts: listArtifactsForRun({
+        missionId,
+        runId,
+        artifactsRoot: artifactsDir
+      })
+    };
+  }
+
   return {
     startMission,
     getStatus,
     cancelMission,
     getLogs,
-    getArtifacts
+    getArtifacts,
+    getRunStatus,
+    getArtifactsByRun
   };
 }
 

--- a/runtime/output/artifact-listing.test.ts
+++ b/runtime/output/artifact-listing.test.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { listArtifactsForRun } from './artifact-listing.ts';
+
+const missionId = 's84-artifacts-mission';
+const runId = 'run_test_0001';
+const baseDir = path.join('artifacts', missionId, runId);
+
+afterEach(() => {
+  fs.rmSync(path.join('artifacts', missionId), { recursive: true, force: true });
+});
+
+describe('artifact listing', () => {
+  it('T-A84-1 lists files for a run in deterministic order', () => {
+    fs.mkdirSync(baseDir, { recursive: true });
+    fs.writeFileSync(path.join(baseDir, 'zeta.json'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(baseDir, 'alpha.csv'), 'a,b\n', 'utf8');
+
+    expect(listArtifactsForRun({ missionId, runId })).toEqual(['alpha.csv', 'zeta.json']);
+  });
+
+  it('T-A84-2 returns empty list when run directory is absent', () => {
+    expect(listArtifactsForRun({ missionId, runId })).toEqual([]);
+  });
+});

--- a/runtime/output/artifact-listing.ts
+++ b/runtime/output/artifact-listing.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { resolveArtifactDirectory } from './artifact-manager.ts';
+
+function listFiles(directory: string): string[] {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  return fs.readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function listArtifactsForRun(input: {
+  missionId: string;
+  runId: string;
+  artifactsRoot?: string;
+}): string[] {
+  const runDirectory = resolveArtifactDirectory(input.missionId, input.runId);
+
+  if (input.artifactsRoot) {
+    const relative = path.join(input.missionId, input.runId);
+    return listFiles(path.join(input.artifactsRoot, relative));
+  }
+
+  return listFiles(runDirectory);
+}


### PR DESCRIPTION
tier-3

```evidence
Sprint 84 implements the Slack Mission Control Interface.

- Adds thin Slack adapter under runtime/adapters/slack.
- Supports /mission run <missionId>
- Supports /mission status <runId>
- Supports /mission artifacts <runId>
- Adds deterministic mission completion notifications.
- Reuses existing mission control-plane services.
- Does not introduce a new execution engine.
- Preserves CLI compatibility.

Verification:
- npm test passed
- npm run lint passed
- npm run typecheck passed
- npm run mission:run verified existing CLI path

Integration coverage added for Slack mission flow.
```
