### PR TITLE
Sprint 2.1: runtime hardening

### DIFF
--- a/control-plane/cli/workflow-run-inspect.test.ts
+++ b/control-plane/cli/workflow-run-inspect.test.ts
@@ -7,7 +7,10 @@ const mocks = vi.hoisted(() => ({
   inspectRun: vi.fn(),
   buildWorkflowRunRecord: vi.fn(),
   buildWorkflowNodeRecords: vi.fn(),
-  getRunDiagnosticReport: vi.fn()
+  getRunDiagnosticReport: vi.fn(),
+  listArtifactsForRun: vi.fn(),
+  parseArtifactExpectationsFromEvents: vi.fn(),
+  buildNormalizedRunInspection: vi.fn()
 }));
 
 vi.mock('../journal/journal.ts', () => ({
@@ -17,6 +20,11 @@ vi.mock('../journal/journal.ts', () => ({
 vi.mock('../observability/run-record.ts', () => ({ buildWorkflowRunRecord: mocks.buildWorkflowRunRecord }));
 vi.mock('../observability/node-record.ts', () => ({ buildWorkflowNodeRecords: mocks.buildWorkflowNodeRecords }));
 vi.mock('../observability/diagnostics.ts', () => ({ getRunDiagnosticReport: mocks.getRunDiagnosticReport }));
+vi.mock('../../runtime/output/artifact-listing.ts', () => ({ listArtifactsForRun: mocks.listArtifactsForRun }));
+vi.mock('../operator/run-inspection.ts', () => ({
+  parseArtifactExpectationsFromEvents: mocks.parseArtifactExpectationsFromEvents,
+  buildNormalizedRunInspection: mocks.buildNormalizedRunInspection
+}));
 
 describe('workflow-run-inspect CLI', () => {
   it('prints run inspection payload', async () => {
@@ -48,6 +56,25 @@ describe('workflow-run-inspect CLI', () => {
       finalContextKeys: ['k1'],
       firstInspectTarget: { targetType: 'node', nodeId: 'node-a' }
     });
+    mocks.parseArtifactExpectationsFromEvents.mockReturnValueOnce([]);
+    mocks.listArtifactsForRun.mockReturnValueOnce([]);
+    mocks.buildNormalizedRunInspection.mockReturnValueOnce({
+      runId: 'run_1',
+      missionId: 'm1',
+      workflowId: 'wf',
+      teamId: 't1',
+      status: 'succeeded',
+      attemptCount: 1,
+      currentAttemptIndex: 0,
+      retryCount: 0,
+      artifacts: [],
+      attempts: [{ attemptIndex: 0, status: 'succeeded' }],
+      artifactValidation: {
+        status: 'complete',
+        missingRequired: [],
+        missingOptional: []
+      }
+    });
 
     const code = await main(['--run=run_1']);
 
@@ -61,6 +88,23 @@ describe('workflow-run-inspect CLI', () => {
         teamId: 't1',
         projectId: 'p1',
         status: 'completed'
+      },
+      runtime: {
+        runId: 'run_1',
+        missionId: 'm1',
+        workflowId: 'wf',
+        teamId: 't1',
+        status: 'succeeded',
+        attemptCount: 1,
+        currentAttemptIndex: 0,
+        retryCount: 0,
+        artifacts: [],
+        attempts: [{ attemptIndex: 0, status: 'succeeded' }],
+        artifactValidation: {
+          status: 'complete',
+          missingRequired: [],
+          missingOptional: []
+        }
       },
       nodes: [
         {

--- a/control-plane/cli/workflow-run-inspect.ts
+++ b/control-plane/cli/workflow-run-inspect.ts
@@ -3,6 +3,8 @@ import { createExecutionJournal } from '../journal/journal.ts';
 import { getRunDiagnosticReport } from '../observability/diagnostics.ts';
 import { buildWorkflowNodeRecords } from '../observability/node-record.ts';
 import { buildWorkflowRunRecord } from '../observability/run-record.ts';
+import { listArtifactsForRun } from '../../runtime/output/artifact-listing.ts';
+import { buildNormalizedRunInspection, parseArtifactExpectationsFromEvents } from '../operator/run-inspection.ts';
 
 function parseArgs(argv: string[]): { runId: string } {
   let runId: string | null = null;
@@ -58,6 +60,20 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
       events: inspected.events,
       nodes: nodeRecords
     });
+    const expectedArtifacts = parseArtifactExpectationsFromEvents(inspected.events);
+    const actualArtifactFiles = runRecord.missionId
+      ? listArtifactsForRun({
+        missionId: runRecord.missionId,
+        runId: runRecord.runId
+      }).filter((file) => file !== 'run-metadata.json')
+      : [];
+    const runtime = buildNormalizedRunInspection({
+      run: runRecord,
+      events: inspected.events,
+      nodeStates: nodeRecords,
+      expectedArtifacts,
+      actualArtifactFiles
+    });
 
     printJson({
       summary: runRecord.summary,
@@ -69,6 +85,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
         projectId: runRecord.projectId,
         status: runRecord.status
       },
+      runtime,
       nodes: nodeRecords.map((node) => ({
         nodeId: node.nodeId,
         status: node.status,

--- a/control-plane/operator/mission-service.profile.test.ts
+++ b/control-plane/operator/mission-service.profile.test.ts
@@ -115,6 +115,31 @@ function writeFixtures(): void {
     }
   });
 
+  writeJson(missionsDir, 'lite-missing-required-artifact.json', {
+    missionId: 'lite-missing-required-artifact',
+    projectId: 'smartfunds-core',
+    teamId: 'smartfunds-research-team',
+    workflowId: 'lite-ok-workflow',
+    profile: 'lite',
+    mutationIntent: 'none',
+    requestedCapabilities: ['artifact_write', 'read'],
+    objective: 'artifact validation failure',
+    successCriteria: ['detect missing required artifact'],
+    deliverables: ['lite-output.md', 'missing-report.md'],
+    initialContext: {
+      declaredArtifacts: [
+        { artifactId: 'lite-output', format: 'markdown' },
+        { artifactId: 'missing-report', format: 'markdown', required: true }
+      ],
+      taskInputsByNode: {
+        'write-lite-output': {
+          artifactId: 'lite-output',
+          content: '# Lite Output\\n\\nArtifact only.\\n'
+        }
+      }
+    }
+  });
+
   writeJson(missionsDir, 'lite-bad-capability.json', {
     missionId: 'lite-bad-capability',
     projectId: 'smartfunds-core',
@@ -231,6 +256,7 @@ beforeEach(() => {
 afterEach(() => {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
   fs.rmSync(path.join('artifacts', 'lite-ok'), { recursive: true, force: true });
+  fs.rmSync(path.join('artifacts', 'lite-missing-required-artifact'), { recursive: true, force: true });
   fs.rmSync(path.join('artifacts', 'governed-default'), { recursive: true, force: true });
   fs.rmSync(path.join('artifacts', 'build-ok'), { recursive: true, force: true });
 });
@@ -298,6 +324,36 @@ describe('mission-service profile routing', () => {
       missionId: 'lite-bad-capability',
       params: {}
     })).rejects.toThrowError('LITE_REPO_MUTATION_FORBIDDEN');
+  });
+
+  it('T-RH-M1 marks mission status failed when required declared artifact is missing', async () => {
+    const service = createMissionService({
+      journal: createExecutionJournal({ rootDir: journalRoot }),
+      missionsDir,
+      workflowsDir,
+      teamsDir,
+      agentsDir
+    });
+
+    const result = await service.startMission({
+      missionId: 'lite-missing-required-artifact',
+      params: {}
+    });
+
+    expect(result).toMatchObject({
+      missionId: 'lite-missing-required-artifact',
+      status: 'failed',
+      executionPath: 'lite'
+    });
+
+    const runId = String(result.workflowRun);
+    const metadata = JSON.parse(
+      fs.readFileSync(path.join('artifacts', 'lite-missing-required-artifact', runId, 'run-metadata.json'), 'utf8')
+    ) as Record<string, unknown>;
+
+    expect(metadata.status).toBe('failed');
+    expect(metadata.failureClass).toBe('artifact_validation_error');
+    expect(metadata.failureReason).toContain('required artifact missing');
   });
 
   it('T-SPB-M3 rejects lite forbidden mutation task steps', async () => {

--- a/control-plane/operator/mission-service.ts
+++ b/control-plane/operator/mission-service.ts
@@ -35,6 +35,7 @@ import {
   type ExecutionPath
 } from './profile-policy.ts';
 import { executeBuildMission, parseBuildMissionContext } from './build-mission-executor.ts';
+import { buildNormalizedRunInspection, parseArtifactExpectationsFromEvents } from './run-inspection.ts';
 
 type MissionServiceOptions = {
   journal?: ExecutionJournal;
@@ -444,6 +445,15 @@ async function executeMissionByPath(input: {
     missionId: input.missionId,
     runId: runRecord.runId
   }).filter((file) => file !== 'run-metadata.json');
+  const expectedArtifacts = parseArtifactExpectationsFromEvents(inspected.events);
+  const runtimeInspection = buildNormalizedRunInspection({
+    run: runRecord,
+    events: inspected.events,
+    nodeStates: nodeRecords,
+    expectedArtifacts,
+    actualArtifactFiles: artifactFiles
+  });
+  const resolvedStatus = runtimeInspection.status === 'failed' ? 'failed' : runRecord.status;
 
   writeArtifact({
     missionId: input.missionId,
@@ -454,7 +464,7 @@ async function executeMissionByPath(input: {
       runId: runRecord.runId,
       missionId: input.missionId,
       workflowId: runRecord.workflowId,
-      status: runRecord.status,
+      status: resolvedStatus,
       requestedProfile: input.requestedProfile,
       requiredProfile: input.profileValidation.requiredProfile,
       profile: input.profile,
@@ -462,15 +472,29 @@ async function executeMissionByPath(input: {
       scopeClassification: input.profileValidation.scopeClassification,
       coreScopeMatched: input.profileValidation.coreScopeMatched,
       coreReasons: input.profileValidation.coreReasons,
-      artifactCount: artifactFiles.length
+      artifactCount: artifactFiles.length,
+      runtimeStatus: runtimeInspection.status,
+      attemptCount: runtimeInspection.attemptCount,
+      currentAttemptIndex: runtimeInspection.currentAttemptIndex,
+      retryCount: runtimeInspection.retryCount,
+      failureClass: runtimeInspection.failureClass ?? null,
+      failureReason: runtimeInspection.failureReason ?? null,
+      artifactValidation: runtimeInspection.artifactValidation
     }
   });
 
   return {
     runId: runRecord.runId,
-    status: runRecord.status,
+    status: resolvedStatus,
     metadata: {
-      artifactCount: artifactFiles.length
+      artifactCount: artifactFiles.length,
+      runtimeStatus: runtimeInspection.status,
+      attemptCount: runtimeInspection.attemptCount,
+      currentAttemptIndex: runtimeInspection.currentAttemptIndex,
+      retryCount: runtimeInspection.retryCount,
+      failureClass: runtimeInspection.failureClass ?? null,
+      failureReason: runtimeInspection.failureReason ?? null,
+      artifactValidation: runtimeInspection.artifactValidation
     }
   };
 }

--- a/control-plane/operator/operator.integration.test.ts
+++ b/control-plane/operator/operator.integration.test.ts
@@ -305,6 +305,15 @@ describe('operator integration', () => {
     expect(workflowInspect.success).toBe(true);
     expect(workflowTrace.success).toBe(true);
     expect((workflowTrace.payload as Record<string, unknown>).executionOrder).toEqual(['node-a']);
+
+    const inspectPayload = workflowInspect.payload as Record<string, unknown>;
+    expect(inspectPayload.lifecycleStatus).toBe('succeeded');
+    expect(inspectPayload.attemptCount).toBe(1);
+    expect(inspectPayload.currentAttemptIndex).toBe(0);
+    expect(inspectPayload.retryCount).toBe(0);
+    expect(Array.isArray(inspectPayload.artifacts)).toBe(true);
+    expect(Array.isArray(inspectPayload.attempts)).toBe(true);
+    expect((inspectPayload.runtime as Record<string, unknown>).status).toBe('succeeded');
   });
 
   it('T-OPI3 routes runtime controls through recovery paths', async () => {

--- a/control-plane/operator/run-inspection.test.ts
+++ b/control-plane/operator/run-inspection.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildNormalizedRunInspection,
+  parseArtifactExpectationsFromEvents,
+  summarizeArtifacts,
+  type ArtifactExpectation
+} from './run-inspection.ts';
+
+const baseRun = {
+  runId: 'run_1',
+  workflowId: 'wf_1',
+  missionId: 'mission-1',
+  teamId: 'team-1',
+  profile: null,
+  executionPath: null,
+  projectId: 'smartfunds-core',
+  status: 'completed',
+  nodeCount: 1,
+  completedNodeCount: 1,
+  failedNodeCount: 0,
+  timeoutNodeCount: 0,
+  retryCount: 0,
+  startSequence: 1,
+  endSequence: 3,
+  activeNodeId: null,
+  agentRoster: [],
+  summary: {
+    runId: 'run_1',
+    workflowId: 'wf_1',
+    missionId: 'mission-1',
+    teamId: 'team-1',
+    projectId: 'smartfunds-core',
+    status: 'completed',
+    nodeCount: 1,
+    completedNodeCount: 1,
+    failedNodeCount: 0,
+    timeoutNodeCount: 0,
+    activeNodeId: null,
+    lastAgentUsed: null,
+    totalOutputsGenerated: 0,
+    totalRetriesConsumed: 0,
+    replayable: true,
+    hasFailure: false,
+    recoverable: false,
+    resumed: false,
+    cancelled: false,
+    safetyViolationCount: 0,
+    summaryLine: 'summary'
+  }
+} as const;
+
+const completedNode = {
+  runId: 'run_1',
+  workflowId: 'wf_1',
+  nodeId: 'node-1',
+  agentId: null,
+  adapterId: 'repo',
+  status: 'completed',
+  dependsOn: [],
+  sequenceStarted: 1,
+  sequenceCompleted: 2,
+  taskInputs: {},
+  taskOutputs: {},
+  previousOutputs: {},
+  contextSnapshot: {},
+  failure: null,
+  retryCount: 0,
+  timeoutType: null
+} as const;
+
+describe('run inspection normalization', () => {
+  it('T-RH1 returns succeeded lifecycle with deterministic artifact summaries', () => {
+    const artifacts: ArtifactExpectation[] = [
+      { path: 'dataset.csv', type: 'csv', required: false },
+      { path: 'report.md', type: 'markdown', required: true }
+    ];
+
+    const inspection = buildNormalizedRunInspection({
+      run: { ...baseRun },
+      events: [],
+      nodeStates: [{ ...completedNode }],
+      expectedArtifacts: artifacts,
+      actualArtifactFiles: ['report.md']
+    });
+
+    expect(inspection.status).toBe('succeeded');
+    expect(inspection.attemptCount).toBe(1);
+    expect(inspection.retryCount).toBe(0);
+    expect(inspection.artifactValidation).toEqual({
+      status: 'partial',
+      missingRequired: [],
+      missingOptional: ['dataset.csv']
+    });
+    expect(inspection.artifacts.map((artifact) => artifact.path)).toEqual(['dataset.csv', 'report.md']);
+  });
+
+  it('T-RH2 reports retry attempt history deterministically', () => {
+    const inspection = buildNormalizedRunInspection({
+      run: { ...baseRun, status: 'completed', retryCount: 1 },
+      events: [
+        {
+          runId: 'run_1',
+          eventId: 'evt_1',
+          sequence: 1,
+          type: 'NODE_RETRY_SCHEDULED',
+          phase: 'implement',
+          taskId: 'node-1',
+          artifactId: null,
+          payload: { retryAttempt: 1 }
+        }
+      ],
+      nodeStates: [{ ...completedNode, retryCount: 1 }],
+      expectedArtifacts: [],
+      actualArtifactFiles: []
+    });
+
+    expect(inspection.retryCount).toBe(1);
+    expect(inspection.attemptCount).toBe(2);
+    expect(inspection.currentAttemptIndex).toBe(1);
+    expect(inspection.attempts).toEqual([
+      {
+        attemptIndex: 0,
+        status: 'failed'
+      },
+      {
+        attemptIndex: 1,
+        status: 'succeeded'
+      }
+    ]);
+  });
+
+  it('T-RH3 maps workflow definition failure class deterministically', () => {
+    const inspection = buildNormalizedRunInspection({
+      run: { ...baseRun, status: 'failed' },
+      events: [],
+      nodeStates: [{
+        ...completedNode,
+        status: 'failed',
+        sequenceCompleted: 2,
+        failure: {
+          code: 'WORKFLOW_VALIDATION_FAILED',
+          message: 'workflow.schema_invalid',
+          nodeId: 'node-1',
+          agentId: null,
+          adapterId: null,
+          details: {}
+        }
+      }],
+      expectedArtifacts: [],
+      actualArtifactFiles: []
+    });
+
+    expect(inspection.status).toBe('failed');
+    expect(inspection.failureClass).toBe('workflow_definition_error');
+    expect(inspection.failureReason).toBe('workflow.schema_invalid');
+  });
+
+  it('T-RH4 fails succeeded run when required artifact is missing', () => {
+    const inspection = buildNormalizedRunInspection({
+      run: { ...baseRun, status: 'completed' },
+      events: [],
+      nodeStates: [{ ...completedNode }],
+      expectedArtifacts: [{ path: 'report.md', type: 'markdown', required: true }],
+      actualArtifactFiles: []
+    });
+
+    expect(inspection.status).toBe('failed');
+    expect(inspection.failureClass).toBe('artifact_validation_error');
+    expect(inspection.failureReason).toContain('required artifact missing: report.md');
+  });
+
+  it('T-RH5 parses declared artifacts from runtime context snapshots', () => {
+    const parsed = parseArtifactExpectationsFromEvents([
+      {
+        runId: 'run_1',
+        eventId: 'evt_1',
+        sequence: 1,
+        type: 'TASK_STARTED',
+        phase: 'implement',
+        taskId: 'node-1',
+        artifactId: null,
+        payload: {
+          context_snapshot: {
+            memory: {
+              declaredArtifacts: [
+                { artifactId: 'report', format: 'markdown' },
+                { artifactId: 'dataset', format: 'csv', required: false }
+              ]
+            }
+          }
+        }
+      }
+    ]);
+
+    expect(parsed).toEqual([
+      { path: 'dataset.csv', type: 'csv', required: false },
+      { path: 'report.md', type: 'markdown', required: true }
+    ]);
+  });
+
+  it('T-RH6 summarizes required and optional missing artifacts stably', () => {
+    const result = summarizeArtifacts({
+      expected: [
+        { path: 'b.md', required: true },
+        { path: 'a.csv', required: false }
+      ],
+      actualFiles: ['c.json']
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.missingRequired).toEqual(['b.md']);
+    expect(result.missingOptional).toEqual(['a.csv']);
+    expect(result.artifacts.map((entry) => entry.path)).toEqual(['a.csv', 'b.md', 'c.json']);
+  });
+});

--- a/control-plane/operator/run-inspection.ts
+++ b/control-plane/operator/run-inspection.ts
@@ -1,0 +1,469 @@
+import type { ExecutionEvent } from '../journal/types.ts';
+import type { WorkflowNodeRecord } from '../observability/node-record.ts';
+import type { WorkflowRunRecord } from '../observability/run-record.ts';
+
+export type CanonicalRunStatus =
+  | 'queued'
+  | 'starting'
+  | 'running'
+  | 'retrying'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled';
+
+export type FailureClass =
+  | 'transient_runtime_error'
+  | 'adapter_error'
+  | 'artifact_validation_error'
+  | 'workflow_definition_error'
+  | 'mission_definition_error'
+  | 'non_retryable_execution_error';
+
+export type ArtifactExpectation = {
+  path: string;
+  type?: string;
+  required: boolean;
+};
+
+export type ArtifactSummary = {
+  path: string;
+  type?: string;
+  required: boolean;
+  exists: boolean;
+  valid: boolean;
+};
+
+export type RunAttemptSummary = {
+  attemptIndex: number;
+  status: CanonicalRunStatus;
+  failureClass?: FailureClass;
+  failureReason?: string;
+};
+
+export type NormalizedRunInspection = {
+  runId: string;
+  missionId: string | null;
+  workflowId: string;
+  teamId: string | null;
+  status: CanonicalRunStatus;
+  attemptCount: number;
+  currentAttemptIndex: number;
+  retryCount: number;
+  failureClass?: FailureClass;
+  failureReason?: string;
+  artifacts: ArtifactSummary[];
+  attempts: RunAttemptSummary[];
+  artifactValidation: {
+    status: 'complete' | 'partial' | 'failed';
+    missingRequired: string[];
+    missingOptional: string[];
+  };
+};
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function extensionForFormat(format: string): string {
+  if (format === 'csv') {
+    return 'csv';
+  }
+  if (format === 'xlsx') {
+    return 'xlsx';
+  }
+  if (format === 'markdown') {
+    return 'md';
+  }
+  return 'json';
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function parseArtifactExpectationsFromEvents(events: ExecutionEvent[]): ArtifactExpectation[] {
+  const ordered = [...events].sort((left, right) => left.sequence - right.sequence);
+
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const payload = toRecord(ordered[index]?.payload);
+    const contextSnapshot = toRecord(payload.context_snapshot);
+    const memory = toRecord(contextSnapshot.memory);
+
+    const candidates = [memory.declaredArtifacts, toRecord(memory.missionContext).declaredArtifacts];
+    for (const candidate of candidates) {
+      if (!Array.isArray(candidate)) {
+        continue;
+      }
+
+      const dedupe = new Map<string, ArtifactExpectation>();
+      for (const value of candidate) {
+        const entry = toRecord(value);
+        const artifactId = typeof entry.artifactId === 'string' ? entry.artifactId.trim() : '';
+        const format = typeof entry.format === 'string' ? entry.format.trim() : '';
+        const required = entry.required !== false;
+        if (artifactId.length === 0 || format.length === 0) {
+          continue;
+        }
+
+        const artifactPath = `${artifactId}.${extensionForFormat(format)}`;
+        const existing = dedupe.get(artifactPath);
+        dedupe.set(artifactPath, {
+          path: artifactPath,
+          type: format,
+          required: existing ? (existing.required || required) : required
+        });
+      }
+
+      return Array.from(dedupe.values()).sort((left, right) => left.path.localeCompare(right.path));
+    }
+  }
+
+  return [];
+}
+
+export function summarizeArtifacts(input: {
+  expected: ArtifactExpectation[];
+  actualFiles: string[];
+}): {
+  artifacts: ArtifactSummary[];
+  status: 'complete' | 'partial' | 'failed';
+  missingRequired: string[];
+  missingOptional: string[];
+} {
+  const actual = sortedUnique(input.actualFiles);
+  const expected = [...input.expected]
+    .map((entry) => ({
+      path: entry.path,
+      type: entry.type,
+      required: entry.required
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+
+  const artifactRows: ArtifactSummary[] = expected.map((artifact) => {
+    const exists = actual.includes(artifact.path);
+    return {
+      path: artifact.path,
+      type: artifact.type,
+      required: artifact.required,
+      exists,
+      valid: exists
+    };
+  });
+
+  const expectedSet = new Set(expected.map((entry) => entry.path));
+  const extras = actual
+    .filter((file) => !expectedSet.has(file))
+    .map((file) => ({
+      path: file,
+      required: false,
+      exists: true,
+      valid: true
+    }));
+
+  const artifacts = [...artifactRows, ...extras].sort((left, right) => left.path.localeCompare(right.path));
+  const missingRequired = artifactRows
+    .filter((entry) => entry.required && !entry.exists)
+    .map((entry) => entry.path)
+    .sort((left, right) => left.localeCompare(right));
+  const missingOptional = artifactRows
+    .filter((entry) => !entry.required && !entry.exists)
+    .map((entry) => entry.path)
+    .sort((left, right) => left.localeCompare(right));
+
+  if (missingRequired.length > 0) {
+    return {
+      artifacts,
+      status: 'failed',
+      missingRequired,
+      missingOptional
+    };
+  }
+
+  return {
+    artifacts,
+    status: missingOptional.length > 0 ? 'partial' : 'complete',
+    missingRequired,
+    missingOptional
+  };
+}
+
+function latestRetrySignal(events: ExecutionEvent[]): boolean {
+  const ordered = [...events].sort((left, right) => left.sequence - right.sequence);
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const event = ordered[index];
+    if (!event) {
+      continue;
+    }
+    if (event.type === 'NODE_RETRY_SCHEDULED' || event.type === 'NODE_RETRY_STARTED') {
+      return true;
+    }
+    if (event.type === 'TASK_STARTED' || event.type === 'TASK_COMPLETED' || event.type === 'TASK_FAILED') {
+      return false;
+    }
+  }
+  return false;
+}
+
+function deriveCanonicalStatus(input: {
+  runStatus: string;
+  events: ExecutionEvent[];
+  nodeStates: WorkflowNodeRecord[];
+  artifactValidationStatus: 'complete' | 'partial' | 'failed';
+}): CanonicalRunStatus {
+  if (input.runStatus === 'cancelled') {
+    return 'cancelled';
+  }
+
+  if (input.artifactValidationStatus === 'failed') {
+    return 'failed';
+  }
+
+  if (input.runStatus === 'completed') {
+    return 'succeeded';
+  }
+
+  if (input.runStatus === 'failed' || input.runStatus === 'timeout') {
+    return 'failed';
+  }
+
+  if (input.runStatus === 'running') {
+    if (input.nodeStates.some((node) => node.status === 'retrying') || latestRetrySignal(input.events)) {
+      return 'retrying';
+    }
+    return 'running';
+  }
+
+  if (input.events.length === 0) {
+    return 'queued';
+  }
+
+  if (input.events.some((event) => event.type === 'TASK_STARTED')) {
+    return 'running';
+  }
+
+  return 'starting';
+}
+
+function mapFailureCodeToClass(code: string): FailureClass {
+  if (
+    code === 'NODE_TIMEOUT'
+    || code === 'ADAPTER_TIMEOUT'
+    || code === 'WORKFLOW_TIMEOUT'
+    || code === 'TOOL_TIMEOUT'
+  ) {
+    return 'transient_runtime_error';
+  }
+
+  if (code === 'WORKFLOW_VALIDATION_FAILED') {
+    return 'workflow_definition_error';
+  }
+
+  if (
+    code === 'ADAPTER_EXECUTION_FAILED'
+    || code === 'TASK_RESULT_INVALID'
+    || code === 'DEPENDENCY_UNSATISFIED'
+    || code === 'AGENT_RESOLUTION_FAILED'
+    || code === 'TOOL_PERMISSION_DENIED'
+    || code === 'CONTEXT_MERGE_FAILED'
+  ) {
+    return 'adapter_error';
+  }
+
+  return 'non_retryable_execution_error';
+}
+
+function extractEventFailureReason(events: ExecutionEvent[]): string | null {
+  const ordered = [...events].sort((left, right) => left.sequence - right.sequence);
+
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const event = ordered[index];
+    if (!event || event.type !== 'RUN_FAILED') {
+      continue;
+    }
+
+    const payload = toRecord(event.payload);
+    const reason = typeof payload.error === 'string' ? payload.error.trim() : '';
+    if (reason.length > 0) {
+      return reason;
+    }
+  }
+
+  return null;
+}
+
+function classifyFailure(input: {
+  canonicalStatus: CanonicalRunStatus;
+  artifactValidation: {
+    missingRequired: string[];
+  };
+  nodeStates: WorkflowNodeRecord[];
+  events: ExecutionEvent[];
+}): { failureClass?: FailureClass; failureReason?: string } {
+  if (input.artifactValidation.missingRequired.length > 0) {
+    const missing = input.artifactValidation.missingRequired.join(', ');
+    return {
+      failureClass: 'artifact_validation_error',
+      failureReason: `required artifact missing: ${missing}`
+    };
+  }
+
+  if (input.canonicalStatus !== 'failed') {
+    return {};
+  }
+
+  const failedNode = [...input.nodeStates]
+    .filter((node) => node.status === 'failed' || node.status === 'timeout')
+    .sort((left, right) => {
+      const leftSequence = left.sequenceCompleted ?? left.sequenceStarted;
+      const rightSequence = right.sequenceCompleted ?? right.sequenceStarted;
+      const sequenceCmp = leftSequence - rightSequence;
+      if (sequenceCmp !== 0) {
+        return sequenceCmp;
+      }
+      return left.nodeId.localeCompare(right.nodeId);
+    })
+    .at(0);
+
+  if (failedNode?.failure?.code) {
+    return {
+      failureClass: mapFailureCodeToClass(failedNode.failure.code),
+      failureReason: failedNode.failure.message
+    };
+  }
+
+  const eventReason = extractEventFailureReason(input.events);
+  if (eventReason) {
+    const normalized = eventReason.toLowerCase();
+    if (normalized.includes('mission') && (normalized.includes('invalid') || normalized.includes('not found'))) {
+      return {
+        failureClass: 'mission_definition_error',
+        failureReason: eventReason
+      };
+    }
+
+    if (normalized.includes('workflow') && (normalized.includes('invalid') || normalized.includes('schema') || normalized.includes('dag'))) {
+      return {
+        failureClass: 'workflow_definition_error',
+        failureReason: eventReason
+      };
+    }
+
+    return {
+      failureClass: 'non_retryable_execution_error',
+      failureReason: eventReason
+    };
+  }
+
+  return {
+    failureClass: 'non_retryable_execution_error',
+    failureReason: 'workflow_execution_failed'
+  };
+}
+
+function deriveRetryCount(nodeStates: WorkflowNodeRecord[]): number {
+  return nodeStates.reduce((max, node) => {
+    const value = typeof node.retryCount === 'number' ? node.retryCount : 0;
+    return value > max ? value : max;
+  }, 0);
+}
+
+function buildAttempts(input: {
+  finalStatus: CanonicalRunStatus;
+  retryCount: number;
+  failureClass?: FailureClass;
+  failureReason?: string;
+}): RunAttemptSummary[] {
+  const attempts: RunAttemptSummary[] = [];
+  const total = input.retryCount + 1;
+
+  for (let index = 0; index < total; index += 1) {
+    if (index === total - 1) {
+      attempts.push({
+        attemptIndex: index,
+        status: input.finalStatus,
+        ...(input.finalStatus === 'failed' && input.failureClass ? { failureClass: input.failureClass } : {}),
+        ...(input.finalStatus === 'failed' && input.failureReason ? { failureReason: input.failureReason } : {})
+      });
+      continue;
+    }
+
+    if (index === 0) {
+      attempts.push({
+        attemptIndex: index,
+        status: 'failed',
+        ...(input.failureClass ? { failureClass: input.failureClass } : {}),
+        ...(input.failureReason ? { failureReason: input.failureReason } : {})
+      });
+      continue;
+    }
+
+    attempts.push({
+      attemptIndex: index,
+      status: 'retrying'
+    });
+  }
+
+  return attempts;
+}
+
+export function buildNormalizedRunInspection(input: {
+  run: WorkflowRunRecord;
+  events: ExecutionEvent[];
+  nodeStates: WorkflowNodeRecord[];
+  actualArtifactFiles: string[];
+  expectedArtifacts?: ArtifactExpectation[];
+}): NormalizedRunInspection {
+  const expectedArtifacts = [...(input.expectedArtifacts ?? [])]
+    .sort((left, right) => left.path.localeCompare(right.path));
+  const artifactValidation = summarizeArtifacts({
+    expected: expectedArtifacts,
+    actualFiles: input.actualArtifactFiles
+  });
+  const canonicalStatus = deriveCanonicalStatus({
+    runStatus: input.run.status,
+    events: input.events,
+    nodeStates: input.nodeStates,
+    artifactValidationStatus: artifactValidation.status
+  });
+
+  const failure = classifyFailure({
+    canonicalStatus,
+    artifactValidation,
+    nodeStates: input.nodeStates,
+    events: input.events
+  });
+
+  const retryCount = deriveRetryCount(input.nodeStates);
+  const attempts = buildAttempts({
+    finalStatus: canonicalStatus,
+    retryCount,
+    failureClass: failure.failureClass,
+    failureReason: failure.failureReason
+  });
+
+  return {
+    runId: input.run.runId,
+    missionId: input.run.missionId,
+    workflowId: input.run.workflowId,
+    teamId: input.run.teamId,
+    status: canonicalStatus,
+    attemptCount: attempts.length,
+    currentAttemptIndex: attempts.length - 1,
+    retryCount,
+    ...(failure.failureClass ? { failureClass: failure.failureClass } : {}),
+    ...(failure.failureReason ? { failureReason: failure.failureReason } : {}),
+    artifacts: artifactValidation.artifacts,
+    attempts,
+    artifactValidation: {
+      status: artifactValidation.status,
+      missingRequired: artifactValidation.missingRequired,
+      missingOptional: artifactValidation.missingOptional
+    }
+  };
+}
+
+export function isFailureClassRetryable(failureClass: FailureClass): boolean {
+  return failureClass === 'transient_runtime_error' || failureClass === 'adapter_error';
+}

--- a/control-plane/operator/workflow-service.ts
+++ b/control-plane/operator/workflow-service.ts
@@ -4,6 +4,8 @@ import { getRunDiagnosticReport } from '../observability/diagnostics.ts';
 import { buildWorkflowNodeRecords } from '../observability/node-record.ts';
 import { buildWorkflowRunRecord, buildWorkflowRunRecords } from '../observability/run-record.ts';
 import { buildWorkflowTrace } from '../observability/trace-builder.ts';
+import { listArtifactsForRun } from '../../runtime/output/artifact-listing.ts';
+import { buildNormalizedRunInspection, parseArtifactExpectationsFromEvents } from './run-inspection.ts';
 
 type WorkflowServiceOptions = {
   journal?: ExecutionJournal;
@@ -48,12 +50,34 @@ export function createWorkflowService(options: WorkflowServiceOptions = {}) {
       events: inspected.events,
       nodes: nodeRecords
     });
+    const expectedArtifacts = parseArtifactExpectationsFromEvents(inspected.events);
+    const actualArtifactFiles = runRecord.missionId
+      ? listArtifactsForRun({
+        missionId: runRecord.missionId,
+        runId: runRecord.runId
+      }).filter((file) => file !== 'run-metadata.json')
+      : [];
+    const runtime = buildNormalizedRunInspection({
+      run: runRecord,
+      events: inspected.events,
+      nodeStates: nodeRecords,
+      expectedArtifacts,
+      actualArtifactFiles
+    });
 
     return {
       runId: runRecord.runId,
       workflowId: runRecord.workflowId,
       missionId: runRecord.missionId,
       status: runRecord.status,
+      lifecycleStatus: runtime.status,
+      attemptCount: runtime.attemptCount,
+      currentAttemptIndex: runtime.currentAttemptIndex,
+      retryCount: runtime.retryCount,
+      failureClass: runtime.failureClass ?? null,
+      failureReason: runtime.failureReason ?? null,
+      artifacts: runtime.artifacts,
+      attempts: runtime.attempts,
       summary: runRecord.summary,
       nodeStates: nodeRecords.map((node) => ({
         nodeId: node.nodeId,
@@ -74,7 +98,8 @@ export function createWorkflowService(options: WorkflowServiceOptions = {}) {
         safetyViolationNodeIds: diagnostics.safetyViolationNodeIds,
         firstInspectTarget: diagnostics.firstInspectTarget,
         finalContextKeys: diagnostics.finalContextKeys
-      }
+      },
+      runtime
     };
   }
 

--- a/docs/architecture/runtime-hardening.md
+++ b/docs/architecture/runtime-hardening.md
@@ -3,6 +3,33 @@
 ## Why Sprint 70 Exists
 Sprint 70 hardens workflow runtime behavior so node/workflow execution can fail, retry, timeout, recover, and cancel in deterministic and replayable ways.
 
+## Productization Phase 1 Runtime Contract
+Productization Phase 1 adds a normalized operator-facing run inspection contract layered on top of journal/observability projections.
+
+Canonical external lifecycle states:
+- `queued`
+- `starting`
+- `running`
+- `retrying`
+- `succeeded`
+- `failed`
+- `cancelled`
+
+Failure classes exposed for operator diagnostics:
+- `transient_runtime_error`
+- `adapter_error`
+- `artifact_validation_error`
+- `workflow_definition_error`
+- `mission_definition_error`
+- `non_retryable_execution_error`
+
+Inspection payloads now include deterministic:
+- attempt count / current attempt index
+- retry count
+- failure class and failure reason
+- artifact validation summary (required/optional presence)
+- stable attempt history and artifact list ordering
+
 ## Sprint 71 Canonical Integration
 Sprint 71 makes hardened execution the default workflow path.
 

--- a/docs/runbooks/workflow-recovery.md
+++ b/docs/runbooks/workflow-recovery.md
@@ -2,12 +2,18 @@
 
 ## Inspect Run
 1. `npm run workflow:run-inspect -- --run <runId>`
-2. Review `failedNodeIds`, `timedOutNodeIds`, and `firstInspectTarget`.
+2. Review `runtime.status`, `runtime.attemptCount`, `runtime.currentAttemptIndex`, and `runtime.retryCount`.
+3. Review `runtime.failureClass` / `runtime.failureReason` when present.
+4. Review `runtime.artifactValidation` and `runtime.artifacts`:
+   - required missing artifacts force terminal `failed`
+   - optional missing artifacts produce `partial` artifact validation only
+5. Review `failedNodeIds`, `timedOutNodeIds`, and `firstInspectTarget`.
 
 ## Retry Failed Node
 1. Verify node is `failed` or `timeout`.
 2. `npm run workflow:retry -- --run <runId> --node <nodeId>`
 3. Check output fields: `retryAttempt`, `tickDelay`, `scheduled`, `started`.
+4. Re-run inspect and verify `runtime.attempts` shows deterministic retry history.
 
 ## Resume Workflow
 1. `npm run workflow:resume -- --run <runId>`

--- a/runtime/__tests__/rwa-market-analysis-artifacts.integration.test.ts
+++ b/runtime/__tests__/rwa-market-analysis-artifacts.integration.test.ts
@@ -128,12 +128,13 @@ describe('rwa-market-analysis artifact integration', () => {
 
     const artifactDir = path.join('artifacts', missionId, runId);
     const files = fs.readdirSync(artifactDir).sort((left, right) => left.localeCompare(right));
-    expect(files).toEqual(['dataset.csv', 'report.md', 'research-pages.json', 'search-results.json']);
+    expect(files).toEqual(['dataset.csv', 'report.md', 'research-pages.json', 'run-metadata.json', 'search-results.json']);
 
     expect(listArtifactsForRun({ missionId, runId })).toEqual([
       'dataset.csv',
       'report.md',
       'research-pages.json',
+      'run-metadata.json',
       'search-results.json'
     ]);
   });


### PR DESCRIPTION
tier-3

```evidence
npx vitest --run control-plane/operator/run-inspection.test.ts control-plane/cli/workflow-run-inspect.test.ts control-plane/operator/mission-service.profile.test.ts control-plane/operator/operator.integration.test.ts runtime/__tests__/rwa-market-analysis-artifacts.integration.test.ts
npm run typecheck
npm run lint
npx tsc -p tsconfig.json --noEmit
npm test
```

## Summary
- add normalized deterministic run inspection with canonical lifecycle and failure classes
- expose additive runtime inspection fields in workflow:inspect and workflow-run-inspect
- enforce required artifact failure outcomes in mission execution metadata/return path while preserving demo compatibility when no declarations exist
- add targeted tests and runtime hardening docs/runbook updates
