### PR TITLE
Sprint C: Activate Build profile lane with bounded branch/commit/PR provenance flow

### DIFF
--- a/control-plane/cli/mission-build.test.ts
+++ b/control-plane/cli/mission-build.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { main } from './mission-build.ts';
+
+const runMissionMain = vi.fn();
+
+vi.mock('./mission-run.ts', () => ({
+  main: (...args: unknown[]) => runMissionMain(...args)
+}));
+
+describe('mission-build CLI', () => {
+  it('T-SPC-CL1 forwards args with --profile build', async () => {
+    runMissionMain.mockResolvedValueOnce(0);
+    const code = await main(['--mission', 'dashboard-copy-refresh']);
+    expect(code).toBe(0);
+    expect(runMissionMain).toHaveBeenCalledWith(['--profile', 'build', '--mission', 'dashboard-copy-refresh']);
+  });
+});

--- a/control-plane/cli/mission-build.ts
+++ b/control-plane/cli/mission-build.ts
@@ -1,0 +1,14 @@
+import { main as runMissionMain } from './mission-run.ts';
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  return runMissionMain(['--profile', 'build', ...argv]);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write('Mission rejected\nCode: unexpected_runtime_error\nReason: unexpected_runtime_error\n');
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-run.test.ts
+++ b/control-plane/cli/mission-run.test.ts
@@ -73,4 +73,30 @@ describe('mission-run CLI', () => {
 
     stdout.mockRestore();
   });
+
+  it('prints build branch and PR metadata when provided', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    startMission.mockResolvedValueOnce({
+      missionId: 'dashboard-copy-refresh',
+      status: 'completed',
+      profile: 'build',
+      executionPath: 'build',
+      workflowRun: 'run_smartfunds-core_0099',
+      artifactCount: 0,
+      branchName: 'build/dashboard-copy-refresh/1234abcd',
+      prNumber: 88,
+      prUrl: 'https://example.test/repo/pull/88'
+    });
+
+    const code = await main(['--mission', 'dashboard-copy-refresh']);
+    expect(code).toBe(0);
+    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('Execution Path: build');
+    expect(output).toContain('Branch: build/dashboard-copy-refresh/1234abcd');
+    expect(output).toContain('PR Number: 88');
+    expect(output).toContain('PR URL: https://example.test/repo/pull/88');
+
+    stdout.mockRestore();
+  });
 });

--- a/control-plane/cli/mission-run.ts
+++ b/control-plane/cli/mission-run.ts
@@ -78,15 +78,31 @@ function printJson(value: unknown): void {
 function printReadableResult(result: Record<string, unknown>): void {
   const missionId = String(result.missionId ?? 'unknown-mission');
   const profile = String(result.profile ?? 'core');
+  const executionPath = typeof result.executionPath === 'string' ? result.executionPath : null;
   const runId = String(result.workflowRun ?? 'unknown-run');
   const status = String(result.status ?? 'unknown');
+  const branchName = typeof result.branchName === 'string' ? result.branchName : null;
+  const prNumber = typeof result.prNumber === 'number' ? result.prNumber : null;
+  const prUrl = typeof result.prUrl === 'string' ? result.prUrl : null;
   const artifactCount = typeof result.artifactCount === 'number' && Number.isFinite(result.artifactCount)
     ? result.artifactCount
     : 0;
 
   process.stdout.write(`Mission: ${missionId}\n`);
   process.stdout.write(`Profile: ${profile}\n`);
+  if (executionPath) {
+    process.stdout.write(`Execution Path: ${executionPath}\n`);
+  }
   process.stdout.write(`Run: ${runId}\n`);
+  if (branchName) {
+    process.stdout.write(`Branch: ${branchName}\n`);
+  }
+  if (prNumber !== null) {
+    process.stdout.write(`PR Number: ${String(prNumber)}\n`);
+  }
+  if (prUrl) {
+    process.stdout.write(`PR URL: ${prUrl}\n`);
+  }
   process.stdout.write(`Status: ${status}\n`);
   process.stdout.write(`Artifacts: ${String(artifactCount)}\n\n`);
   process.stdout.write('Next:\n');

--- a/control-plane/journal/journal.ts
+++ b/control-plane/journal/journal.ts
@@ -27,7 +27,7 @@ export type ExecutionJournal = {
     kind: RunKind;
     entrypoint: string;
     profile?: string;
-    executionPath?: 'governed' | 'lite';
+    executionPath?: 'governed' | 'lite' | 'build';
   }) => ExecutionRun;
   appendEvent: (input: {
     runId: string;
@@ -50,7 +50,7 @@ export function createExecutionJournal(options: JournalOptions = {}): ExecutionJ
     kind: RunKind;
     entrypoint: string;
     profile?: string;
-    executionPath?: 'governed' | 'lite';
+    executionPath?: 'governed' | 'lite' | 'build';
   }): ExecutionRun {
     const context = resolveProjectContext(input.projectId);
 

--- a/control-plane/journal/storage.ts
+++ b/control-plane/journal/storage.ts
@@ -55,7 +55,7 @@ function normalizeRun(run: ExecutionRun): ExecutionRun {
     entrypoint: run.entrypoint,
     createdIndex: run.createdIndex,
     ...(typeof run.profile === 'string' ? { profile: run.profile } : {}),
-    ...(run.executionPath === 'governed' || run.executionPath === 'lite'
+    ...(run.executionPath === 'governed' || run.executionPath === 'lite' || run.executionPath === 'build'
       ? { executionPath: run.executionPath }
       : {})
   };

--- a/control-plane/journal/types.ts
+++ b/control-plane/journal/types.ts
@@ -50,7 +50,7 @@ export type ExecutionRun = {
   entrypoint: string;
   createdIndex: number;
   profile?: string;
-  executionPath?: 'governed' | 'lite';
+  executionPath?: 'governed' | 'lite' | 'build';
 };
 
 export type ExecutionEvent = {
@@ -89,7 +89,7 @@ export type CreateRunInput = {
   kind: RunKind;
   entrypoint: string;
   profile?: string;
-  executionPath?: 'governed' | 'lite';
+  executionPath?: 'governed' | 'lite' | 'build';
 };
 
 export type AppendEventInput = {

--- a/control-plane/missions/definitions/build/dashboard-copy-refresh.json
+++ b/control-plane/missions/definitions/build/dashboard-copy-refresh.json
@@ -1,0 +1,50 @@
+{
+  "missionId": "dashboard-copy-refresh",
+  "name": "Dashboard Copy Refresh",
+  "projectId": "smartfunds-core",
+  "teamId": "smartfunds-research-team",
+  "workflowId": "build-dashboard-copy-refresh",
+  "profile": "build",
+  "mutationIntent": "ui_change",
+  "requestedCapabilities": [
+    "artifact_write",
+    "pr_open",
+    "read",
+    "repo_write"
+  ],
+  "targetScope": {
+    "repo": "smartfunds-agent-sandbox",
+    "paths": [
+      "dashboard/**",
+      "docs/**"
+    ]
+  },
+  "objective": "Apply an approved copy-only refresh for dashboard UX in build-safe surfaces.",
+  "successCriteria": [
+    "Open a PR with deterministic runtime provenance",
+    "Restrict changes to dashboard/docs scope",
+    "Exclude runtime artifacts from staged diff"
+  ],
+  "deliverables": [
+    "dashboard/ui/index.html",
+    "docs/runbooks/build-profile-operations.md"
+  ],
+  "initialContext": {
+    "buildMutations": [
+      {
+        "path": "docs/runbooks/build-profile-operations.md",
+        "content": "# Build Profile Operations\\n\\nThis file can be updated by build profile missions in approved scope.\\n"
+      },
+      {
+        "path": "dashboard/ui/index.html",
+        "content": "<!doctype html>\\n<html><body><h1>SmartFunds Dashboard</h1><p>Build profile copy refresh.</p></body></html>\\n"
+      }
+    ],
+    "buildChecks": []
+  },
+  "tags": [
+    "build",
+    "dashboard",
+    "demo-safe"
+  ]
+}

--- a/control-plane/missions/mission-validator.test.ts
+++ b/control-plane/missions/mission-validator.test.ts
@@ -90,4 +90,18 @@ describe('mission-validator', () => {
       paths: ['apps/**', 'tools/**']
     });
   });
+
+  it('T-SPC-M13 accepts build-specific mutation intents', () => {
+    const mission = validateMissionDefinition(validMission({
+      profile: 'build',
+      mutationIntent: 'ui_change',
+      requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write'],
+      targetScope: {
+        repo: 'smartfunds-agent-sandbox',
+        paths: ['dashboard/**']
+      }
+    }));
+
+    expect(mission.mutationIntent).toBe('ui_change');
+  });
 });

--- a/control-plane/missions/mission-validator.ts
+++ b/control-plane/missions/mission-validator.ts
@@ -4,7 +4,19 @@ import type { CapabilityClass, MutationIntent, PolicyProfile } from '../policy/t
 const MISSION_PRIORITIES: MissionPriority[] = ['low', 'medium', 'high', 'critical'];
 const POLICY_PROFILES: PolicyProfile[] = ['lite', 'build', 'core'];
 const CAPABILITY_CLASSES: CapabilityClass[] = ['artifact_write', 'pr_open', 'protected_write', 'read', 'repo_write'];
-const MUTATION_INTENTS: MutationIntent[] = ['none', 'artifact', 'code_change', 'governance_change'];
+const MUTATION_INTENTS: MutationIntent[] = [
+  'none',
+  'artifact',
+  'code_change',
+  'ui_change',
+  'product_update',
+  'tooling_change',
+  'governance_change',
+  'protected_infra_mutation',
+  'financial_rail_mutation',
+  'entity_registry_mutation',
+  'control_plane_mutation'
+];
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;

--- a/control-plane/observability/run-record.ts
+++ b/control-plane/observability/run-record.ts
@@ -10,7 +10,7 @@ export type WorkflowRunRecord = {
   missionId: string | null;
   teamId: string | null;
   profile: string | null;
-  executionPath: 'governed' | 'lite' | null;
+  executionPath: 'governed' | 'lite' | 'build' | null;
   projectId: string;
   status: string;
   nodeCount: number;

--- a/control-plane/operator/build-mission-executor.test.ts
+++ b/control-plane/operator/build-mission-executor.test.ts
@@ -1,0 +1,154 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { executeBuildMission, __testOnly, parseBuildMissionContext } from './build-mission-executor.ts';
+
+type CommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+function withCwd<T>(cwd: string, fn: () => T): T {
+  const previous = process.cwd();
+  process.chdir(cwd);
+  try {
+    return fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+describe('build-mission-executor', () => {
+  it('T-SPC-BE1 produces deterministic branch names', () => {
+    const first = __testOnly.buildBranchName({
+      missionId: 'dashboard-copy-refresh',
+      runId: 'run_0001',
+      targetRepo: 'smartfunds-agent-sandbox',
+      targetPaths: ['dashboard/**', 'docs/**']
+    });
+    const second = __testOnly.buildBranchName({
+      missionId: 'dashboard-copy-refresh',
+      runId: 'run_0001',
+      targetRepo: 'smartfunds-agent-sandbox',
+      targetPaths: ['docs/**', 'dashboard/**']
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it('T-SPC-BE2 parses mission context deterministically', () => {
+    const parsed = parseBuildMissionContext({
+      buildMutations: [
+        { path: 'docs/a.md', content: 'A\n' },
+        { path: 'dashboard/ui/index.html', content: '<h1>x</h1>\n' }
+      ],
+      buildChecks: [
+        { command: 'npm', args: ['run', 'lint'] },
+        { command: 'npm', args: ['test'] }
+      ]
+    });
+
+    expect(parsed).toEqual({
+      mutationPlan: [
+        { path: 'docs/a.md', content: 'A\n' },
+        { path: 'dashboard/ui/index.html', content: '<h1>x</h1>\n' }
+      ],
+      checks: [
+        { command: 'npm', args: ['run', 'lint'] },
+        { command: 'npm', args: ['test'] }
+      ]
+    });
+  });
+
+  it('T-SPC-BE3 runs deterministic branch/commit/pr flow with provenance', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'build-mission-executor-'));
+    const state = {
+      stagedFiles: [] as string[],
+      createdPrBody: ''
+    };
+
+    const runner = (command: string, args: string[]): CommandResult => {
+      if (command === 'git') {
+        if (args[0] === 'show-ref' || args[0] === 'ls-remote') {
+          return { code: 1, stdout: '', stderr: '' };
+        }
+        if (args[0] === 'add') {
+          state.stagedFiles = args.slice(2).map((entry) => entry.trim()).sort((left, right) => left.localeCompare(right));
+          return { code: 0, stdout: '', stderr: '' };
+        }
+        if (args[0] === 'diff' && args[1] === '--cached' && args[2] === '--name-only') {
+          return { code: 0, stdout: `${state.stagedFiles.join('\n')}\n`, stderr: '' };
+        }
+        return { code: 0, stdout: '', stderr: '' };
+      }
+
+      if (command === 'gh') {
+        if (args[0] === 'pr' && args[1] === 'view') {
+          return { code: 1, stdout: '', stderr: '' };
+        }
+        if (args[0] === 'pr' && args[1] === 'create') {
+          const bodyFile = args[args.indexOf('--body-file') + 1];
+          state.createdPrBody = fs.readFileSync(bodyFile as string, 'utf8');
+          return { code: 0, stdout: 'https://example.test/org/repo/pull/24\n', stderr: '' };
+        }
+        if (args[0] === 'pr' && args[1] === 'edit') {
+          return { code: 0, stdout: '', stderr: '' };
+        }
+      }
+
+      return { code: 1, stdout: '', stderr: 'unsupported' };
+    };
+
+    const result = withCwd(tmpRoot, () => executeBuildMission({
+      missionId: 'dashboard-copy-refresh',
+      runId: 'run_smartfunds-core_0001',
+      targetRepo: 'smartfunds-agent-sandbox',
+      targetPaths: ['dashboard/**', 'docs/**'],
+      mutationPlan: [
+        { path: 'docs/build-mission.md', content: '# Build Mission\n' },
+        { path: 'dashboard/ui/index.html', content: '<h1>Build</h1>\n' }
+      ],
+      checks: []
+    }, { commandRunner: runner }));
+
+    expect(result.branchName).toContain('build/dashboard-copy-refresh/');
+    expect(result.prNumber).toBe(24);
+    expect(result.prUrl).toBe('https://example.test/org/repo/pull/24');
+    expect(result.mutationSummary).toEqual(['dashboard/ui/index.html', 'docs/build-mission.md']);
+    expect(state.createdPrBody).toContain('Mission ID: dashboard-copy-refresh');
+    expect(state.createdPrBody).toContain('Execution Path: build');
+  });
+
+  it('T-SPC-BE4 rejects runtime artifact leakage into staged files', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'build-mission-executor-'));
+    const runner = (command: string, args: string[]): CommandResult => {
+      if (command === 'git') {
+        if (args[0] === 'show-ref' || args[0] === 'ls-remote') {
+          return { code: 1, stdout: '', stderr: '' };
+        }
+        if (args[0] === 'diff') {
+          return {
+            code: 0,
+            stdout: 'docs/build-mission.md\nartifacts/build/run_1/report.md\n',
+            stderr: ''
+          };
+        }
+        return { code: 0, stdout: '', stderr: '' };
+      }
+      return { code: 1, stdout: '', stderr: '' };
+    };
+
+    expect(() => withCwd(tmpRoot, () => executeBuildMission({
+      missionId: 'dashboard-copy-refresh',
+      runId: 'run_smartfunds-core_0001',
+      targetRepo: 'smartfunds-agent-sandbox',
+      targetPaths: ['docs/**'],
+      mutationPlan: [{ path: 'docs/build-mission.md', content: '# Build\n' }],
+      checks: []
+    }, { commandRunner: runner }))).toThrowError('BUILD_PROTECTED_SCOPE_FORBIDDEN');
+  });
+});

--- a/control-plane/operator/build-mission-executor.ts
+++ b/control-plane/operator/build-mission-executor.ts
@@ -1,0 +1,451 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import { canonicalStringify, sha256 } from '../finance/determinism.ts';
+import { mutationKernel } from '../pr/mutationKernel.ts';
+
+type BuildMutation = {
+  path: string;
+  content: string;
+};
+
+type BuildCheck = {
+  command: string;
+  args?: string[];
+};
+
+type CommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+type CommandRunner = (command: string, args: string[]) => CommandResult;
+
+export type BuildMissionExecutionInput = {
+  missionId: string;
+  runId: string;
+  targetRepo: string;
+  targetPaths: string[];
+  mutationPlan: BuildMutation[];
+  checks: BuildCheck[];
+};
+
+export type BuildMissionExecutionResult = {
+  branchName: string;
+  prNumber?: number;
+  prUrl?: string;
+  mutationSummary: string[];
+};
+
+const DEFAULT_BASE_BRANCH = 'main';
+const DEFAULT_COMMIT_MESSAGE_PREFIX = 'feat(build): ';
+
+const PROTECTED_PATH_PREFIXES = [
+  'control-plane/',
+  'entities/',
+  'runtime/',
+  'policies/'
+] as const;
+
+const FORBIDDEN_STAGE_PREFIXES = ['artifacts/', '.tmp/', 'runtime-data/'] as const;
+const FORBIDDEN_STAGE_SUFFIXES = ['/run-metadata.json', 'run-metadata.json'] as const;
+
+function defaultCommandRunner(command: string, args: string[]): CommandResult {
+  try {
+    const stdout = execFileSync(command, args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    return {
+      code: 0,
+      stdout: stdout ?? '',
+      stderr: ''
+    };
+  } catch (error) {
+    const execError = error as { status?: number; stdout?: string | Buffer; stderr?: string | Buffer };
+    return {
+      code: execError.status ?? 1,
+      stdout: typeof execError.stdout === 'string'
+        ? execError.stdout
+        : Buffer.isBuffer(execError.stdout)
+          ? execError.stdout.toString('utf8')
+          : '',
+      stderr: typeof execError.stderr === 'string'
+        ? execError.stderr
+        : Buffer.isBuffer(execError.stderr)
+          ? execError.stderr.toString('utf8')
+          : ''
+    };
+  }
+}
+
+function runOrFail(runner: CommandRunner, command: string, args: string[], codeOnFailure: string): CommandResult {
+  const result = runner(command, args);
+  if (result.code !== 0) {
+    throw new Error(codeOnFailure);
+  }
+  return result;
+}
+
+function normalizeRepoPath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/').trim();
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function isSafePath(pathValue: string): boolean {
+  return pathValue.length > 0
+    && !pathValue.startsWith('/')
+    && !pathValue.includes('..')
+    && !pathValue.includes('\\');
+}
+
+function isProtectedPath(pathValue: string): boolean {
+  return PROTECTED_PATH_PREFIXES.some((prefix) => pathValue.startsWith(prefix));
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = escapeRegex(glob);
+  const pattern = escaped
+    .replace(/\*\*/g, '__DOUBLE_STAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLE_STAR__/g, '.*');
+  return new RegExp(`^${pattern}$`);
+}
+
+function pathMatchesAllowed(pathValue: string, allowedPatterns: string[]): boolean {
+  return allowedPatterns.some((pattern) => globToRegExp(pattern).test(pathValue));
+}
+
+function buildBranchName(input: { missionId: string; runId: string; targetRepo: string; targetPaths: string[] }): string {
+  const mission = input.missionId.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'mission';
+  const hash = sha256(canonicalStringify({
+    missionId: input.missionId,
+    runId: input.runId,
+    targetRepo: input.targetRepo,
+    targetPaths: [...input.targetPaths].sort((left, right) => left.localeCompare(right))
+  })).slice(0, 12);
+  return `build/${mission}/${hash}`;
+}
+
+function branchExists(runner: CommandRunner, branchName: string): boolean {
+  const local = runner('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`]);
+  if (local.code === 0) {
+    return true;
+  }
+
+  const remote = runner('git', ['ls-remote', '--heads', 'origin', branchName]);
+  if (remote.code !== 0) {
+    return false;
+  }
+  return remote.stdout.trim().length > 0;
+}
+
+function parsePrNumber(output: string): number | undefined {
+  const lines = output.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+  for (const line of lines) {
+    const match = line.match(/\/pull\/(\d+)/);
+    if (!match) {
+      continue;
+    }
+    const parsed = Number.parseInt(match[1] as string, 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function parsePrView(output: string): { number?: number; url?: string; body?: string } {
+  const trimmed = output.trim();
+  if (trimmed.length === 0) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as { number?: unknown; url?: unknown; body?: unknown };
+    return {
+      ...(typeof parsed.number === 'number' ? { number: parsed.number } : {}),
+      ...(typeof parsed.url === 'string' ? { url: parsed.url } : {}),
+      ...(typeof parsed.body === 'string' ? { body: parsed.body } : {})
+    };
+  } catch {
+    return {
+      ...(parsePrNumber(trimmed) ? { number: parsePrNumber(trimmed) } : {})
+    };
+  }
+}
+
+function writePrBodyFile(runId: string, body: string): string {
+  fs.mkdirSync('.tmp', { recursive: true });
+  const filePath = path.join('.tmp', `build-run-${runId}.pr-body.md`);
+  fs.writeFileSync(filePath, `${body.replace(/\r\n?/g, '\n').replace(/\n*$/, '')}\n`, 'utf8');
+  return filePath;
+}
+
+function ensureMutationsAllowed(input: { mutations: BuildMutation[]; targetPaths: string[] }): BuildMutation[] {
+  if (input.mutations.length === 0) {
+    throw new Error('BUILD_TARGET_SCOPE_DENIED');
+  }
+
+  const normalized = input.mutations
+    .map((mutation) => ({
+      path: normalizeRepoPath(mutation.path),
+      content: mutation.content
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+
+  const duplicates = normalized
+    .map((entry) => entry.path)
+    .filter((entry, index, list) => list.indexOf(entry) !== index);
+  if (duplicates.length > 0) {
+    throw new Error('BUILD_TARGET_SCOPE_DENIED');
+  }
+
+  for (const mutation of normalized) {
+    if (!isSafePath(mutation.path)) {
+      throw new Error('BUILD_TARGET_SCOPE_DENIED');
+    }
+    if (isProtectedPath(mutation.path)) {
+      throw new Error('BUILD_PROTECTED_SCOPE_FORBIDDEN');
+    }
+    if (!pathMatchesAllowed(mutation.path, input.targetPaths)) {
+      throw new Error('BUILD_TARGET_SCOPE_DENIED');
+    }
+  }
+
+  return normalized;
+}
+
+function ensureNoForbiddenStagedFiles(stagedFiles: string[]): void {
+  const normalized = stagedFiles.map((entry) => normalizeRepoPath(entry)).filter((entry) => entry.length > 0);
+  const forbidden = normalized.find((entry) => {
+    if (FORBIDDEN_STAGE_PREFIXES.some((prefix) => entry.startsWith(prefix))) {
+      return true;
+    }
+    return FORBIDDEN_STAGE_SUFFIXES.some((suffix) => entry === suffix || entry.endsWith(suffix));
+  });
+
+  if (forbidden) {
+    throw new Error('BUILD_PROTECTED_SCOPE_FORBIDDEN');
+  }
+}
+
+function ensureOnlyExpectedStagedFiles(stagedFiles: string[], expectedFiles: string[]): void {
+  const normalizedStaged = sortedUnique(stagedFiles.map((entry) => normalizeRepoPath(entry)).filter((entry) => entry.length > 0));
+  const normalizedExpected = sortedUnique(expectedFiles.map((entry) => normalizeRepoPath(entry)));
+
+  if (canonicalStringify(normalizedStaged) !== canonicalStringify(normalizedExpected)) {
+    throw new Error('BUILD_TARGET_SCOPE_DENIED');
+  }
+}
+
+function runChecks(runner: CommandRunner, checks: BuildCheck[]): void {
+  for (const check of [...checks].sort((left, right) => left.command.localeCompare(right.command))) {
+    const args = Array.isArray(check.args) ? [...check.args] : [];
+    runOrFail(runner, check.command, args, 'BUILD_TARGET_SCOPE_DENIED');
+  }
+}
+
+function buildProvenanceBody(input: {
+  currentBody: string;
+  missionId: string;
+  runId: string;
+  targetRepo: string;
+  targetPaths: string[];
+  branchName: string;
+  mutationSummary: string[];
+}): string {
+  const evidenceFields = Object.fromEntries(Object.entries({
+    'Mission ID': input.missionId,
+    'Run ID': input.runId,
+    'Profile': 'build',
+    'Target Repo': input.targetRepo,
+    'Target Paths': input.targetPaths.join(', ') || 'N/A',
+    'Artifacts Produced': 'runtime-only',
+    'Execution Path': 'build',
+    'Branch': input.branchName,
+    'Mutation Summary': input.mutationSummary.join(', ') || 'none'
+  }).sort(([left], [right]) => left.localeCompare(right)));
+
+  return mutationKernel({
+    currentBody: input.currentBody,
+    currentLabels: ['tier-3'],
+    desiredTier: 'tier-3',
+    evidenceFields,
+    allowedLabelMutations: ['tier-0', 'tier-1', 'tier-2', 'tier-3']
+  }).newBody;
+}
+
+function parseBuildMutations(value: unknown): BuildMutation[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => entry as Record<string, unknown>)
+    .flatMap((entry) => {
+      const filePath = typeof entry.path === 'string' ? entry.path : '';
+      const content = typeof entry.content === 'string' ? entry.content : '';
+      if (filePath.trim().length === 0) {
+        return [];
+      }
+      return [{ path: filePath, content }];
+    });
+}
+
+function parseBuildChecks(value: unknown): BuildCheck[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => entry as Record<string, unknown>)
+    .flatMap((entry) => {
+      const command = typeof entry.command === 'string' ? entry.command.trim() : '';
+      if (command.length === 0) {
+        return [];
+      }
+      const args = Array.isArray(entry.args)
+        ? entry.args.filter((arg): arg is string => typeof arg === 'string')
+        : [];
+      return [{ command, ...(args.length > 0 ? { args } : {}) }];
+    });
+}
+
+export function executeBuildMission(input: BuildMissionExecutionInput, options: { commandRunner?: CommandRunner } = {}): BuildMissionExecutionResult {
+  const runner = options.commandRunner ?? defaultCommandRunner;
+  const allowedPaths = sortedUnique(input.targetPaths.map((entry) => normalizeRepoPath(entry)).filter((entry) => entry.length > 0));
+  const branchName = buildBranchName({
+    missionId: input.missionId,
+    runId: input.runId,
+    targetRepo: input.targetRepo,
+    targetPaths: allowedPaths
+  });
+
+  if (branchExists(runner, branchName)) {
+    throw new Error('BUILD_TARGET_SCOPE_DENIED');
+  }
+
+  const normalizedMutations = ensureMutationsAllowed({
+    mutations: input.mutationPlan,
+    targetPaths: allowedPaths
+  });
+
+  runOrFail(runner, 'git', ['checkout', '-b', branchName], 'BUILD_TARGET_SCOPE_DENIED');
+
+  for (const mutation of normalizedMutations) {
+    fs.mkdirSync(path.dirname(mutation.path), { recursive: true });
+    fs.writeFileSync(mutation.path, mutation.content, 'utf8');
+  }
+
+  const targetFiles = normalizedMutations.map((entry) => entry.path);
+  runOrFail(runner, 'git', ['add', '--', ...targetFiles], 'BUILD_TARGET_SCOPE_DENIED');
+
+  const staged = runOrFail(runner, 'git', ['diff', '--cached', '--name-only'], 'BUILD_TARGET_SCOPE_DENIED')
+    .stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+
+  ensureNoForbiddenStagedFiles(staged);
+  ensureOnlyExpectedStagedFiles(staged, targetFiles);
+
+  runChecks(runner, input.checks);
+
+  runOrFail(
+    runner,
+    'git',
+    ['commit', '-m', `${DEFAULT_COMMIT_MESSAGE_PREFIX}${input.missionId}`],
+    'BUILD_TARGET_SCOPE_DENIED'
+  );
+  runOrFail(runner, 'git', ['push', '--set-upstream', 'origin', branchName], 'BUILD_TARGET_SCOPE_DENIED');
+
+  const viewResult = runner('gh', ['pr', 'view', '--head', branchName, '--json', 'number,url,body']);
+  const existing = viewResult.code === 0 ? parsePrView(viewResult.stdout) : {};
+
+  const mutationSummary = normalizedMutations.map((entry) => entry.path);
+  const prBody = buildProvenanceBody({
+    currentBody: existing.body ?? '',
+    missionId: input.missionId,
+    runId: input.runId,
+    targetRepo: input.targetRepo,
+    targetPaths: allowedPaths,
+    branchName,
+    mutationSummary
+  });
+  const prBodyFile = writePrBodyFile(input.runId, prBody);
+
+  let prNumber = existing.number;
+  let prUrl = existing.url;
+
+  if (typeof existing.number === 'number') {
+    runOrFail(runner, 'gh', ['pr', 'edit', String(existing.number), '--body-file', prBodyFile], 'BUILD_TARGET_SCOPE_DENIED');
+    runOrFail(runner, 'gh', ['pr', 'edit', String(existing.number), '--add-label', 'tier-3'], 'BUILD_TARGET_SCOPE_DENIED');
+  } else {
+    const createResult = runOrFail(runner, 'gh', [
+      'pr',
+      'create',
+      '--base',
+      DEFAULT_BASE_BRANCH,
+      '--head',
+      branchName,
+      '--title',
+      `${DEFAULT_COMMIT_MESSAGE_PREFIX}${input.missionId}`,
+      '--body-file',
+      prBodyFile
+    ], 'BUILD_TARGET_SCOPE_DENIED');
+
+    prNumber = parsePrNumber(createResult.stdout);
+    prUrl = createResult.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.includes('/pull/'));
+
+    if (prNumber === undefined || prUrl === undefined) {
+      const reloaded = runOrFail(runner, 'gh', ['pr', 'view', '--head', branchName, '--json', 'number,url'], 'BUILD_TARGET_SCOPE_DENIED');
+      const parsed = parsePrView(reloaded.stdout);
+      prNumber = parsed.number;
+      prUrl = parsed.url;
+    }
+
+    if (prNumber !== undefined) {
+      runOrFail(runner, 'gh', ['pr', 'edit', String(prNumber), '--add-label', 'tier-3'], 'BUILD_TARGET_SCOPE_DENIED');
+    }
+  }
+
+  return {
+    branchName,
+    ...(prNumber !== undefined ? { prNumber } : {}),
+    ...(prUrl ? { prUrl } : {}),
+    mutationSummary
+  };
+}
+
+export function parseBuildMissionContext(value: Record<string, unknown>): {
+  mutationPlan: BuildMutation[];
+  checks: BuildCheck[];
+} {
+  return {
+    mutationPlan: parseBuildMutations(value.buildMutations),
+    checks: parseBuildChecks(value.buildChecks)
+  };
+}
+
+export const __testOnly = {
+  buildBranchName,
+  ensureNoForbiddenStagedFiles,
+  ensureOnlyExpectedStagedFiles,
+  parseBuildMissionContext
+};

--- a/control-plane/operator/mission-service.profile.test.ts
+++ b/control-plane/operator/mission-service.profile.test.ts
@@ -1,10 +1,33 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createExecutionJournal } from '../journal/journal.ts';
 import { createMissionService } from './mission-service.ts';
+
+const executeBuildMissionMock = vi.fn();
+
+vi.mock('./build-mission-executor.ts', () => ({
+  executeBuildMission: (...args: unknown[]) => executeBuildMissionMock(...args),
+  parseBuildMissionContext: (value: Record<string, unknown>) => ({
+    mutationPlan: Array.isArray(value.buildMutations)
+      ? value.buildMutations.filter((entry): entry is { path: string; content: string } => (
+        typeof entry === 'object'
+        && entry !== null
+        && typeof (entry as { path?: unknown }).path === 'string'
+        && typeof (entry as { content?: unknown }).content === 'string'
+      ))
+      : [],
+    checks: Array.isArray(value.buildChecks)
+      ? value.buildChecks.filter((entry): entry is { command: string; args?: string[] } => (
+        typeof entry === 'object'
+        && entry !== null
+        && typeof (entry as { command?: unknown }).command === 'string'
+      ))
+      : []
+  })
+}));
 
 const tmpRoot = path.join('control-plane', '__tests__', 'tmp-mission-service-profile');
 const missionsDir = path.join(tmpRoot, 'missions');
@@ -131,6 +154,31 @@ function writeFixtures(): void {
     initialContext: {}
   });
 
+  writeJson(missionsDir, 'build-ok.json', {
+    missionId: 'build-ok',
+    projectId: 'smartfunds-core',
+    teamId: 'smartfunds-research-team',
+    workflowId: 'build-noop-workflow',
+    profile: 'build',
+    mutationIntent: 'code_change',
+    requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write'],
+    targetScope: {
+      repo: 'smartfunds-agent-sandbox',
+      paths: ['docs/**']
+    },
+    objective: 'build run',
+    successCriteria: ['create pr'],
+    deliverables: ['docs update'],
+    initialContext: {
+      buildMutations: [
+        {
+          path: 'docs/build-mission.md',
+          content: '# Build Mission\n'
+        }
+      ]
+    }
+  });
+
   writeJson(workflowsDir, 'lite-ok-workflow.json', {
     workflowId: 'lite-ok-workflow',
     nodes: [
@@ -160,18 +208,31 @@ function writeFixtures(): void {
       }
     ]
   });
+
+  writeJson(workflowsDir, 'build-noop-workflow.json', {
+    workflowId: 'build-noop-workflow',
+    nodes: []
+  });
 }
 
 beforeEach(() => {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
   fs.mkdirSync(tmpRoot, { recursive: true });
   writeFixtures();
+  executeBuildMissionMock.mockReset();
+  executeBuildMissionMock.mockReturnValue({
+    branchName: 'build/build-ok/abcdef123456',
+    prNumber: 42,
+    prUrl: 'https://example.test/repo/pull/42',
+    mutationSummary: ['docs/build-mission.md']
+  });
 });
 
 afterEach(() => {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
   fs.rmSync(path.join('artifacts', 'lite-ok'), { recursive: true, force: true });
   fs.rmSync(path.join('artifacts', 'governed-default'), { recursive: true, force: true });
+  fs.rmSync(path.join('artifacts', 'build-ok'), { recursive: true, force: true });
 });
 
 describe('mission-service profile routing', () => {
@@ -269,5 +330,47 @@ describe('mission-service profile routing', () => {
 
     const runs = journal.listRuns();
     expect(runs.some((run) => run.entrypoint.startsWith('workflow:governed-default-workflow:'))).toBe(true);
+  });
+
+  it('T-SPC-M5 routes build mission through build path and persists branch/pr metadata', async () => {
+    const service = createMissionService({
+      journal: createExecutionJournal({ rootDir: journalRoot }),
+      missionsDir,
+      workflowsDir,
+      teamsDir,
+      agentsDir
+    });
+
+    const result = await service.startMission({
+      missionId: 'build-ok',
+      params: {}
+    });
+
+    expect(result).toMatchObject({
+      missionId: 'build-ok',
+      status: 'completed',
+      profile: 'build',
+      executionPath: 'build',
+      branchName: 'build/build-ok/abcdef123456',
+      prNumber: 42
+    });
+    expect(executeBuildMissionMock).toHaveBeenCalledTimes(1);
+
+    const runId = String(result.workflowRun);
+    const metadata = JSON.parse(
+      fs.readFileSync(path.join('artifacts', 'build-ok', runId, 'run-metadata.json'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(metadata).toMatchObject({
+      profile: 'build',
+      executionPath: 'build',
+      branchName: 'build/build-ok/abcdef123456',
+      prNumber: 42
+    });
+
+    const runs = createExecutionJournal({ rootDir: journalRoot }).listRuns();
+    const missionRun = runs.find((run) => run.entrypoint === 'mission:build-ok');
+    expect(missionRun).toBeDefined();
+    expect(missionRun?.executionPath).toBe('build');
+    expect(runs.some((run) => run.entrypoint.startsWith('workflow:build-noop-workflow:'))).toBe(false);
   });
 });

--- a/control-plane/operator/mission-service.ts
+++ b/control-plane/operator/mission-service.ts
@@ -34,6 +34,7 @@ import {
   resolveExecutionProfile,
   type ExecutionPath
 } from './profile-policy.ts';
+import { executeBuildMission, parseBuildMissionContext } from './build-mission-executor.ts';
 
 type MissionServiceOptions = {
   journal?: ExecutionJournal;
@@ -346,7 +347,7 @@ async function executeMissionByPath(input: {
   executionPath: ExecutionPath;
   profile: string;
   workflowsDir?: string;
-}): Promise<{ runId: string; status: string }> {
+}): Promise<{ runId: string; status: string; metadata?: Record<string, unknown> }> {
   const workflow = loadWorkflowDefinitionById(input.workflowId, input.workflowsDir);
 
   if (input.executionPath === 'lite') {
@@ -455,7 +456,10 @@ async function executeMissionByPath(input: {
 
   return {
     runId: runRecord.runId,
-    status: runRecord.status
+    status: runRecord.status,
+    metadata: {
+      artifactCount: artifactFiles.length
+    }
   };
 }
 
@@ -473,6 +477,131 @@ async function executeLiteMission(input: {
     ...input,
     executionPath: 'lite'
   });
+}
+
+async function executeBuildMissionPath(input: {
+  journal: ExecutionJournal;
+  missionId: string;
+  projectId: string;
+  workflowId: string;
+  missionParameters: Record<string, string>;
+  missionContext: Record<string, unknown>;
+  profile: string;
+  targetScope?: { repo: string; paths?: string[] };
+}): Promise<{ runId: string; status: string; metadata?: Record<string, unknown> }> {
+  const run = input.journal.createRun({
+    projectId: input.projectId,
+    kind: 'mission',
+    entrypoint: `mission:${input.missionId}`,
+    profile: input.profile,
+    executionPath: 'build'
+  });
+
+  input.journal.appendEvent({
+    runId: run.runId,
+    type: 'PHASE_STARTED',
+    phase: 'implement',
+    payload: {
+      context_snapshot: {
+        missionId: input.missionId,
+        missionParameters: input.missionParameters,
+        metadata: {
+          workflowId: input.workflowId
+        }
+      }
+    }
+  });
+
+  const missionContextData = parseBuildMissionContext(input.missionContext);
+  const targetRepo = input.targetScope?.repo ?? 'smartfunds-agent-sandbox';
+  const targetPaths = input.targetScope?.paths ?? [];
+
+  let buildResult: ReturnType<typeof executeBuildMission>;
+  try {
+    buildResult = executeBuildMission({
+      missionId: input.missionId,
+      runId: run.runId,
+      targetRepo,
+      targetPaths,
+      mutationPlan: missionContextData.mutationPlan,
+      checks: missionContextData.checks
+    });
+  } catch (error) {
+    input.journal.appendEvent({
+      runId: run.runId,
+      type: 'RUN_FAILED',
+      phase: 'release',
+      payload: {
+        context_snapshot: {
+          missionId: input.missionId,
+          missionParameters: input.missionParameters,
+          metadata: {
+            workflowId: input.workflowId
+          }
+        },
+        error: error instanceof Error ? error.message : 'BUILD_TARGET_SCOPE_DENIED'
+      }
+    });
+    throw error;
+  }
+
+  input.journal.appendEvent({
+    runId: run.runId,
+    type: 'RUN_COMPLETED',
+    phase: 'release',
+    payload: {
+      context_snapshot: {
+        missionId: input.missionId,
+        missionParameters: input.missionParameters,
+        metadata: {
+          workflowId: input.workflowId
+        }
+      },
+      build: {
+        branchName: buildResult.branchName,
+        prNumber: buildResult.prNumber ?? null,
+        prUrl: buildResult.prUrl ?? null,
+        mutationSummary: buildResult.mutationSummary
+      }
+    }
+  });
+
+  const artifactFiles = listArtifactsForRun({
+    missionId: input.missionId,
+    runId: run.runId
+  }).filter((file) => file !== 'run-metadata.json');
+
+  writeArtifact({
+    missionId: input.missionId,
+    runId: run.runId,
+    type: 'json',
+    filename: 'run-metadata.json',
+    content: {
+      runId: run.runId,
+      missionId: input.missionId,
+      workflowId: input.workflowId,
+      status: 'completed',
+      profile: input.profile,
+      executionPath: 'build',
+      branchName: buildResult.branchName,
+      prNumber: buildResult.prNumber ?? null,
+      prUrl: buildResult.prUrl ?? null,
+      artifactCount: artifactFiles.length,
+      mutationSummary: [...buildResult.mutationSummary].sort((left, right) => left.localeCompare(right))
+    }
+  });
+
+  return {
+    runId: run.runId,
+    status: 'completed',
+    metadata: {
+      branchName: buildResult.branchName,
+      prNumber: buildResult.prNumber ?? null,
+      prUrl: buildResult.prUrl ?? null,
+      artifactCount: artifactFiles.length,
+      mutationSummary: [...buildResult.mutationSummary].sort((left, right) => left.localeCompare(right))
+    }
+  };
 }
 
 async function executeGovernedMission(input: {
@@ -500,10 +629,14 @@ async function executeMission(input: {
   missionContext: Record<string, unknown>;
   executionPath: ExecutionPath;
   profile: string;
+  targetScope?: { repo: string; paths?: string[] };
   workflowsDir?: string;
-}): Promise<{ runId: string; status: string }> {
+}): Promise<{ runId: string; status: string; metadata?: Record<string, unknown> }> {
   if (input.executionPath === 'lite') {
     return executeLiteMission(input);
+  }
+  if (input.executionPath === 'build') {
+    return executeBuildMissionPath(input);
   }
   return executeGovernedMission(input);
 }
@@ -551,6 +684,7 @@ export function createMissionService(options: MissionServiceOptions = {}) {
       missionContext: mergedContext,
       profile: resolved.profile,
       executionPath: resolved.executionPath,
+      targetScope: mission.targetScope,
       workflowsDir: options.workflowsDir
     });
 
@@ -564,6 +698,14 @@ export function createMissionService(options: MissionServiceOptions = {}) {
       status: mapRunStatusToMissionStatus(executed.status),
       profile: resolved.profile,
       executionPath: resolved.executionPath,
+      ...(resolved.executionPath === 'build' && executed.metadata
+        ? {
+          branchName: executed.metadata.branchName,
+          prNumber: executed.metadata.prNumber,
+          prUrl: executed.metadata.prUrl,
+          mutationSummary: executed.metadata.mutationSummary
+        }
+        : {}),
       teamId: mission.teamId,
       workflowId: mission.workflowId,
       workflowRun: executed.runId,
@@ -592,7 +734,13 @@ export function createMissionService(options: MissionServiceOptions = {}) {
         status: latest ? mapRunStatusToMissionStatus(latest.status) : 'created',
         workflowRun: latest?.runId ?? null,
         profile: latest?.profile ?? mission.profile ?? 'core',
-        executionPath: latest?.executionPath ?? ((mission.profile ?? 'core') === 'lite' ? 'lite' : 'governed'),
+        executionPath: latest?.executionPath ?? (
+          (mission.profile ?? 'core') === 'lite'
+            ? 'lite'
+            : (mission.profile ?? 'core') === 'build'
+              ? 'build'
+              : 'governed'
+        ),
         teamId: mission.teamId,
         workflowId: mission.workflowId
       };

--- a/control-plane/operator/profile-errors.ts
+++ b/control-plane/operator/profile-errors.ts
@@ -4,7 +4,13 @@ export type ProfileErrorCode =
   | 'PROFILE_EXECUTION_PATH_REQUIRED'
   | 'LITE_REPO_MUTATION_FORBIDDEN'
   | 'LITE_PR_OPEN_FORBIDDEN'
-  | 'LITE_PROTECTED_WRITE_FORBIDDEN';
+  | 'LITE_PROTECTED_WRITE_FORBIDDEN'
+  | 'BUILD_PROTECTED_SCOPE_FORBIDDEN'
+  | 'BUILD_TARGET_SCOPE_DENIED'
+  | 'BUILD_PR_OPEN_REQUIRED'
+  | 'BUILD_REPO_WRITE_REQUIRED'
+  | 'BUILD_MUTATION_INTENT_FORBIDDEN'
+  | 'BUILD_PROTECTED_WRITE_FORBIDDEN';
 
 export class ProfilePolicyError extends Error {
   readonly code: ProfileErrorCode;
@@ -14,4 +20,3 @@ export class ProfilePolicyError extends Error {
     this.code = code;
   }
 }
-

--- a/control-plane/operator/profile-policy.test.ts
+++ b/control-plane/operator/profile-policy.test.ts
@@ -46,6 +46,16 @@ describe('profile-policy', () => {
     expect(resolved.executionPath).toBe('governed');
   });
 
+  it('T-SPC-P6 resolves profile=build to build execution path', () => {
+    const resolved = resolveExecutionProfile({
+      mission: mission({ profile: 'build' })
+    });
+
+    expect(resolved.profile).toBe('build');
+    expect(resolved.executionPath).toBe('build');
+    expect(resolved.allowedCapabilities).toEqual(['artifact_write', 'pr_open', 'read', 'repo_write']);
+  });
+
   it('T-SPB-P4 lite rejects forbidden capability requests', () => {
     expect(() => assertProfileCapabilities({
       mission: mission({
@@ -61,5 +71,99 @@ describe('profile-policy', () => {
     expect(() => assertLiteTaskAllowed('open_pr')).toThrowError('LITE_PR_OPEN_FORBIDDEN');
     expect(() => assertLiteTaskAllowed('protected_write')).toThrowError('LITE_PROTECTED_WRITE_FORBIDDEN');
   });
-});
 
+  it('T-SPC-P7 build requires repo_write and pr_open and rejects protected_write', () => {
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'code_change',
+        requestedCapabilities: ['pr_open', 'read'],
+        targetScope: {
+          repo: 'smartfunds-agent-sandbox',
+          paths: ['docs/**']
+        }
+      }),
+      profile: 'build'
+    })).toThrowError('BUILD_REPO_WRITE_REQUIRED');
+
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'code_change',
+        requestedCapabilities: ['repo_write', 'read'],
+        targetScope: {
+          repo: 'smartfunds-agent-sandbox',
+          paths: ['docs/**']
+        }
+      }),
+      profile: 'build'
+    })).toThrowError('BUILD_PR_OPEN_REQUIRED');
+
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'code_change',
+        requestedCapabilities: ['artifact_write', 'pr_open', 'protected_write', 'read', 'repo_write'],
+        targetScope: {
+          repo: 'smartfunds-agent-sandbox',
+          paths: ['docs/**']
+        }
+      }),
+      profile: 'build'
+    })).toThrowError('BUILD_PROTECTED_WRITE_FORBIDDEN');
+  });
+
+  it('T-SPC-P8 build enforces mutation intent and protected path boundaries', () => {
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'governance_change',
+        requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write'],
+        targetScope: {
+          repo: 'smartfunds-agent-sandbox',
+          paths: ['docs/**']
+        }
+      }),
+      profile: 'build'
+    })).toThrowError('BUILD_MUTATION_INTENT_FORBIDDEN');
+
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'code_change',
+        requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write'],
+        targetScope: {
+          repo: 'smartfunds-agent-sandbox',
+          paths: ['control-plane/**']
+        }
+      }),
+      profile: 'build'
+    })).toThrowError('BUILD_PROTECTED_SCOPE_FORBIDDEN');
+  });
+
+  it('T-SPC-P9 build accepts allowed scope and intent', () => {
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'ui_change',
+        requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write'],
+        targetScope: {
+          repo: 'smartfunds-agent-sandbox',
+          paths: ['dashboard/**']
+        }
+      }),
+      profile: 'build'
+    })).not.toThrow();
+  });
+
+  it('T-SPC-P10 build requires explicit target scope paths', () => {
+    expect(() => assertProfileCapabilities({
+      mission: mission({
+        profile: 'build',
+        mutationIntent: 'code_change',
+        requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write']
+      }),
+      profile: 'build'
+    })).toThrowError('BUILD_TARGET_SCOPE_DENIED');
+  });
+});

--- a/control-plane/operator/profile-policy.ts
+++ b/control-plane/operator/profile-policy.ts
@@ -1,10 +1,10 @@
 import { PROFILE_CAPABILITIES } from '../policy/capabilities.ts';
-import type { CapabilityClass, PolicyProfile } from '../policy/types.ts';
+import type { CapabilityClass, MutationIntent, PolicyProfile } from '../policy/types.ts';
 import { validateProfileRequest } from '../policy/profile-validation.ts';
 import type { MissionDefinition } from '../missions/mission-types.ts';
 import { ProfilePolicyError, type ProfileErrorCode } from './profile-errors.ts';
 
-export type ExecutionPath = 'governed' | 'lite';
+export type ExecutionPath = 'governed' | 'lite' | 'build';
 
 const POLICY_PROFILES: readonly PolicyProfile[] = ['lite', 'build', 'core'] as const;
 
@@ -19,6 +19,22 @@ const LITE_FORBIDDEN_TASK_PATTERNS: Array<{ pattern: RegExp; code: ProfileErrorC
   { pattern: /commit/i, code: 'LITE_REPO_MUTATION_FORBIDDEN', reason: 'Lite missions cannot execute commit workflows.' },
   { pattern: /patch/i, code: 'LITE_REPO_MUTATION_FORBIDDEN', reason: 'Lite missions cannot execute patch workflows.' }
 ];
+
+const BUILD_ALLOWED_MUTATION_INTENTS: readonly MutationIntent[] = [
+  'none',
+  'artifact',
+  'code_change',
+  'ui_change',
+  'product_update',
+  'tooling_change'
+] as const;
+
+const BUILD_PROTECTED_PATH_PREFIXES = [
+  'control-plane/',
+  'entities/',
+  'runtime/',
+  'policies/'
+] as const;
 
 function isPolicyProfile(value: string): value is PolicyProfile {
   return POLICY_PROFILES.includes(value as PolicyProfile);
@@ -44,6 +60,19 @@ function mapCapabilityDenial(capability: CapabilityClass): ProfilePolicyError {
   return new ProfilePolicyError('PROFILE_CAPABILITY_DENIED', `Lite missions cannot request ${capability}.`);
 }
 
+function mapBuildCapabilityDenial(capability: CapabilityClass): ProfilePolicyError {
+  if (capability === 'protected_write') {
+    return new ProfilePolicyError('BUILD_PROTECTED_WRITE_FORBIDDEN', 'Build missions cannot request protected_write.');
+  }
+  if (capability === 'repo_write') {
+    return new ProfilePolicyError('BUILD_REPO_WRITE_REQUIRED', 'Build missions require repo_write.');
+  }
+  if (capability === 'pr_open') {
+    return new ProfilePolicyError('BUILD_PR_OPEN_REQUIRED', 'Build missions require pr_open.');
+  }
+  return new ProfilePolicyError('PROFILE_CAPABILITY_DENIED', `Build missions cannot request ${capability}.`);
+}
+
 function extractDeniedCapability(violations: string[]): CapabilityClass | null {
   const denied = violations
     .find((violation) => violation.startsWith('profile_lite_disallows_') && !violation.includes('mutation_intent'));
@@ -64,6 +93,11 @@ function extractDeniedCapability(violations: string[]): CapabilityClass | null {
   }
 
   return null;
+}
+
+function isBuildProtectedPath(pathValue: string): boolean {
+  const normalized = pathValue.trim();
+  return BUILD_PROTECTED_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 export function resolveExecutionProfile(input: {
@@ -88,7 +122,11 @@ export function resolveExecutionProfile(input: {
 
   return {
     profile: effective,
-    executionPath: effective === 'lite' ? 'lite' : 'governed',
+    executionPath: effective === 'lite'
+      ? 'lite'
+      : effective === 'build'
+        ? 'build'
+        : 'governed',
     allowedCapabilities: [...PROFILE_CAPABILITIES[effective]].sort((left, right) => left.localeCompare(right))
   };
 }
@@ -97,6 +135,37 @@ export function assertProfileCapabilities(input: {
   mission: MissionDefinition;
   profile: PolicyProfile;
 }): void {
+  if (input.profile === 'build') {
+    if (!input.mission.targetScope || input.mission.targetScope.paths === undefined || input.mission.targetScope.paths.length === 0) {
+      throw new ProfilePolicyError('BUILD_TARGET_SCOPE_DENIED', 'Build missions must declare a targetScope with at least one path.');
+    }
+
+    const requested = new Set(input.mission.requestedCapabilities ?? []);
+    if (!requested.has('repo_write')) {
+      throw new ProfilePolicyError('BUILD_REPO_WRITE_REQUIRED', 'Build missions must request repo_write.');
+    }
+    if (!requested.has('pr_open')) {
+      throw new ProfilePolicyError('BUILD_PR_OPEN_REQUIRED', 'Build missions must request pr_open.');
+    }
+
+    const mutationIntent = input.mission.mutationIntent ?? 'none';
+    if (!BUILD_ALLOWED_MUTATION_INTENTS.includes(mutationIntent)) {
+      throw new ProfilePolicyError(
+        'BUILD_MUTATION_INTENT_FORBIDDEN',
+        `Build missions cannot request mutationIntent=${mutationIntent}.`
+      );
+    }
+
+    const requestedPaths = input.mission.targetScope?.paths ?? [];
+    const protectedPath = requestedPaths.find((entry) => isBuildProtectedPath(entry));
+    if (protectedPath) {
+      throw new ProfilePolicyError(
+        'BUILD_PROTECTED_SCOPE_FORBIDDEN',
+        `Build missions cannot target protected path: ${protectedPath}.`
+      );
+    }
+  }
+
   const validation = validateProfileRequest({
     profile: input.profile,
     requestedCapabilities: input.mission.requestedCapabilities ?? [],
@@ -112,6 +181,49 @@ export function assertProfileCapabilities(input: {
     const deniedCapability = extractDeniedCapability(validation.violations);
     if (deniedCapability) {
       throw mapCapabilityDenial(deniedCapability);
+    }
+  }
+
+  if (input.profile === 'build') {
+    const buildCapabilityDenial = validation.violations
+      .find((violation) => violation.startsWith('profile_build_disallows_') && !violation.includes('mutation_intent'))
+      ?.replace('profile_build_disallows_', '');
+
+    if (
+      buildCapabilityDenial === 'read'
+      || buildCapabilityDenial === 'artifact_write'
+      || buildCapabilityDenial === 'repo_write'
+      || buildCapabilityDenial === 'pr_open'
+      || buildCapabilityDenial === 'protected_write'
+    ) {
+      throw mapBuildCapabilityDenial(buildCapabilityDenial);
+    }
+
+    const deniedPathViolation = validation.violations
+      .find((violation) => violation.startsWith('profile_build_disallows_target_path_'));
+    if (deniedPathViolation) {
+      const deniedPath = deniedPathViolation.replace('profile_build_disallows_target_path_', '');
+      const code = isBuildProtectedPath(deniedPath)
+        ? 'BUILD_PROTECTED_SCOPE_FORBIDDEN'
+        : 'BUILD_TARGET_SCOPE_DENIED';
+      throw new ProfilePolicyError(code, `Build missions cannot target path: ${deniedPath}.`);
+    }
+
+    if (validation.violations.includes('profile_build_disallows_target_repo')) {
+      throw new ProfilePolicyError(
+        'BUILD_TARGET_SCOPE_DENIED',
+        'Build missions cannot target the requested repository.'
+      );
+    }
+
+    const mutationViolation = validation.violations
+      .find((violation) => violation.startsWith('profile_build_disallows_mutation_intent_'));
+    if (mutationViolation) {
+      const deniedIntent = mutationViolation.replace('profile_build_disallows_mutation_intent_', '');
+      throw new ProfilePolicyError(
+        'BUILD_MUTATION_INTENT_FORBIDDEN',
+        `Build missions cannot request mutationIntent=${deniedIntent}.`
+      );
     }
   }
 
@@ -139,4 +251,3 @@ export function assertLiteWorkflowTasks(workflowTasks: string[]): void {
     assertLiteTaskAllowed(task);
   }
 }
-

--- a/control-plane/policy/profile-validation.test.ts
+++ b/control-plane/policy/profile-validation.test.ts
@@ -139,4 +139,19 @@ describe('profile-validation', () => {
       })
     );
   });
+
+  it('T-SPC-PV10 build accepts ui_change mutation intent on allowed scope', () => {
+    const result = validateProfileRequest({
+      profile: 'build',
+      requestedCapabilities: ['artifact_write', 'pr_open', 'read', 'repo_write'],
+      mutationIntent: 'ui_change',
+      targetScope: {
+        repo: 'smartfunds-agent-sandbox',
+        paths: ['dashboard/ui/index.html']
+      }
+    }, registry);
+
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
 });

--- a/control-plane/policy/profile-validation.ts
+++ b/control-plane/policy/profile-validation.ts
@@ -19,7 +19,14 @@ const CAPABILITY_CLASSES: CapabilityClass[] = [
 const MUTATION_INTENTS: MutationIntent[] = [
   'artifact',
   'code_change',
+  'control_plane_mutation',
+  'entity_registry_mutation',
+  'financial_rail_mutation',
   'governance_change',
+  'product_update',
+  'protected_infra_mutation',
+  'tooling_change',
+  'ui_change',
   'none'
 ];
 

--- a/control-plane/policy/types.ts
+++ b/control-plane/policy/types.ts
@@ -14,7 +14,14 @@ export type MutationIntent =
   | 'none'
   | 'artifact'
   | 'code_change'
-  | 'governance_change';
+  | 'ui_change'
+  | 'product_update'
+  | 'tooling_change'
+  | 'governance_change'
+  | 'protected_infra_mutation'
+  | 'financial_rail_mutation'
+  | 'entity_registry_mutation'
+  | 'control_plane_mutation';
 
 export interface TargetScope {
   repo: string;

--- a/control-plane/workflows/definitions/build-dashboard-copy-refresh.json
+++ b/control-plane/workflows/definitions/build-dashboard-copy-refresh.json
@@ -1,0 +1,9 @@
+{
+  "workflowId": "build-dashboard-copy-refresh",
+  "nodes": [
+    {
+      "id": "build-placeholder",
+      "task": "output.write_markdown"
+    }
+  ]
+}

--- a/dashboard/__tests__/artifactLoader.test.ts
+++ b/dashboard/__tests__/artifactLoader.test.ts
@@ -143,4 +143,40 @@ describe('artifactLoader', () => {
       expect((error as ArtifactLoaderError).code).toBe('INVALID_ARTIFACT_PATH');
     }
   });
+
+  it('T-SPC-AL7 exposes build branch/pr metadata and mutation summary from run metadata', () => {
+    writeFile(path.join(fixturesRoot, 'build-mission', 'run_0500', 'report.md'), '# Report\n');
+    writeFile(path.join(fixturesRoot, 'build-mission', 'run_0500', 'run-metadata.json'), JSON.stringify({
+      profile: 'build',
+      executionPath: 'build',
+      branchName: 'build/build-mission/abcd1234',
+      prNumber: 12,
+      prUrl: 'https://example.test/repo/pull/12',
+      mutationSummary: ['docs/a.md', 'dashboard/ui/index.html']
+    }));
+
+    const loader = new ArtifactLoader(fixturesRoot);
+    expect(loader.listRuns()).toEqual([
+      {
+        runId: 'run_0500',
+        missionId: 'build-mission',
+        profile: 'build',
+        executionPath: 'build',
+        branchName: 'build/build-mission/abcd1234',
+        prNumber: 12,
+        prUrl: 'https://example.test/repo/pull/12'
+      }
+    ]);
+
+    expect(loader.getRunDetails('run_0500')).toMatchObject({
+      runId: 'run_0500',
+      missionId: 'build-mission',
+      profile: 'build',
+      executionPath: 'build',
+      branchName: 'build/build-mission/abcd1234',
+      prNumber: 12,
+      prUrl: 'https://example.test/repo/pull/12',
+      mutationSummary: ['dashboard/ui/index.html', 'docs/a.md']
+    });
+  });
 });

--- a/dashboard/artifactLoader.ts
+++ b/dashboard/artifactLoader.ts
@@ -172,6 +172,10 @@ function maybeExtractMetadata(runDirectory: string): {
   profile?: string;
   executionPath?: string;
   artifactCount?: number;
+  branchName?: string;
+  prNumber?: number;
+  prUrl?: string;
+  mutationSummary?: string[];
   nodes?: string[];
 } {
   const metadataFileNames = ['run-metadata.json', 'run.json', 'metadata.json', 'summary.json'];
@@ -189,10 +193,16 @@ function maybeExtractMetadata(runDirectory: string): {
       const profile = typeof parsed.profile === 'string' ? parsed.profile : undefined;
       const executionPath = typeof parsed.executionPath === 'string' ? parsed.executionPath : undefined;
       const artifactCount = typeof parsed.artifactCount === 'number' ? parsed.artifactCount : undefined;
+      const branchName = typeof parsed.branchName === 'string' ? parsed.branchName : undefined;
+      const prNumber = typeof parsed.prNumber === 'number' ? parsed.prNumber : undefined;
+      const prUrl = typeof parsed.prUrl === 'string' ? parsed.prUrl : undefined;
+      const mutationSummary = Array.isArray(parsed.mutationSummary) && parsed.mutationSummary.every((entry) => typeof entry === 'string')
+        ? [...parsed.mutationSummary].sort((left, right) => left.localeCompare(right)) as string[]
+        : undefined;
       const nodes = Array.isArray(parsed.nodes) && parsed.nodes.every((entry) => typeof entry === 'string')
         ? parsed.nodes as string[]
         : undefined;
-      return { workflowId, status, profile, executionPath, artifactCount, nodes };
+      return { workflowId, status, profile, executionPath, artifactCount, branchName, prNumber, prUrl, mutationSummary, nodes };
     } catch {
       continue;
     }
@@ -237,7 +247,10 @@ export class ArtifactLoader {
         ...(metadata.status ? { status: metadata.status } : {}),
         ...(metadata.profile ? { profile: metadata.profile } : {}),
         ...(metadata.executionPath ? { executionPath: metadata.executionPath } : {}),
-        ...(typeof metadata.artifactCount === 'number' ? { artifactCount: metadata.artifactCount } : {})
+        ...(typeof metadata.artifactCount === 'number' ? { artifactCount: metadata.artifactCount } : {}),
+        ...(metadata.branchName ? { branchName: metadata.branchName } : {}),
+        ...(typeof metadata.prNumber === 'number' ? { prNumber: metadata.prNumber } : {}),
+        ...(metadata.prUrl ? { prUrl: metadata.prUrl } : {})
       };
     });
   }
@@ -258,6 +271,10 @@ export class ArtifactLoader {
       ...(metadata.profile ? { profile: metadata.profile } : {}),
       ...(metadata.executionPath ? { executionPath: metadata.executionPath } : {}),
       ...(typeof metadata.artifactCount === 'number' ? { artifactCount: metadata.artifactCount } : {}),
+      ...(metadata.branchName ? { branchName: metadata.branchName } : {}),
+      ...(typeof metadata.prNumber === 'number' ? { prNumber: metadata.prNumber } : {}),
+      ...(metadata.prUrl ? { prUrl: metadata.prUrl } : {}),
+      ...(metadata.mutationSummary ? { mutationSummary: metadata.mutationSummary } : {}),
       ...(metadata.nodes ? { nodes: metadata.nodes } : {}),
       artifacts: listArtifacts(runDirectory.runDirectory)
     };

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -7,6 +7,9 @@ export interface RunSummary {
   profile?: string;
   executionPath?: string;
   artifactCount?: number;
+  branchName?: string;
+  prNumber?: number;
+  prUrl?: string;
 }
 
 export interface ArtifactSummary {
@@ -23,6 +26,10 @@ export interface RunDetails {
   profile?: string;
   executionPath?: string;
   artifactCount?: number;
+  branchName?: string;
+  prNumber?: number;
+  prUrl?: string;
+  mutationSummary?: string[];
   nodes?: string[];
   artifacts: ArtifactSummary[];
 }

--- a/docs/architecture/build-profile-v1.md
+++ b/docs/architecture/build-profile-v1.md
@@ -1,0 +1,67 @@
+# Build Profile v1 Activation
+
+## Scope
+
+Sprint C activates `build` as a real runtime execution lane.
+
+The activation is additive:
+
+- Lite remains active for non-mutating missions.
+- Build is now active for bounded code-shipping missions.
+- Core is not yet profile-activated as a dedicated runtime lane.
+- Tier governance remains authoritative for current governance enforcement.
+
+## Runtime Dispatch
+
+Mission execution now supports explicit profile routing:
+
+- `executeLiteMission()`
+- `executeBuildMission()`
+- `executeGovernedMission()` (legacy/default path)
+
+`profile=build` routes only to the dedicated Build executor path.
+
+## Build Capability Contract
+
+Build requires and allows:
+
+- `read`
+- `artifact_write`
+- `repo_write`
+- `pr_open`
+
+Build rejects:
+
+- `protected_write`
+
+Deterministic Build errors are emitted for forbidden capabilities, forbidden intents, and denied target scope.
+
+## Scope Boundaries
+
+Build scope enforcement remains registry-driven and conservative for non-Core surfaces:
+
+- `apps/**`
+- `dashboard/**`
+- `tools/**`
+- `docs/**`
+
+Protected/Core-sensitive paths remain out of Build scope.
+
+## Build Execution Flow
+
+Dedicated Build execution performs:
+
+1. profile/capability/scope/intent validation
+2. deterministic branch name derivation
+3. bounded file mutation in approved scope only
+4. staged-file hygiene checks (artifact leakage rejection)
+5. commit + push
+6. PR open/update
+7. machine-generated runtime provenance in PR body
+8. run metadata emission (`profile`, `executionPath`, branch/PR data, mutation summary)
+
+## Governance Compatibility
+
+Build PR body generation reuses existing deterministic governance mutation patterns and preserves tier/evidence structure compatibility.
+
+No global CI/workflow cutover is introduced in Sprint C.

--- a/docs/runbooks/build-profile-operations.md
+++ b/docs/runbooks/build-profile-operations.md
@@ -1,0 +1,76 @@
+# Runbook: Build Profile Operations
+
+## Status
+
+- Lite: active
+- Build: active
+- Core profile lane: not yet active
+- Tier governance: retained and required
+
+This runbook documents Build lane operations for Sprint C activation.
+
+## Run a Build Mission
+
+```bash
+npm run mission:build -- --mission dashboard-copy-refresh
+```
+
+Expected output includes:
+
+- Mission ID
+- Profile (`build`)
+- Execution Path (`build`)
+- Run ID
+- Branch name
+- PR number/URL (when available)
+- Status
+- Artifact count
+
+## Inspect Build Run Metadata
+
+```bash
+npm run runs:list
+npm run artifacts:view -- --run <run-id>
+```
+
+Build run metadata includes:
+
+- `profile=build`
+- `executionPath=build`
+- `branchName`
+- `prNumber` / `prUrl`
+- `artifactCount`
+- `mutationSummary`
+
+## Build Mission Contract
+
+Build missions must include:
+
+- `profile: "build"`
+- `requestedCapabilities` with `repo_write` and `pr_open`
+- `targetScope` repo + conservative path globs
+- Build-safe `mutationIntent` (for example `code_change`, `ui_change`, `product_update`, `tooling_change`)
+
+Build missions must not request `protected_write`.
+
+## Artifact Leakage Safeguards
+
+Build staged-file hygiene rejects runtime artifact leakage, including:
+
+- `artifacts/**`
+- `.tmp/**`
+- `runtime-data/**`
+- runtime metadata files such as `run-metadata.json`
+
+If leakage is detected, Build execution fails deterministically before commit.
+
+## Governance Notes
+
+Build activation does not remove or replace:
+
+- tier labels
+- evidence blocks
+- `validate-pr.ts`
+- legacy governed/default runtime path
+
+Core boundary activation is deferred to later sprints.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "swarms:execute": "node --experimental-strip-types control-plane/cli/swarms-execute.ts",
     "mission:run": "node --experimental-strip-types control-plane/cli/mission-run.ts",
     "mission:lite": "node --experimental-strip-types control-plane/cli/mission-lite.ts",
+    "mission:build": "node --experimental-strip-types control-plane/cli/mission-build.ts",
     "operator": "node --experimental-strip-types control-plane/operator/cli.ts",
     "mission:inspect": "node --experimental-strip-types control-plane/cli/mission-inspect.ts",
     "mission:agents": "node --experimental-strip-types control-plane/cli/mission-agents.ts",

--- a/scripts/__tests__/runs-list.test.ts
+++ b/scripts/__tests__/runs-list.test.ts
@@ -77,4 +77,27 @@ describe('runs:list script', () => {
     expect(out).toContain('status=completed');
     expect(out).toContain('artifacts=2');
   });
+
+  it('T-SPC-RL5 includes branch and PR metadata for build runs', async () => {
+    const runId = 'run_smartfunds-core_0010';
+    const runDir = path.join(artifactsRoot, 'build-mission', runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'run-metadata.json'), JSON.stringify({
+      profile: 'build',
+      executionPath: 'build',
+      status: 'completed',
+      artifactCount: 0,
+      branchName: 'build/build-mission/abc123',
+      prNumber: 77
+    }), 'utf8');
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await main([]);
+    expect(code).toBe(0);
+    const out = stdout.mock.calls.map((call) => String(call[0])).join('');
+    expect(out).toContain('profile=build');
+    expect(out).toContain('path=build');
+    expect(out).toContain('branch=build/build-mission/abc123');
+    expect(out).toContain('pr=77');
+  });
 });

--- a/scripts/artifacts-utils.ts
+++ b/scripts/artifacts-utils.ts
@@ -12,6 +12,10 @@ export type RunArtifactMetadata = {
   executionPath?: string;
   status?: string;
   artifactCount?: number;
+  branchName?: string;
+  prNumber?: number;
+  prUrl?: string;
+  mutationSummary?: string[];
 };
 
 export function findRunDirectoriesByRunId(artifactsRoot: string, runId: string): ResolvedRunDirectory[] {
@@ -97,7 +101,17 @@ export function readRunMetadata(directory: string): RunArtifactMetadata {
       ...(typeof parsed.profile === 'string' ? { profile: parsed.profile } : {}),
       ...(typeof parsed.executionPath === 'string' ? { executionPath: parsed.executionPath } : {}),
       ...(typeof parsed.status === 'string' ? { status: parsed.status } : {}),
-      ...(typeof parsed.artifactCount === 'number' ? { artifactCount: parsed.artifactCount } : {})
+      ...(typeof parsed.artifactCount === 'number' ? { artifactCount: parsed.artifactCount } : {}),
+      ...(typeof parsed.branchName === 'string' ? { branchName: parsed.branchName } : {}),
+      ...(typeof parsed.prNumber === 'number' ? { prNumber: parsed.prNumber } : {}),
+      ...(typeof parsed.prUrl === 'string' ? { prUrl: parsed.prUrl } : {}),
+      ...(Array.isArray(parsed.mutationSummary)
+        ? {
+          mutationSummary: parsed.mutationSummary
+            .filter((entry): entry is string => typeof entry === 'string')
+            .sort((left, right) => left.localeCompare(right))
+        }
+        : {})
     };
   } catch {
     return {};

--- a/scripts/artifacts-view.ts
+++ b/scripts/artifacts-view.ts
@@ -62,7 +62,16 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     if (typeof metadata.artifactCount === 'number') {
       process.stdout.write(`Artifact Count: ${String(metadata.artifactCount)}\n`);
     }
-    if (metadata.profile || metadata.executionPath || typeof metadata.artifactCount === 'number') {
+    if (typeof metadata.branchName === 'string') {
+      process.stdout.write(`Branch: ${metadata.branchName}\n`);
+    }
+    if (typeof metadata.prNumber === 'number') {
+      process.stdout.write(`PR Number: ${String(metadata.prNumber)}\n`);
+    }
+    if (typeof metadata.prUrl === 'string') {
+      process.stdout.write(`PR URL: ${metadata.prUrl}\n`);
+    }
+    if (metadata.profile || metadata.executionPath || typeof metadata.artifactCount === 'number' || metadata.branchName || typeof metadata.prNumber === 'number' || metadata.prUrl) {
       process.stdout.write('\n');
     }
 

--- a/scripts/runs-list.ts
+++ b/scripts/runs-list.ts
@@ -24,7 +24,11 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
       const artifacts = typeof run.metadata.artifactCount === 'number'
         ? ` artifacts=${String(run.metadata.artifactCount)}`
         : '';
-      process.stdout.write(`${run.runId}  ${run.missionId}${profile}${executionPath}${status}${artifacts}\n`);
+      const branchName = run.metadata.branchName ? ` branch=${run.metadata.branchName}` : '';
+      const prNumber = typeof run.metadata.prNumber === 'number' ? ` pr=${String(run.metadata.prNumber)}` : '';
+      process.stdout.write(
+        `${run.runId}  ${run.missionId}${profile}${executionPath}${status}${artifacts}${branchName}${prNumber}\n`
+      );
     }
 
     return 0;


### PR DESCRIPTION
tier-3

```evidence
Risk Tier: 3
Justification: Activates a new build runtime execution lane with repository mutation + PR flow while preserving existing lite and governed paths; changes impact governance-adjacent operator runtime behavior.
Affected Paths: control-plane/operator/**, control-plane/policy/**, control-plane/journal/**, control-plane/observability/**, control-plane/cli/**, control-plane/missions/definitions/build/**, control-plane/workflows/definitions/build-dashboard-copy-refresh.json, scripts/**, dashboard/**, docs/architecture/build-profile-v1.md, docs/runbooks/build-profile-operations.md, package.json
Tests Added: build executor unit tests, profile-policy build enforcement tests, mission-service build routing tests, mission-build CLI tests, observability metadata tests, workflow consistency + targeted regression suites
Determinism Statement: Build path uses deterministic branch derivation from mission/run scope hash, sorted mutation summaries, stable error codes/messages, fail-closed staged-file hygiene, and governance-compatible deterministic PR body mutation patterns
Execution Path: build
Profile Activation: Lite active; Build active; Core not profile-activated
Backward Compatibility: Legacy governed/default path retained; Lite behavior retained; tier governance and validate-pr contract unchanged
Validation: final isolated smoke check confirmed profile=build, executionPath=build, deterministic branch creation, PR open/update path invocation, metadata branch/PR fields, and no runtime artifact leakage
```
