### PR TITLE
Sprint 2.21 — Market Intelligence Synthesis Layer

### DIFF
--- a/control-plane/cli/market-synthesis-cli.test.ts
+++ b/control-plane/cli/market-synthesis-cli.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { main as historyMain } from './market-synthesis-history.ts';
+import { main as inspectMain } from './market-synthesis-inspect.ts';
+import { main as linksMain } from './market-synthesis-links.ts';
+import { main as listMain } from './market-synthesis-list.ts';
+import { main as materializeMain } from './market-synthesis-materialize.ts';
+import { main as readinessMain } from './market-synthesis-readiness.ts';
+import { main as statusMain } from './market-synthesis-status.ts';
+
+const {
+  listMarketSyntheses,
+  inspectMarketSynthesis,
+  getMarketStatus,
+  getMarketLinks,
+  getMarketReadiness,
+  getMarketHistory,
+  materializeMarketSynthesis
+} = vi.hoisted(() => ({
+  listMarketSyntheses: vi.fn(() => [{ marketSynthesisId: 'market-risk-synthesis', displayName: 'Market Risk', synthesisType: 'market_risk', enabled: true }]),
+  inspectMarketSynthesis: vi.fn(() => ({ marketSynthesisId: 'market-risk-synthesis', lifecycleState: 'progressing' })),
+  getMarketStatus: vi.fn(() => ({ marketSynthesisId: 'market-risk-synthesis', lifecycleState: 'progressing', readinessState: 'analyzing', completionState: 'incomplete' })),
+  getMarketLinks: vi.fn(() => ({ marketSynthesisId: 'market-risk-synthesis', linkedCrossSwarmIds: ['protocol-response-cluster'] })),
+  getMarketReadiness: vi.fn(() => ({ marketSynthesisId: 'market-risk-synthesis', readinessState: 'analyzing' })),
+  getMarketHistory: vi.fn(() => ({ marketSynthesisId: 'market-risk-synthesis', entries: [] })),
+  materializeMarketSynthesis: vi.fn(() => ({ marketSynthesisId: 'market-risk-synthesis', statusPath: 'a', reportPath: 'b', markdownPath: 'c', historyPath: 'd' }))
+}));
+
+vi.mock('../market-synthesis/market-synthesis-inspection.ts', () => ({
+  createMarketInspection: vi.fn(() => ({
+    listMarketSyntheses,
+    inspectMarketSynthesis,
+    getMarketStatus,
+    getMarketLinks,
+    getMarketReadiness,
+    getMarketHistory,
+    materializeMarketSynthesis,
+  }))
+}));
+
+describe('market-synthesis CLI commands', () => {
+  it('T-MS-CLI1 market-synthesis:list prints deterministic output', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await listMain([]);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify(listMarketSyntheses())}\n`);
+    stdout.mockRestore();
+  });
+
+  it('T-MS-CLI2 market-synthesis:inspect requires --market', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await inspectMain([]);
+
+    expect(code).toBe(1);
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('MISSING_ARGUMENT: --market');
+    stdout.mockRestore();
+  });
+
+  it('T-MS-CLI3 market-synthesis:status routes --market', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await statusMain(['--market', 'market-risk-synthesis']);
+
+    expect(code).toBe(0);
+    expect(getMarketStatus).toHaveBeenCalledWith('market-risk-synthesis');
+    stdout.mockRestore();
+  });
+
+  it('T-MS-CLI4 market-synthesis:links routes --market', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await linksMain(['--market=market-risk-synthesis']);
+
+    expect(code).toBe(0);
+    expect(getMarketLinks).toHaveBeenCalledWith('market-risk-synthesis');
+    stdout.mockRestore();
+  });
+
+  it('T-MS-CLI5 market-synthesis:readiness routes --market', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await readinessMain(['--market', 'market-risk-synthesis']);
+
+    expect(code).toBe(0);
+    expect(getMarketReadiness).toHaveBeenCalledWith('market-risk-synthesis');
+    stdout.mockRestore();
+  });
+
+  it('T-MS-CLI6 market-synthesis:history routes --market', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await historyMain(['--market', 'market-risk-synthesis']);
+
+    expect(code).toBe(0);
+    expect(getMarketHistory).toHaveBeenCalledWith('market-risk-synthesis');
+    stdout.mockRestore();
+  });
+
+  it('T-MS-CLI7 market-synthesis:materialize routes --market', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await materializeMain(['--market', 'market-risk-synthesis']);
+
+    expect(code).toBe(0);
+    expect(materializeMarketSynthesis).toHaveBeenCalledWith('market-risk-synthesis');
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify(materializeMarketSynthesis())}\n`);
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/cli/market-synthesis-history.ts
+++ b/control-plane/cli/market-synthesis-history.ts
@@ -1,0 +1,56 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): { marketSynthesisId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--market') {
+      const marketSynthesisId = argv[index + 1];
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { marketSynthesisId };
+    }
+    if (arg.startsWith('--market=')) {
+      const marketSynthesisId = arg.slice('--market='.length);
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { marketSynthesisId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --market');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.getMarketHistory(args.marketSynthesisId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/market-synthesis-inspect.ts
+++ b/control-plane/cli/market-synthesis-inspect.ts
@@ -1,0 +1,56 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): { marketSynthesisId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--market') {
+      const marketSynthesisId = argv[index + 1];
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { marketSynthesisId };
+    }
+    if (arg.startsWith('--market=')) {
+      const marketSynthesisId = arg.slice('--market='.length);
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { marketSynthesisId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --market');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.inspectMarketSynthesis(args.marketSynthesisId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/market-synthesis-links.ts
+++ b/control-plane/cli/market-synthesis-links.ts
@@ -1,0 +1,56 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): { marketSynthesisId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--market') {
+      const marketSynthesisId = argv[index + 1];
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { marketSynthesisId };
+    }
+    if (arg.startsWith('--market=')) {
+      const marketSynthesisId = arg.slice('--market='.length);
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { marketSynthesisId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --market');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.getMarketLinks(args.marketSynthesisId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/market-synthesis-list.ts
+++ b/control-plane/cli/market-synthesis-list.ts
@@ -1,0 +1,34 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): Record<string, never> {
+  if (argv.length > 0) {
+    throw new Error(`UNKNOWN_ARGUMENT: ${argv[0]}`);
+  }
+  return {};
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.listMarketSyntheses());
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/market-synthesis-materialize.ts
+++ b/control-plane/cli/market-synthesis-materialize.ts
@@ -1,0 +1,56 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): { marketSynthesisId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--market') {
+      const marketSynthesisId = argv[index + 1];
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { marketSynthesisId };
+    }
+    if (arg.startsWith('--market=')) {
+      const marketSynthesisId = arg.slice('--market='.length);
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { marketSynthesisId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --market');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.materializeMarketSynthesis(args.marketSynthesisId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/market-synthesis-readiness.ts
+++ b/control-plane/cli/market-synthesis-readiness.ts
@@ -1,0 +1,56 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): { marketSynthesisId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--market') {
+      const marketSynthesisId = argv[index + 1];
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { marketSynthesisId };
+    }
+    if (arg.startsWith('--market=')) {
+      const marketSynthesisId = arg.slice('--market='.length);
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { marketSynthesisId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --market');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.getMarketReadiness(args.marketSynthesisId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/market-synthesis-status.ts
+++ b/control-plane/cli/market-synthesis-status.ts
@@ -1,0 +1,56 @@
+import { createMarketInspection } from '../market-synthesis/market-synthesis-inspection.ts';
+import { canonicalStringify } from '../finance/determinism.ts';
+
+function parseArgs(argv: string[]): { marketSynthesisId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--market') {
+      const marketSynthesisId = argv[index + 1];
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { marketSynthesisId };
+    }
+    if (arg.startsWith('--market=')) {
+      const marketSynthesisId = arg.slice('--market='.length);
+      if (!marketSynthesisId) {
+        throw new Error('MISSING_ARGUMENT: --market');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { marketSynthesisId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --market');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMarketInspection();
+    printJson(inspection.getMarketStatus(args.marketSynthesisId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/market-synthesis/definitions/governance-instability-market-synthesis.json
+++ b/control-plane/market-synthesis/definitions/governance-instability-market-synthesis.json
@@ -1,0 +1,13 @@
+{
+  "marketSynthesisId": "governance-instability-market-synthesis",
+  "displayName": "Governance Instability Market Synthesis",
+  "synthesisType": "governance_instability",
+  "enabled": true,
+  "crossSwarmMatchingRules": {
+    "eventFamilies": ["governance", "market"],
+    "responseFamilies": ["governance", "market"]
+  },
+  "scopeConstraints": {
+    "minCrossSwarms": 1
+  }
+}

--- a/control-plane/market-synthesis/definitions/liquidity-stress-market-synthesis.json
+++ b/control-plane/market-synthesis/definitions/liquidity-stress-market-synthesis.json
@@ -1,0 +1,14 @@
+{
+  "marketSynthesisId": "liquidity-stress-market-synthesis",
+  "displayName": "Liquidity Stress Market Synthesis",
+  "synthesisType": "liquidity_stress",
+  "enabled": true,
+  "crossSwarmMatchingRules": {
+    "eventFamilies": ["liquidity", "market"],
+    "protocolFamilies": ["aave", "compound"],
+    "responseFamilies": ["liquidity", "market"]
+  },
+  "scopeConstraints": {
+    "minCrossSwarms": 1
+  }
+}

--- a/control-plane/market-synthesis/definitions/market-risk-synthesis.json
+++ b/control-plane/market-synthesis/definitions/market-risk-synthesis.json
@@ -1,0 +1,13 @@
+{
+  "marketSynthesisId": "market-risk-synthesis",
+  "displayName": "Market Risk Synthesis",
+  "synthesisType": "market_risk",
+  "enabled": true,
+  "crossSwarmMatchingRules": {
+    "eventFamilies": ["market", "protocol", "governance", "liquidity", "yield"],
+    "responseFamilies": ["market", "protocol", "governance", "liquidity"]
+  },
+  "scopeConstraints": {
+    "minCrossSwarms": 2
+  }
+}

--- a/control-plane/market-synthesis/definitions/yield-instability-market-synthesis.json
+++ b/control-plane/market-synthesis/definitions/yield-instability-market-synthesis.json
@@ -1,0 +1,14 @@
+{
+  "marketSynthesisId": "yield-instability-market-synthesis",
+  "displayName": "Yield Instability Market Synthesis",
+  "synthesisType": "yield_instability",
+  "enabled": true,
+  "crossSwarmMatchingRules": {
+    "eventFamilies": ["yield", "market"],
+    "protocolFamilies": ["aave", "curve"],
+    "responseFamilies": ["market", "protocol"]
+  },
+  "scopeConstraints": {
+    "minCrossSwarms": 1
+  }
+}

--- a/control-plane/market-synthesis/market-synthesis-history-store.test.ts
+++ b/control-plane/market-synthesis/market-synthesis-history-store.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  computeMarketSynthesisEventDedupeKey,
+  createMarketSynthesisHistoryStore
+} from './market-synthesis-history-store.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-market-synthesis-history');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('market-synthesis history store', () => {
+  it('T-MS-H1 appends deterministic events and dedupes by fingerprint', () => {
+    const store = createMarketSynthesisHistoryStore({
+      artifactsRoot: path.join(tmpRoot, 'artifacts', 'market-synthesis')
+    });
+
+    const first = store.append({
+      marketSynthesisId: 'market-risk-synthesis',
+      eventType: 'market_synthesis_initialized',
+      reason: 'market_synthesis_projection_generated',
+      linkedCrossSwarmIds: ['b', 'a'],
+      slotReference: 'daily:2026-03-11'
+    });
+
+    const second = store.append({
+      marketSynthesisId: 'market-risk-synthesis',
+      eventType: 'market_synthesis_initialized',
+      reason: 'market_synthesis_projection_generated',
+      linkedCrossSwarmIds: ['a', 'b'],
+      slotReference: 'daily:2026-03-11'
+    });
+
+    expect(first.appended).toBe(true);
+    expect(second.appended).toBe(false);
+    expect(store.load('market-risk-synthesis').entries[0]?.linkedCrossSwarmIds).toEqual(['a', 'b']);
+  });
+
+  it('T-MS-H2 keeps stable ordering', () => {
+    const store = createMarketSynthesisHistoryStore({
+      artifactsRoot: path.join(tmpRoot, 'artifacts', 'market-synthesis')
+    });
+
+    store.append({
+      marketSynthesisId: 'market-risk-synthesis',
+      eventType: 'market_completed',
+      reason: 'done',
+      linkedCrossSwarmIds: ['a'],
+      slotReference: 'daily:2026-03-12'
+    });
+
+    store.append({
+      marketSynthesisId: 'market-risk-synthesis',
+      eventType: 'readiness_changed',
+      reason: 'analyzing',
+      linkedCrossSwarmIds: ['a'],
+      slotReference: 'daily:2026-03-11'
+    });
+
+    const loaded = store.load('market-risk-synthesis');
+    expect(loaded.entries.map((entry) => entry.slotReference)).toEqual(['daily:2026-03-12', 'daily:2026-03-11']);
+  });
+
+  it('T-MS-H3 dedupe fingerprint is deterministic', () => {
+    const input = {
+      marketSynthesisId: 'market-risk-synthesis',
+      eventType: 'market_progressed' as const,
+      reason: 'market_lifecycle_progressing',
+      linkedCrossSwarmIds: ['a'],
+      slotReference: 'daily:2026-03-11'
+    };
+
+    expect(computeMarketSynthesisEventDedupeKey(input)).toBe(computeMarketSynthesisEventDedupeKey(input));
+  });
+});

--- a/control-plane/market-synthesis/market-synthesis-history-store.ts
+++ b/control-plane/market-synthesis/market-synthesis-history-store.ts
@@ -1,0 +1,240 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { canonicalStringify, sha256 } from '../finance/determinism.ts';
+
+import type {
+  MarketSynthesisHistory,
+  MarketSynthesisHistoryEntry,
+  MarketSynthesisHistoryEventType,
+} from './market-synthesis-types.ts';
+
+export const DEFAULT_MARKET_SYNTHESIS_ARTIFACTS_ROOT = path.join('artifacts', 'market-synthesis');
+
+function normalizeRelativeSegment(value: string, fieldName: string): string {
+  const normalized = value.trim().replace(/\\/g, '/').replace(/^\/+/, '');
+  if (normalized.length === 0 || normalized.includes('..') || normalized.includes('/')) {
+    throw new Error(`INVALID_${fieldName.toUpperCase()}: ${value}`);
+  }
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    return [];
+  }
+
+  return [...value].sort((left, right) => left.localeCompare(right));
+}
+
+function compareEntries(left: MarketSynthesisHistoryEntry, right: MarketSynthesisHistoryEntry): number {
+  const leftSlot = left.slotReference ?? '';
+  const rightSlot = right.slotReference ?? '';
+  const slotCmp = rightSlot.localeCompare(leftSlot);
+  if (slotCmp !== 0) {
+    return slotCmp;
+  }
+  return left.eventDedupeKey.localeCompare(right.eventDedupeKey);
+}
+
+function parseEntry(value: unknown): MarketSynthesisHistoryEntry {
+  if (!isRecord(value)) {
+    throw new Error('MARKET_SYNTHESIS_INVALID_HISTORY_ENTRY');
+  }
+
+  const marketSynthesisId = asString(value.marketSynthesisId);
+  const eventType = asString(value.eventType) as MarketSynthesisHistoryEventType;
+  const reason = asString(value.reason);
+  const eventDedupeKey = asString(value.eventDedupeKey);
+
+  if (!marketSynthesisId || !eventType || !reason || !eventDedupeKey) {
+    throw new Error('MARKET_SYNTHESIS_INVALID_HISTORY_ENTRY');
+  }
+
+  return {
+    marketSynthesisId,
+    eventType,
+    reason,
+    eventDedupeKey,
+    linkedCrossSwarmIds: asStringArray(value.linkedCrossSwarmIds),
+    ...(asString(value.slotReference) ? { slotReference: asString(value.slotReference)! } : {})
+  };
+}
+
+function readHistoryFile(filePath: string, fallback: MarketSynthesisHistory): MarketSynthesisHistory {
+  if (!fs.existsSync(filePath)) {
+    return fallback;
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('MARKET_SYNTHESIS_INVALID_HISTORY');
+  }
+
+  const marketSynthesisId = asString(parsed.marketSynthesisId);
+  if (!marketSynthesisId) {
+    throw new Error('MARKET_SYNTHESIS_INVALID_HISTORY');
+  }
+
+  const entries = Array.isArray(parsed.entries)
+    ? parsed.entries.map((entry) => parseEntry(entry)).sort(compareEntries)
+    : [];
+
+  return {
+    marketSynthesisId,
+    entries
+  };
+}
+
+export function resolveMarketSynthesisArtifactsRoot(rootDir?: string): string {
+  return path.resolve(rootDir ?? DEFAULT_MARKET_SYNTHESIS_ARTIFACTS_ROOT);
+}
+
+export function resolveMarketSynthesisArtifactDir(input: { marketSynthesisId: string; rootDir?: string }): string {
+  const marketSynthesisId = normalizeRelativeSegment(input.marketSynthesisId, 'market_synthesis_id');
+  return path.join(resolveMarketSynthesisArtifactsRoot(input.rootDir), marketSynthesisId);
+}
+
+export function ensureMarketSynthesisArtifactDir(input: { marketSynthesisId: string; rootDir?: string }): string {
+  const dirPath = resolveMarketSynthesisArtifactDir(input);
+  fs.mkdirSync(dirPath, { recursive: true });
+  return dirPath;
+}
+
+export function resolveMarketSynthesisArtifactPaths(input: { marketSynthesisId: string; rootDir?: string }): {
+  dirPath: string;
+  statusJsonPath: string;
+  historyJsonPath: string;
+  reportJsonPath: string;
+  reportMarkdownPath: string;
+} {
+  const dirPath = resolveMarketSynthesisArtifactDir(input);
+
+  return {
+    dirPath,
+    statusJsonPath: path.join(dirPath, 'market-synthesis-status.json'),
+    historyJsonPath: path.join(dirPath, 'market-synthesis-history.json'),
+    reportJsonPath: path.join(dirPath, 'market-synthesis-report.json'),
+    reportMarkdownPath: path.join(dirPath, 'market-synthesis-report.md')
+  };
+}
+
+export function computeMarketSynthesisEventDedupeKey(input: {
+  marketSynthesisId: string;
+  eventType: MarketSynthesisHistoryEventType;
+  reason: string;
+  linkedCrossSwarmIds?: string[];
+  slotReference?: string;
+}): string {
+  return sha256(canonicalStringify({
+    marketSynthesisId: input.marketSynthesisId,
+    eventType: input.eventType,
+    reason: input.reason,
+    linkedCrossSwarmIds: [...(input.linkedCrossSwarmIds ?? [])].sort((left, right) => left.localeCompare(right)),
+    slotReference: input.slotReference ?? ''
+  }));
+}
+
+export function createMarketSynthesisHistoryStore(options: { artifactsRoot?: string } = {}) {
+  function load(marketSynthesisId: string): MarketSynthesisHistory {
+    const paths = resolveMarketSynthesisArtifactPaths({
+      marketSynthesisId,
+      rootDir: options.artifactsRoot
+    });
+
+    return readHistoryFile(paths.historyJsonPath, {
+      marketSynthesisId,
+      entries: []
+    });
+  }
+
+  function append(input: {
+    marketSynthesisId: string;
+    eventType: MarketSynthesisHistoryEventType;
+    reason: string;
+    linkedCrossSwarmIds?: string[];
+    slotReference?: string;
+  }): {
+    history: MarketSynthesisHistory;
+    appended: boolean;
+    entry: MarketSynthesisHistoryEntry;
+  } {
+    ensureMarketSynthesisArtifactDir({
+      marketSynthesisId: input.marketSynthesisId,
+      rootDir: options.artifactsRoot
+    });
+
+    const paths = resolveMarketSynthesisArtifactPaths({
+      marketSynthesisId: input.marketSynthesisId,
+      rootDir: options.artifactsRoot
+    });
+
+    const eventDedupeKey = computeMarketSynthesisEventDedupeKey(input);
+    const entry: MarketSynthesisHistoryEntry = {
+      marketSynthesisId: input.marketSynthesisId,
+      eventType: input.eventType,
+      reason: input.reason,
+      eventDedupeKey,
+      linkedCrossSwarmIds: [...(input.linkedCrossSwarmIds ?? [])].sort((left, right) => left.localeCompare(right)),
+      ...(input.slotReference ? { slotReference: input.slotReference } : {})
+    };
+
+    const current = load(input.marketSynthesisId);
+    if (current.entries.some((row) => row.eventDedupeKey === eventDedupeKey)) {
+      return {
+        history: current,
+        appended: false,
+        entry,
+      };
+    }
+
+    const next: MarketSynthesisHistory = {
+      marketSynthesisId: input.marketSynthesisId,
+      entries: [...current.entries, entry].sort(compareEntries),
+    };
+
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(next)}\n`, 'utf8');
+
+    return {
+      history: next,
+      appended: true,
+      entry,
+    };
+  }
+
+  function write(history: MarketSynthesisHistory): string {
+    ensureMarketSynthesisArtifactDir({
+      marketSynthesisId: history.marketSynthesisId,
+      rootDir: options.artifactsRoot
+    });
+
+    const paths = resolveMarketSynthesisArtifactPaths({
+      marketSynthesisId: history.marketSynthesisId,
+      rootDir: options.artifactsRoot
+    });
+
+    const normalized: MarketSynthesisHistory = {
+      marketSynthesisId: history.marketSynthesisId,
+      entries: [...history.entries].sort(compareEntries)
+    };
+
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(normalized)}\n`, 'utf8');
+    return paths.historyJsonPath;
+  }
+
+  return {
+    load,
+    append,
+    write
+  };
+}
+
+export type MarketSynthesisHistoryStore = ReturnType<typeof createMarketSynthesisHistoryStore>;

--- a/control-plane/market-synthesis/market-synthesis-inspection.ts
+++ b/control-plane/market-synthesis/market-synthesis-inspection.ts
@@ -1,0 +1,291 @@
+import {
+  createMarketSynthesisHistoryStore,
+  type MarketSynthesisHistoryStore,
+} from './market-synthesis-history-store.ts';
+import {
+  createMarketSynthesisLinker,
+  type MarketSynthesisLinker,
+} from './market-synthesis-linker.ts';
+import {
+  createMarketSynthesisMaterializer,
+  type MarketSynthesisMaterializer,
+} from './market-synthesis-materializer.ts';
+import {
+  createMarketSynthesisProjection,
+  type MarketSynthesisProjectionEngine,
+} from './market-synthesis-projection.ts';
+import {
+  createMarketSynthesisRegistry,
+  type MarketSynthesisRegistry,
+} from './market-synthesis-registry.ts';
+import {
+  createMarketSynthesisStatusProjection,
+  type MarketSynthesisStatusProjectionEngine,
+} from './market-synthesis-status.ts';
+
+function toReadinessReason(readinessState: string, blockers: string[]): string {
+  if (readinessState === 'blocked') {
+    return blockers.join('|') || 'market_readiness_blocked';
+  }
+  if (readinessState === 'coherent') {
+    return 'market_readiness_coherent';
+  }
+  if (readinessState === 'analyzing') {
+    return 'market_readiness_analyzing';
+  }
+  return 'market_readiness_pending';
+}
+
+function toLifecycleReason(lifecycleState: string): string {
+  if (lifecycleState === 'progressing') {
+    return 'market_lifecycle_progressing';
+  }
+  if (lifecycleState === 'active') {
+    return 'market_lifecycle_active';
+  }
+  if (lifecycleState === 'initializing') {
+    return 'market_lifecycle_initializing';
+  }
+  return 'market_synthesis_initialized';
+}
+
+export function createMarketInspection(options: {
+  registry?: MarketSynthesisRegistry;
+  linker?: MarketSynthesisLinker;
+  statusProjection?: MarketSynthesisStatusProjectionEngine;
+  projection?: MarketSynthesisProjectionEngine;
+  materializer?: MarketSynthesisMaterializer;
+  historyStore?: MarketSynthesisHistoryStore;
+  definitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const definitionsDir = options.definitionsDir ?? options.marketSynthesisDefinitionsDir;
+
+  const registry = options.registry ?? createMarketSynthesisRegistry({ definitionsDir });
+
+  const linker = options.linker ?? createMarketSynthesisLinker({
+    registry,
+    definitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    now: options.now,
+  });
+
+  const statusProjection = options.statusProjection ?? createMarketSynthesisStatusProjection({
+    registry,
+    linker,
+    definitionsDir,
+    now: options.now,
+  });
+
+  const historyStore = options.historyStore ?? createMarketSynthesisHistoryStore({
+    artifactsRoot: options.marketSynthesisArtifactsRoot
+  });
+
+  const projection = options.projection ?? createMarketSynthesisProjection({
+    registry,
+    statusProjection,
+    historyStore,
+    definitionsDir,
+    now: options.now,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+  });
+
+  const materializer = options.materializer ?? createMarketSynthesisMaterializer({
+    projection,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    definitionsDir,
+    now: options.now,
+  });
+
+  function listMarketSyntheses() {
+    return registry.listDefinitions().map((entry) => ({
+      marketSynthesisId: entry.marketSynthesisId,
+      displayName: entry.displayName,
+      synthesisType: entry.synthesisType,
+      enabled: entry.enabled,
+    }));
+  }
+
+  function inspectMarketSynthesis(marketSynthesisId: string) {
+    return projection.projectOne(marketSynthesisId);
+  }
+
+  function getMarketStatus(marketSynthesisId: string) {
+    const status = statusProjection.projectOne(marketSynthesisId);
+    return {
+      marketSynthesisId,
+      lifecycleState: status.lifecycleState,
+      readinessState: status.readinessState,
+      completionState: status.completionState,
+      linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+      blockingReasons: status.blockingReasons,
+      strengths: status.strengths,
+      limitations: status.limitations,
+    };
+  }
+
+  function getMarketLinks(marketSynthesisId: string) {
+    const link = linker.buildLinks().find((entry) => entry.marketSynthesisId === marketSynthesisId);
+    if (!link) {
+      throw new Error(`MARKET_SYNTHESIS_NOT_FOUND: ${marketSynthesisId}`);
+    }
+
+    return {
+      marketSynthesisId,
+      linkedCrossSwarmIds: link.linkedCrossSwarmIds,
+      linkedCrossSwarms: link.linkedCrossSwarms,
+      rationale: link.rationale,
+    };
+  }
+
+  function getMarketReadiness(marketSynthesisId: string) {
+    const status = statusProjection.projectOne(marketSynthesisId);
+    return {
+      marketSynthesisId,
+      readinessState: status.readinessState,
+      completionState: status.completionState,
+      blockingReasons: status.blockingReasons,
+      strengths: status.strengths,
+      limitations: status.limitations,
+    };
+  }
+
+  function getMarketHistory(marketSynthesisId: string) {
+    registry.getDefinition(marketSynthesisId);
+    return historyStore.load(marketSynthesisId);
+  }
+
+  function evaluateMarketSynthesis(input: { marketSynthesisId: string; slotReference?: string }) {
+    const status = statusProjection.projectOne(input.marketSynthesisId);
+
+    historyStore.append({
+      marketSynthesisId: input.marketSynthesisId,
+      eventType: 'market_synthesis_initialized',
+      reason: 'market_synthesis_projection_generated',
+      linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+      ...(input.slotReference ? { slotReference: input.slotReference } : {})
+    });
+
+    if (status.linkedCrossSwarmIds.length > 0) {
+      historyStore.append({
+        marketSynthesisId: input.marketSynthesisId,
+        eventType: 'cross_swarm_linked',
+        reason: `linked_cross_swarms:${String(status.linkedCrossSwarmIds.length)}`,
+        linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {})
+      });
+    }
+
+    historyStore.append({
+      marketSynthesisId: input.marketSynthesisId,
+      eventType: 'readiness_changed',
+      reason: toReadinessReason(status.readinessState, status.blockingReasons),
+      linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+      ...(input.slotReference ? { slotReference: input.slotReference } : {})
+    });
+
+    if (status.lifecycleState === 'initializing' || status.lifecycleState === 'active' || status.lifecycleState === 'progressing') {
+      historyStore.append({
+        marketSynthesisId: input.marketSynthesisId,
+        eventType: 'market_progressed',
+        reason: toLifecycleReason(status.lifecycleState),
+        linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {})
+      });
+    }
+
+    if (status.lifecycleState === 'stabilizing') {
+      historyStore.append({
+        marketSynthesisId: input.marketSynthesisId,
+        eventType: 'market_stabilized',
+        reason: status.blockingReasons.join('|') || 'market_stabilizing',
+        linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {})
+      });
+    }
+
+    if (status.completionState === 'completed') {
+      historyStore.append({
+        marketSynthesisId: input.marketSynthesisId,
+        eventType: 'market_completed',
+        reason: 'market_completion_requirements_satisfied',
+        linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {})
+      });
+    }
+
+    if (status.completionState === 'inconclusive') {
+      historyStore.append({
+        marketSynthesisId: input.marketSynthesisId,
+        eventType: 'market_marked_inconclusive',
+        reason: status.limitations.join('|') || 'market_completion_inconclusive',
+        linkedCrossSwarmIds: status.linkedCrossSwarmIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {})
+      });
+    }
+
+    return {
+      projection: inspectMarketSynthesis(input.marketSynthesisId),
+      history: historyStore.load(input.marketSynthesisId),
+    };
+  }
+
+  function materializeMarketSynthesis(marketSynthesisId: string) {
+    const projected = inspectMarketSynthesis(marketSynthesisId);
+    const materialized = materializer.materializeProjection({ projection: projected });
+    historyStore.write(historyStore.load(marketSynthesisId));
+
+    return {
+      ...materialized,
+      historyPath: projected.artifactPaths.historyJsonPath,
+    };
+  }
+
+  return {
+    listMarketSyntheses,
+    inspectMarketSynthesis,
+    getMarketStatus,
+    getMarketLinks,
+    getMarketReadiness,
+    getMarketHistory,
+    evaluateMarketSynthesis,
+    materializeMarketSynthesis,
+  };
+}
+
+export type MarketInspection = ReturnType<typeof createMarketInspection>;

--- a/control-plane/market-synthesis/market-synthesis-linker.test.ts
+++ b/control-plane/market-synthesis/market-synthesis-linker.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMarketSynthesisLinker } from './market-synthesis-linker.ts';
+
+describe('market-synthesis linker', () => {
+  it('T-MS-L1 groups related cross-swarms via deterministic shared families and explicit rationale', () => {
+    const linker = createMarketSynthesisLinker({
+      registry: {
+        listDefinitions: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {
+            eventFamilies: ['market'],
+            responseFamilies: ['market']
+          },
+          scopeConstraints: { minCrossSwarms: 1 }
+        }],
+        getDefinition: () => { throw new Error('unused'); }
+      } as any,
+      crossSwarmInspection: {
+        listCrossSwarms: () => [{ crossSwarmId: 'market-shock-cluster', displayName: 'Market Shock', groupType: 'market_shock_cluster', enabled: true }],
+        inspectCrossSwarm: () => ({
+          crossSwarmId: 'market-shock-cluster',
+          displayName: 'Market Shock',
+          groupType: 'market_shock_cluster',
+          enabled: true,
+          linkedSwarmIds: ['a'],
+          linkedSwarms: [{
+            crossSwarmId: 'market-shock-cluster',
+            swarmId: 'a',
+            teamId: 'team-a',
+            swarmDisplayName: 'A',
+            lifecycleState: 'progressing',
+            readinessState: 'analyzing',
+            completionSatisfied: false,
+            unresolvedConflictCount: 0,
+            activeInvestigationCount: 1,
+            linkedInvestigationIds: ['inv-1'],
+            linkedSynthesisIds: [],
+            protocolFamilies: ['aave'],
+            assetFamilies: [],
+            eventFamilies: ['market'],
+            cohortFamilies: ['market'],
+            rationale: []
+          }],
+          lifecycleState: 'progressing',
+          readinessState: 'analyzing',
+          completion: {
+            crossSwarmId: 'market-shock-cluster',
+            isComplete: false,
+            unmetRequirements: [],
+            completedSwarmCount: 0,
+            totalSwarmCount: 1,
+            blockedSwarmCount: 0,
+            unresolvedConflictCount: 0
+          },
+          blockers: [],
+          conflicts: [],
+          strengths: [],
+          limitations: [],
+          rationale: [],
+          historySummary: { totalEvents: 0 },
+          artifactPaths: { dirPath: '', statusJsonPath: '', historyJsonPath: '', reportJsonPath: '', reportMarkdownPath: '' },
+          statusPreview: {},
+          reportPreview: {}
+        })
+      } as any
+    });
+
+    const links = linker.buildLinks();
+
+    expect(links[0]?.linkedCrossSwarmIds).toEqual(['market-shock-cluster']);
+    expect(links[0]?.rationale).toContain('market-shock-cluster:shared_event_family:market');
+    expect(links[0]?.rationale).toContain('market-shock-cluster:shared_response_family:market');
+  });
+
+  it('T-MS-L2 excludes unrelated cross-swarms', () => {
+    const linker = createMarketSynthesisLinker({
+      registry: {
+        listDefinitions: () => [{
+          marketSynthesisId: 'governance-instability-market-synthesis',
+          displayName: 'Governance Instability',
+          synthesisType: 'governance_instability',
+          enabled: true,
+          crossSwarmMatchingRules: {
+            eventFamilies: ['governance']
+          },
+          scopeConstraints: { minCrossSwarms: 1 }
+        }],
+        getDefinition: () => { throw new Error('unused'); }
+      } as any,
+      crossSwarmInspection: {
+        listCrossSwarms: () => [{ crossSwarmId: 'liquidity-instability-cluster', displayName: 'Liquidity', groupType: 'liquidity_instability_cluster', enabled: true }],
+        inspectCrossSwarm: () => ({
+          crossSwarmId: 'liquidity-instability-cluster',
+          displayName: 'Liquidity',
+          groupType: 'liquidity_instability_cluster',
+          enabled: true,
+          linkedSwarmIds: [],
+          linkedSwarms: [],
+          lifecycleState: 'active',
+          readinessState: 'analyzing',
+          completion: {
+            crossSwarmId: 'liquidity-instability-cluster',
+            isComplete: false,
+            unmetRequirements: [],
+            completedSwarmCount: 0,
+            totalSwarmCount: 0,
+            blockedSwarmCount: 0,
+            unresolvedConflictCount: 0
+          },
+          blockers: [],
+          conflicts: [],
+          strengths: [],
+          limitations: [],
+          rationale: [],
+          historySummary: { totalEvents: 0 },
+          artifactPaths: { dirPath: '', statusJsonPath: '', historyJsonPath: '', reportJsonPath: '', reportMarkdownPath: '' },
+          statusPreview: {},
+          reportPreview: {}
+        })
+      } as any
+    });
+
+    const links = linker.buildLinks();
+    expect(links[0]?.linkedCrossSwarmIds).toEqual([]);
+  });
+});

--- a/control-plane/market-synthesis/market-synthesis-linker.ts
+++ b/control-plane/market-synthesis/market-synthesis-linker.ts
@@ -1,0 +1,251 @@
+import {
+  createCrossSwarmInspection,
+  type CrossSwarmInspection,
+} from '../cross-swarms/cross-swarm-inspection.ts';
+
+import {
+  createMarketSynthesisRegistry,
+  type MarketSynthesisRegistry,
+} from './market-synthesis-registry.ts';
+import type {
+  LinkedCrossSwarmSummary,
+  MarketSynthesisDefinition,
+  MarketSynthesisLinkProjection,
+  MarketSynthesisLifecycleState,
+  MarketSynthesisReadinessState,
+} from './market-synthesis-types.ts';
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function familyFromDashOrUnderscore(value: string): string {
+  const normalized = normalizeToken(value);
+  return normalized.split(/[-_]/)[0] ?? normalized;
+}
+
+function intersects(left: string[], right: string[]): string[] {
+  const rightSet = new Set(right.map((entry) => normalizeToken(entry)));
+  return left
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => rightSet.has(entry))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function toLifecycleState(value: string): MarketSynthesisLifecycleState {
+  if (value === 'inactive' || value === 'initializing' || value === 'active' || value === 'progressing' || value === 'stabilizing' || value === 'completed') {
+    return value;
+  }
+  if (value === 'activated') {
+    return 'active';
+  }
+  return 'inactive';
+}
+
+function toReadinessState(value: string): MarketSynthesisReadinessState {
+  if (value === 'pending' || value === 'analyzing' || value === 'coherent' || value === 'blocked') {
+    return value;
+  }
+  return 'pending';
+}
+
+type CrossSwarmContext = LinkedCrossSwarmSummary;
+
+function buildCrossSwarmContexts(inspection: CrossSwarmInspection): CrossSwarmContext[] {
+  return inspection
+    .listCrossSwarms()
+    .map((entry) => {
+      const projection = inspection.inspectCrossSwarm(entry.crossSwarmId);
+      const linkedCrossSwarmFamilies = uniqueSorted([
+        familyFromDashOrUnderscore(projection.crossSwarmId),
+        familyFromDashOrUnderscore(projection.groupType)
+      ]);
+
+      return {
+        crossSwarmId: projection.crossSwarmId,
+        displayName: projection.displayName,
+        groupType: projection.groupType,
+        lifecycleState: toLifecycleState(projection.lifecycleState),
+        readinessState: toReadinessState(projection.readinessState),
+        completionSatisfied: projection.completion.isComplete,
+        unresolvedConflictCount: projection.completion.unresolvedConflictCount,
+        blockers: [...projection.blockers].sort((left, right) => left.localeCompare(right)),
+        conflicts: [...projection.conflicts].sort((left, right) => left.localeCompare(right)),
+        protocolFamilies: uniqueSorted(projection.linkedSwarms.flatMap((linked) => linked.protocolFamilies)),
+        assetFamilies: uniqueSorted(projection.linkedSwarms.flatMap((linked) => linked.assetFamilies)),
+        eventFamilies: uniqueSorted(projection.linkedSwarms.flatMap((linked) => linked.eventFamilies)),
+        responseFamilies: linkedCrossSwarmFamilies
+      };
+    })
+    .sort((left, right) => left.crossSwarmId.localeCompare(right.crossSwarmId));
+}
+
+function explicitDefinitionMatch(definition: MarketSynthesisDefinition, context: CrossSwarmContext): string[] {
+  const synthesisFamilies = uniqueSorted([
+    familyFromDashOrUnderscore(definition.marketSynthesisId),
+    familyFromDashOrUnderscore(definition.synthesisType)
+  ]);
+  const crossFamilies = uniqueSorted([
+    familyFromDashOrUnderscore(context.crossSwarmId),
+    familyFromDashOrUnderscore(context.groupType),
+    ...context.responseFamilies
+  ]);
+
+  return intersects(synthesisFamilies, crossFamilies);
+}
+
+function matchByRules(definition: MarketSynthesisDefinition, context: CrossSwarmContext): {
+  matches: boolean;
+  rationale: string[];
+} {
+  const rationale: string[] = [];
+
+  const explicit = explicitDefinitionMatch(definition, context);
+  if (explicit.length > 0) {
+    rationale.push(...explicit.map((entry) => `explicit_definition_match:${entry}`));
+  }
+
+  const eventFamilies = definition.crossSwarmMatchingRules.eventFamilies ?? [];
+  if (eventFamilies.length > 0) {
+    const overlap = intersects(context.eventFamilies, eventFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_event_family:${entry}`));
+  }
+
+  const protocolFamilies = definition.crossSwarmMatchingRules.protocolFamilies ?? [];
+  if (protocolFamilies.length > 0) {
+    const overlap = intersects(context.protocolFamilies, protocolFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_protocol_family:${entry}`));
+  }
+
+  const assetFamilies = definition.crossSwarmMatchingRules.assetFamilies ?? [];
+  if (assetFamilies.length > 0) {
+    const overlap = intersects(context.assetFamilies, assetFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_asset_family:${entry}`));
+  }
+
+  const responseFamilies = definition.crossSwarmMatchingRules.responseFamilies ?? [];
+  if (responseFamilies.length > 0) {
+    const overlap = intersects(context.responseFamilies, responseFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_response_family:${entry}`));
+  }
+
+  if (rationale.length === 0) {
+    return { matches: false, rationale: [] };
+  }
+
+  return {
+    matches: true,
+    rationale: uniqueSorted(rationale)
+  };
+}
+
+export function createMarketSynthesisLinker(options: {
+  registry?: MarketSynthesisRegistry;
+  crossSwarmInspection?: CrossSwarmInspection;
+  definitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createMarketSynthesisRegistry({ definitionsDir: options.definitionsDir });
+
+  const crossSwarmInspection = options.crossSwarmInspection ?? createCrossSwarmInspection({
+    definitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    now: options.now
+  });
+
+  function buildLinks(): MarketSynthesisLinkProjection[] {
+    const contexts = buildCrossSwarmContexts(crossSwarmInspection);
+
+    return registry
+      .listDefinitions()
+      .map((definition) => {
+        const linked = definition.enabled
+          ? contexts
+            .map((context) => {
+              const match = matchByRules(definition, context);
+              if (!match.matches) {
+                return null;
+              }
+              return {
+                context,
+                rationale: match.rationale.map((entry) => `${context.crossSwarmId}:${entry}`)
+              };
+            })
+            .filter((entry): entry is { context: CrossSwarmContext; rationale: string[] } => entry !== null)
+          : [];
+
+        const linkedCrossSwarms = linked
+          .map((entry) => entry.context)
+          .sort((left, right) => left.crossSwarmId.localeCompare(right.crossSwarmId));
+
+        const linkedCrossSwarmIds = linkedCrossSwarms
+          .map((entry) => entry.crossSwarmId)
+          .sort((left, right) => left.localeCompare(right));
+
+        return {
+          marketSynthesisId: definition.marketSynthesisId,
+          displayName: definition.displayName,
+          synthesisType: definition.synthesisType,
+          enabled: definition.enabled,
+          linkedCrossSwarmIds,
+          linkedCrossSwarms,
+          rationale: uniqueSorted(linked.flatMap((entry) => entry.rationale))
+        } satisfies MarketSynthesisLinkProjection;
+      })
+      .sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+  }
+
+  return {
+    buildLinks
+  };
+}
+
+export type MarketSynthesisLinker = ReturnType<typeof createMarketSynthesisLinker>;

--- a/control-plane/market-synthesis/market-synthesis-materializer.ts
+++ b/control-plane/market-synthesis/market-synthesis-materializer.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+
+import {
+  ensureMarketSynthesisArtifactDir,
+  resolveMarketSynthesisArtifactPaths,
+} from './market-synthesis-history-store.ts';
+import {
+  createMarketSynthesisProjection,
+  type MarketSynthesisProjectionEngine,
+} from './market-synthesis-projection.ts';
+import type { MarketSynthesisProjection } from './market-synthesis-types.ts';
+
+function toMarkdownReport(reportPreview: Record<string, unknown>): string {
+  const lines = [
+    '# Market Intelligence Synthesis Report',
+    '',
+    `${canonicalStringify(reportPreview)}`
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+export interface MaterializedMarketSynthesis {
+  marketSynthesisId: string;
+  statusPath: string;
+  reportPath: string;
+  markdownPath: string;
+}
+
+export function createMarketSynthesisMaterializer(options: {
+  projection?: MarketSynthesisProjectionEngine;
+  marketSynthesisArtifactsRoot?: string;
+  definitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const projection = options.projection ?? createMarketSynthesisProjection({
+    definitionsDir: options.definitionsDir ?? options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  function materializeProjection(input: { projection: MarketSynthesisProjection }): MaterializedMarketSynthesis {
+    ensureMarketSynthesisArtifactDir({
+      marketSynthesisId: input.projection.marketSynthesisId,
+      rootDir: options.marketSynthesisArtifactsRoot,
+    });
+
+    const paths = resolveMarketSynthesisArtifactPaths({
+      marketSynthesisId: input.projection.marketSynthesisId,
+      rootDir: options.marketSynthesisArtifactsRoot,
+    });
+
+    fs.writeFileSync(paths.statusJsonPath, `${canonicalStringify(input.projection.statusPreview)}\n`, 'utf8');
+    fs.writeFileSync(paths.reportJsonPath, `${canonicalStringify(input.projection.reportPreview)}\n`, 'utf8');
+    fs.writeFileSync(paths.reportMarkdownPath, toMarkdownReport(input.projection.reportPreview), 'utf8');
+
+    return {
+      marketSynthesisId: input.projection.marketSynthesisId,
+      statusPath: paths.statusJsonPath,
+      reportPath: paths.reportJsonPath,
+      markdownPath: paths.reportMarkdownPath,
+    };
+  }
+
+  function materializeOne(marketSynthesisId: string): MaterializedMarketSynthesis {
+    const projected = projection.projectOne(marketSynthesisId);
+    return materializeProjection({ projection: projected });
+  }
+
+  return {
+    materializeProjection,
+    materializeOne,
+  };
+}
+
+export type MarketSynthesisMaterializer = ReturnType<typeof createMarketSynthesisMaterializer>;

--- a/control-plane/market-synthesis/market-synthesis-projection.ts
+++ b/control-plane/market-synthesis/market-synthesis-projection.ts
@@ -1,0 +1,139 @@
+import {
+  createMarketSynthesisHistoryStore,
+  resolveMarketSynthesisArtifactPaths,
+  type MarketSynthesisHistoryStore,
+} from './market-synthesis-history-store.ts';
+import {
+  createMarketSynthesisRegistry,
+  type MarketSynthesisRegistry,
+} from './market-synthesis-registry.ts';
+import {
+  createMarketSynthesisStatusProjection,
+  type MarketSynthesisStatusProjectionEngine,
+} from './market-synthesis-status.ts';
+import type {
+  MarketSynthesisProjection,
+  MarketSynthesisStatusProjection,
+} from './market-synthesis-types.ts';
+
+function toProjection(input: {
+  status: MarketSynthesisStatusProjection;
+  historyStore: MarketSynthesisHistoryStore;
+  artifactsRoot?: string;
+}): MarketSynthesisProjection {
+  const history = input.historyStore.load(input.status.marketSynthesisId);
+  const artifactPaths = resolveMarketSynthesisArtifactPaths({
+    marketSynthesisId: input.status.marketSynthesisId,
+    rootDir: input.artifactsRoot
+  });
+
+  const statusPreview = {
+    marketSynthesisId: input.status.marketSynthesisId,
+    lifecycleState: input.status.lifecycleState,
+    readinessState: input.status.readinessState,
+    completionState: input.status.completionState,
+    linkedCrossSwarmIds: input.status.linkedCrossSwarmIds,
+    blockingReasons: input.status.blockingReasons,
+    strengths: input.status.strengths,
+    limitations: input.status.limitations,
+  } as Record<string, unknown>;
+
+  const reportPreview = {
+    ...input.status,
+    history,
+  } as Record<string, unknown>;
+
+  return {
+    ...input.status,
+    historySummary: {
+      totalEvents: history.entries.length,
+      ...(history.entries[0] ? { lastEventType: history.entries[0].eventType } : {}),
+      ...(history.entries[0] ? { lastEventDedupeKey: history.entries[0].eventDedupeKey } : {}),
+    },
+    artifactPaths,
+    statusPreview,
+    reportPreview,
+  };
+}
+
+export function createMarketSynthesisProjection(options: {
+  registry?: MarketSynthesisRegistry;
+  statusProjection?: MarketSynthesisStatusProjectionEngine;
+  historyStore?: MarketSynthesisHistoryStore;
+  definitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createMarketSynthesisRegistry({
+    definitionsDir: options.definitionsDir ?? options.marketSynthesisDefinitionsDir
+  });
+
+  const statusProjection = options.statusProjection ?? createMarketSynthesisStatusProjection({
+    registry,
+    definitionsDir: options.definitionsDir ?? options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    now: options.now,
+  });
+
+  const historyStore = options.historyStore ?? createMarketSynthesisHistoryStore({
+    artifactsRoot: options.marketSynthesisArtifactsRoot
+  });
+
+  function projectOne(marketSynthesisId: string): MarketSynthesisProjection {
+    registry.getDefinition(marketSynthesisId);
+    const status = statusProjection.projectOne(marketSynthesisId);
+    return toProjection({
+      status,
+      historyStore,
+      artifactsRoot: options.marketSynthesisArtifactsRoot,
+    });
+  }
+
+  function projectAll(): MarketSynthesisProjection[] {
+    return registry
+      .listDefinitions()
+      .map((entry) => projectOne(entry.marketSynthesisId))
+      .sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+  }
+
+  return {
+    projectOne,
+    projectAll,
+  };
+}
+
+export type MarketSynthesisProjectionEngine = ReturnType<typeof createMarketSynthesisProjection>;

--- a/control-plane/market-synthesis/market-synthesis-registry.test.ts
+++ b/control-plane/market-synthesis/market-synthesis-registry.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createMarketSynthesisRegistry,
+  loadMarketSynthesisDefinitions,
+} from './market-synthesis-registry.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-market-synthesis-definitions');
+
+function writeJson(fileName: string, value: unknown): void {
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('market-synthesis registry', () => {
+  it('T-MS-R1 loads valid definitions in deterministic order', () => {
+    writeJson('zeta.json', {
+      marketSynthesisId: 'zeta',
+      displayName: 'Zeta',
+      synthesisType: 'zeta_type',
+      enabled: true,
+      crossSwarmMatchingRules: {
+        eventFamilies: ['market']
+      },
+      scopeConstraints: {
+        minCrossSwarms: 2
+      }
+    });
+    writeJson('alpha.json', {
+      marketSynthesisId: 'alpha',
+      displayName: 'Alpha',
+      synthesisType: 'alpha_type',
+      enabled: true,
+      crossSwarmMatchingRules: {
+        responseFamilies: ['protocol']
+      }
+    });
+
+    const loaded = loadMarketSynthesisDefinitions({ definitionsDir: tmpRoot });
+    expect(loaded.map((entry) => entry.marketSynthesisId)).toEqual(['alpha', 'zeta']);
+  });
+
+  it('T-MS-R2 rejects invalid schema', () => {
+    writeJson('invalid.json', {
+      marketSynthesisId: 'bad',
+      displayName: 'Bad',
+      synthesisType: 'bad_type',
+      enabled: true,
+      crossSwarmMatchingRules: {
+        eventFamilies: [123]
+      }
+    });
+
+    expect(() => loadMarketSynthesisDefinitions({ definitionsDir: tmpRoot })).toThrow(/crossSwarmMatchingRules.eventFamilies/);
+  });
+
+  it('T-MS-R3 rejects duplicate market synthesis ids', () => {
+    const payload = {
+      marketSynthesisId: 'dup',
+      displayName: 'Dup',
+      synthesisType: 'dup_type',
+      enabled: true,
+      crossSwarmMatchingRules: {
+        eventFamilies: ['market']
+      }
+    };
+
+    writeJson('a.json', payload);
+    writeJson('b.json', payload);
+
+    expect(() => createMarketSynthesisRegistry({ definitionsDir: tmpRoot })).toThrow(/Duplicate marketSynthesisId detected/);
+  });
+});

--- a/control-plane/market-synthesis/market-synthesis-registry.ts
+++ b/control-plane/market-synthesis/market-synthesis-registry.ts
@@ -1,0 +1,212 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  MarketSynthesisError,
+  type MarketSynthesisDefinition,
+} from './market-synthesis-types.ts';
+
+export const DEFAULT_MARKET_SYNTHESIS_DEFINITIONS_DIR = 'control-plane/market-synthesis/definitions';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asTrimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function asUniqueStringArray(value: unknown, sourceLabel: string, fieldName: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} ${fieldName} must be an array of non-empty strings.`
+    );
+  }
+
+  const normalized = value.map((entry) => asTrimmedString(entry));
+  if (normalized.some((entry) => !entry)) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} ${fieldName} must be an array of non-empty strings.`
+    );
+  }
+
+  return Array.from(new Set(normalized as string[])).sort((left, right) => left.localeCompare(right));
+}
+
+function validateMatchingRules(
+  value: unknown,
+  sourceLabel: string
+): MarketSynthesisDefinition['crossSwarmMatchingRules'] {
+  if (!isRecord(value)) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} crossSwarmMatchingRules must be an object.`
+    );
+  }
+
+  const eventFamilies = value.eventFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.eventFamilies, sourceLabel, 'crossSwarmMatchingRules.eventFamilies');
+
+  const protocolFamilies = value.protocolFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.protocolFamilies, sourceLabel, 'crossSwarmMatchingRules.protocolFamilies');
+
+  const assetFamilies = value.assetFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.assetFamilies, sourceLabel, 'crossSwarmMatchingRules.assetFamilies');
+
+  const responseFamilies = value.responseFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.responseFamilies, sourceLabel, 'crossSwarmMatchingRules.responseFamilies');
+
+  return {
+    ...(eventFamilies ? { eventFamilies } : {}),
+    ...(protocolFamilies ? { protocolFamilies } : {}),
+    ...(assetFamilies ? { assetFamilies } : {}),
+    ...(responseFamilies ? { responseFamilies } : {})
+  };
+}
+
+function validateScopeConstraints(
+  value: unknown,
+  sourceLabel: string
+): MarketSynthesisDefinition['scopeConstraints'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} scopeConstraints must be an object.`
+    );
+  }
+
+  if (value.minCrossSwarms === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value.minCrossSwarms) || (value.minCrossSwarms as number) < 0) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} scopeConstraints.minCrossSwarms must be a non-negative integer.`
+    );
+  }
+
+  return { minCrossSwarms: value.minCrossSwarms as number };
+}
+
+export function validateMarketSynthesisDefinition(
+  value: unknown,
+  sourceLabel = '<inline>'
+): MarketSynthesisDefinition {
+  if (!isRecord(value)) {
+    throw new MarketSynthesisError('MARKET_SYNTHESIS_INVALID_DEFINITION', `Market synthesis definition ${sourceLabel} must be an object.`);
+  }
+
+  const marketSynthesisId = asTrimmedString(value.marketSynthesisId);
+  const displayName = asTrimmedString(value.displayName);
+  const synthesisType = asTrimmedString(value.synthesisType);
+  const enabled = asBoolean(value.enabled);
+  const crossSwarmMatchingRules = validateMatchingRules(value.crossSwarmMatchingRules, sourceLabel);
+  const scopeConstraints = validateScopeConstraints(value.scopeConstraints, sourceLabel);
+
+  if (!marketSynthesisId) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} marketSynthesisId must be a non-empty string.`
+    );
+  }
+  if (!displayName) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} displayName must be a non-empty string.`
+    );
+  }
+  if (!synthesisType) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} synthesisType must be a non-empty string.`
+    );
+  }
+  if (enabled === null) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_INVALID_DEFINITION',
+      `Market synthesis definition ${sourceLabel} enabled must be a boolean.`
+    );
+  }
+
+  return {
+    marketSynthesisId,
+    displayName,
+    synthesisType,
+    enabled,
+    crossSwarmMatchingRules,
+    ...(scopeConstraints ? { scopeConstraints } : {})
+  };
+}
+
+export function loadMarketSynthesisDefinitions(options: { definitionsDir?: string } = {}): MarketSynthesisDefinition[] {
+  const definitionsDir = path.resolve(options.definitionsDir ?? DEFAULT_MARKET_SYNTHESIS_DEFINITIONS_DIR);
+  if (!fs.existsSync(definitionsDir)) {
+    throw new MarketSynthesisError(
+      'MARKET_SYNTHESIS_DEFINITIONS_NOT_FOUND',
+      `Market synthesis definitions directory not found: ${definitionsDir}`
+    );
+  }
+
+  const files = fs.readdirSync(definitionsDir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort((left, right) => left.localeCompare(right));
+
+  return files
+    .map((entry) => {
+      const filePath = path.join(definitionsDir, entry);
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+      return validateMarketSynthesisDefinition(parsed, entry);
+    })
+    .sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+}
+
+export function createMarketSynthesisRegistry(options: { definitionsDir?: string } = {}) {
+  const definitions = loadMarketSynthesisDefinitions({ definitionsDir: options.definitionsDir });
+  const byId = new Map<string, MarketSynthesisDefinition>();
+
+  for (const definition of definitions) {
+    if (byId.has(definition.marketSynthesisId)) {
+      throw new MarketSynthesisError(
+        'MARKET_SYNTHESIS_DUPLICATE_DEFINITION',
+        `Duplicate marketSynthesisId detected: ${definition.marketSynthesisId}`
+      );
+    }
+    byId.set(definition.marketSynthesisId, definition);
+  }
+
+  function listDefinitions(): MarketSynthesisDefinition[] {
+    return Array.from(byId.values()).sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+  }
+
+  function getDefinition(marketSynthesisId: string): MarketSynthesisDefinition {
+    const found = byId.get(marketSynthesisId);
+    if (!found) {
+      throw new MarketSynthesisError('MARKET_SYNTHESIS_NOT_FOUND', `Market synthesis definition not found: ${marketSynthesisId}`);
+    }
+    return found;
+  }
+
+  return {
+    listDefinitions,
+    getDefinition
+  };
+}
+
+export type MarketSynthesisRegistry = ReturnType<typeof createMarketSynthesisRegistry>;

--- a/control-plane/market-synthesis/market-synthesis-status.test.ts
+++ b/control-plane/market-synthesis/market-synthesis-status.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMarketSynthesisStatusProjection } from './market-synthesis-status.ts';
+
+describe('market-synthesis status projection', () => {
+  it('T-MS-S1 classifies blocked readiness when blockers/conflicts are present', () => {
+    const projection = createMarketSynthesisStatusProjection({
+      registry: {
+        listDefinitions: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 1 }
+        }],
+        getDefinition: () => ({
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 1 }
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          linkedCrossSwarmIds: ['a'],
+          linkedCrossSwarms: [{
+            crossSwarmId: 'a',
+            displayName: 'A',
+            groupType: 'market_shock_cluster',
+            lifecycleState: 'stabilizing',
+            readinessState: 'blocked',
+            completionSatisfied: false,
+            unresolvedConflictCount: 2,
+            blockers: ['incomplete_swarm:a'],
+            conflicts: ['swarm_conflicts:a:2'],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: [],
+            responseFamilies: []
+          }],
+          rationale: []
+        }]
+      } as any
+    });
+
+    const status = projection.projectOne('market-risk-synthesis');
+    expect(status.readinessState).toBe('blocked');
+    expect(status.completionState).toBe('inconclusive');
+  });
+
+  it('T-MS-S2 classifies coherent and completed only with complete coherent coverage', () => {
+    const projection = createMarketSynthesisStatusProjection({
+      registry: {
+        listDefinitions: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 2 }
+        }],
+        getDefinition: () => ({
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 2 }
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          linkedCrossSwarmIds: ['a', 'b'],
+          linkedCrossSwarms: [{
+            crossSwarmId: 'a',
+            displayName: 'A',
+            groupType: 'market_shock_cluster',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionSatisfied: true,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: [],
+            responseFamilies: []
+          }, {
+            crossSwarmId: 'b',
+            displayName: 'B',
+            groupType: 'protocol_response_cluster',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionSatisfied: true,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: [],
+            responseFamilies: []
+          }],
+          rationale: []
+        }]
+      } as any
+    });
+
+    const status = projection.projectOne('market-risk-synthesis');
+    expect(status.readinessState).toBe('coherent');
+    expect(status.completionState).toBe('completed');
+  });
+
+  it('T-MS-S3 classifies inconclusive when coverage is weak', () => {
+    const projection = createMarketSynthesisStatusProjection({
+      registry: {
+        listDefinitions: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 2 }
+        }],
+        getDefinition: () => ({
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 2 }
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          enabled: true,
+          linkedCrossSwarmIds: ['a'],
+          linkedCrossSwarms: [{
+            crossSwarmId: 'a',
+            displayName: 'A',
+            groupType: 'market_shock_cluster',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionSatisfied: true,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: [],
+            responseFamilies: []
+          }],
+          rationale: []
+        }]
+      } as any
+    });
+
+    const status = projection.projectOne('market-risk-synthesis');
+    expect(status.completionState).toBe('inconclusive');
+    expect(status.blockingReasons).toContain('weak_coverage:min_required:2:linked:1');
+  });
+});

--- a/control-plane/market-synthesis/market-synthesis-status.ts
+++ b/control-plane/market-synthesis/market-synthesis-status.ts
@@ -1,0 +1,300 @@
+import {
+  createMarketSynthesisLinker,
+  type MarketSynthesisLinkProjection,
+  type MarketSynthesisLinker
+} from './market-synthesis-linker.ts';
+import {
+  createMarketSynthesisRegistry,
+  type MarketSynthesisRegistry,
+} from './market-synthesis-registry.ts';
+import type {
+  MarketSynthesisCompletionState,
+  MarketSynthesisLifecycleState,
+  MarketSynthesisReadinessState,
+  MarketSynthesisStatusProjection,
+} from './market-synthesis-types.ts';
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function evaluateLifecycleState(link: MarketSynthesisLinkProjection): MarketSynthesisLifecycleState {
+  if (!link.enabled || link.linkedCrossSwarms.length === 0) {
+    return 'inactive';
+  }
+
+  const states = link.linkedCrossSwarms.map((entry) => entry.lifecycleState);
+
+  if (states.every((state) => state === 'inactive')) {
+    return 'inactive';
+  }
+  if (states.every((state) => state === 'initializing' || state === 'inactive')) {
+    return 'initializing';
+  }
+  if (states.every((state) => state === 'completed')) {
+    return 'completed';
+  }
+  if (states.some((state) => state === 'stabilizing')) {
+    return 'stabilizing';
+  }
+  if (states.some((state) => state === 'progressing')) {
+    return 'progressing';
+  }
+  if (states.some((state) => state === 'active')) {
+    return 'active';
+  }
+
+  return 'initializing';
+}
+
+function buildBlockingReasons(input: {
+  link: MarketSynthesisLinkProjection;
+  minCrossSwarms: number;
+}): { blockingReasons: string[]; contradictions: string[]; weakCoverage: boolean } {
+  const reasons: string[] = [];
+
+  if (!input.link.enabled) {
+    reasons.push('market_synthesis_disabled');
+  }
+  if (input.link.linkedCrossSwarmIds.length === 0) {
+    reasons.push('no_linked_cross_swarms');
+  }
+
+  const weakCoverage = input.link.linkedCrossSwarmIds.length < input.minCrossSwarms;
+  if (weakCoverage) {
+    reasons.push(
+      `weak_coverage:min_required:${String(input.minCrossSwarms)}:linked:${String(input.link.linkedCrossSwarmIds.length)}`
+    );
+  }
+
+  for (const crossSwarm of input.link.linkedCrossSwarms) {
+    if (crossSwarm.readinessState === 'blocked') {
+      reasons.push(`linked_cross_swarm_blocked:${crossSwarm.crossSwarmId}`);
+    }
+    if (crossSwarm.unresolvedConflictCount > 0) {
+      reasons.push(`linked_cross_swarm_conflicts:${crossSwarm.crossSwarmId}:${String(crossSwarm.unresolvedConflictCount)}`);
+    }
+    reasons.push(...crossSwarm.blockers.map((entry) => `linked_cross_swarm_blocker:${crossSwarm.crossSwarmId}:${entry}`));
+    reasons.push(...crossSwarm.conflicts.map((entry) => `linked_cross_swarm_conflict:${crossSwarm.crossSwarmId}:${entry}`));
+  }
+
+  const readinessStates = uniqueSorted(input.link.linkedCrossSwarms.map((entry) => entry.readinessState));
+  const contradictions: string[] = [];
+  if (readinessStates.includes('coherent') && readinessStates.includes('blocked')) {
+    contradictions.push('contradictory_readiness_signals');
+  }
+
+  return {
+    blockingReasons: uniqueSorted([...reasons, ...contradictions]),
+    contradictions,
+    weakCoverage,
+  };
+}
+
+function evaluateReadinessState(input: {
+  link: MarketSynthesisLinkProjection;
+  blockingReasons: string[];
+  contradictions: string[];
+}): MarketSynthesisReadinessState {
+  if (!input.link.enabled || input.link.linkedCrossSwarms.length === 0) {
+    return 'pending';
+  }
+
+  if (input.blockingReasons.length > 0 || input.contradictions.length > 0) {
+    return 'blocked';
+  }
+
+  const readinessStates = input.link.linkedCrossSwarms.map((entry) => entry.readinessState);
+  if (readinessStates.every((entry) => entry === 'coherent')) {
+    return 'coherent';
+  }
+  if (readinessStates.some((entry) => entry === 'analyzing' || entry === 'coherent')) {
+    return 'analyzing';
+  }
+  return 'pending';
+}
+
+function evaluateCompletionState(input: {
+  link: MarketSynthesisLinkProjection;
+  readinessState: MarketSynthesisReadinessState;
+  weakCoverage: boolean;
+  contradictions: string[];
+  blockingReasons: string[];
+}): MarketSynthesisCompletionState {
+  if (!input.link.enabled) {
+    return 'incomplete';
+  }
+
+  if (input.weakCoverage || input.contradictions.length > 0) {
+    return 'inconclusive';
+  }
+
+  if (input.blockingReasons.length > 0 || input.readinessState === 'blocked') {
+    return 'inconclusive';
+  }
+
+  const allComplete = input.link.linkedCrossSwarms.length > 0
+    && input.link.linkedCrossSwarms.every((entry) => entry.completionSatisfied);
+
+  if (allComplete && input.readinessState === 'coherent') {
+    return 'completed';
+  }
+
+  return 'incomplete';
+}
+
+function buildStrengths(link: MarketSynthesisLinkProjection): string[] {
+  const strengths: string[] = [];
+
+  if (link.linkedCrossSwarms.length > 0) {
+    strengths.push(`linked_cross_swarms:${String(link.linkedCrossSwarms.length)}`);
+  }
+
+  const coherentCount = link.linkedCrossSwarms.filter((entry) => entry.readinessState === 'coherent').length;
+  if (coherentCount > 0) {
+    strengths.push(`coherent_cross_swarms:${String(coherentCount)}`);
+  }
+
+  const completedCount = link.linkedCrossSwarms.filter((entry) => entry.completionSatisfied).length;
+  if (completedCount > 0) {
+    strengths.push(`completed_cross_swarms:${String(completedCount)}`);
+  }
+
+  return uniqueSorted(strengths);
+}
+
+function buildLimitations(input: {
+  link: MarketSynthesisLinkProjection;
+  completionState: MarketSynthesisCompletionState;
+  blockingReasons: string[];
+}): string[] {
+  const limitations = [...input.blockingReasons];
+
+  if (input.link.linkedCrossSwarms.some((entry) => entry.lifecycleState !== 'completed')) {
+    limitations.push('linked_cross_swarms_still_progressing');
+  }
+
+  if (input.completionState === 'inconclusive') {
+    limitations.push('completion_inconclusive');
+  }
+
+  return uniqueSorted(limitations);
+}
+
+export function createMarketSynthesisStatusProjection(options: {
+  registry?: MarketSynthesisRegistry;
+  linker?: MarketSynthesisLinker;
+  definitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createMarketSynthesisRegistry({
+    definitionsDir: options.definitionsDir ?? options.marketSynthesisDefinitionsDir
+  });
+
+  const linker = options.linker ?? createMarketSynthesisLinker({
+    registry,
+    definitionsDir: options.definitionsDir ?? options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    now: options.now
+  });
+
+  function projectOne(marketSynthesisId: string): MarketSynthesisStatusProjection {
+    const definition = registry.getDefinition(marketSynthesisId);
+    const link = linker.buildLinks().find((entry) => entry.marketSynthesisId === marketSynthesisId);
+    if (!link) {
+      throw new Error(`MARKET_SYNTHESIS_NOT_FOUND: ${marketSynthesisId}`);
+    }
+
+    const minCrossSwarms = definition.scopeConstraints?.minCrossSwarms ?? 1;
+    const { blockingReasons, contradictions, weakCoverage } = buildBlockingReasons({
+      link,
+      minCrossSwarms,
+    });
+
+    const lifecycleState = evaluateLifecycleState(link);
+    const readinessState = evaluateReadinessState({
+      link,
+      blockingReasons,
+      contradictions,
+    });
+
+    const completionState = evaluateCompletionState({
+      link,
+      readinessState,
+      weakCoverage,
+      contradictions,
+      blockingReasons,
+    });
+
+    const strengths = buildStrengths(link);
+    const limitations = buildLimitations({
+      link,
+      completionState,
+      blockingReasons,
+    });
+
+    return {
+      marketSynthesisId,
+      displayName: definition.displayName,
+      synthesisType: definition.synthesisType,
+      enabled: definition.enabled,
+      lifecycleState,
+      readinessState,
+      completionState,
+      linkedCrossSwarmIds: [...link.linkedCrossSwarmIds].sort((left, right) => left.localeCompare(right)),
+      linkedCrossSwarms: [...link.linkedCrossSwarms].sort((left, right) => left.crossSwarmId.localeCompare(right.crossSwarmId)),
+      blockingReasons,
+      strengths,
+      limitations,
+      rationale: [...link.rationale].sort((left, right) => left.localeCompare(right)),
+    };
+  }
+
+  function projectAll(): MarketSynthesisStatusProjection[] {
+    return registry
+      .listDefinitions()
+      .map((entry) => projectOne(entry.marketSynthesisId))
+      .sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+  }
+
+  return {
+    projectOne,
+    projectAll,
+  };
+}
+
+export type MarketSynthesisStatusProjectionEngine = ReturnType<typeof createMarketSynthesisStatusProjection>;

--- a/control-plane/market-synthesis/market-synthesis-types.ts
+++ b/control-plane/market-synthesis/market-synthesis-types.ts
@@ -1,0 +1,146 @@
+export const MARKET_SYNTHESIS_LIFECYCLE_STATES = [
+  'inactive',
+  'initializing',
+  'active',
+  'progressing',
+  'stabilizing',
+  'completed'
+] as const;
+
+export const MARKET_SYNTHESIS_READINESS_STATES = [
+  'pending',
+  'analyzing',
+  'coherent',
+  'blocked'
+] as const;
+
+export const MARKET_SYNTHESIS_COMPLETION_STATES = [
+  'completed',
+  'incomplete',
+  'inconclusive'
+] as const;
+
+export const MARKET_SYNTHESIS_HISTORY_EVENT_TYPES = [
+  'market_synthesis_initialized',
+  'cross_swarm_linked',
+  'readiness_changed',
+  'market_progressed',
+  'market_stabilized',
+  'market_completed',
+  'market_marked_inconclusive'
+] as const;
+
+export type MarketSynthesisLifecycleState = typeof MARKET_SYNTHESIS_LIFECYCLE_STATES[number];
+export type MarketSynthesisReadinessState = typeof MARKET_SYNTHESIS_READINESS_STATES[number];
+export type MarketSynthesisCompletionState = typeof MARKET_SYNTHESIS_COMPLETION_STATES[number];
+export type MarketSynthesisHistoryEventType = typeof MARKET_SYNTHESIS_HISTORY_EVENT_TYPES[number];
+
+export interface MarketSynthesisDefinition {
+  marketSynthesisId: string;
+  displayName: string;
+  synthesisType: string;
+  enabled: boolean;
+  crossSwarmMatchingRules: {
+    eventFamilies?: string[];
+    protocolFamilies?: string[];
+    assetFamilies?: string[];
+    responseFamilies?: string[];
+  };
+  scopeConstraints?: {
+    minCrossSwarms?: number;
+  };
+}
+
+export interface MarketSynthesisUnit {
+  marketSynthesisId: string;
+  displayName: string;
+  synthesisType: string;
+  enabled: boolean;
+  linkedCrossSwarmIds: string[];
+}
+
+export interface LinkedCrossSwarmSummary {
+  crossSwarmId: string;
+  displayName: string;
+  groupType: string;
+  lifecycleState: MarketSynthesisLifecycleState;
+  readinessState: MarketSynthesisReadinessState;
+  completionSatisfied: boolean;
+  unresolvedConflictCount: number;
+  blockers: string[];
+  conflicts: string[];
+  protocolFamilies: string[];
+  assetFamilies: string[];
+  eventFamilies: string[];
+  responseFamilies: string[];
+}
+
+export interface MarketSynthesisLinkProjection {
+  marketSynthesisId: string;
+  displayName: string;
+  synthesisType: string;
+  enabled: boolean;
+  linkedCrossSwarmIds: string[];
+  linkedCrossSwarms: LinkedCrossSwarmSummary[];
+  rationale: string[];
+}
+
+export interface MarketSynthesisStatus {
+  marketSynthesisId: string;
+  lifecycleState: MarketSynthesisLifecycleState;
+  readinessState: MarketSynthesisReadinessState;
+  completionState: MarketSynthesisCompletionState;
+  linkedCrossSwarmIds: string[];
+  blockingReasons: string[];
+  strengths: string[];
+  limitations: string[];
+}
+
+export interface MarketSynthesisStatusProjection extends MarketSynthesisStatus {
+  displayName: string;
+  synthesisType: string;
+  enabled: boolean;
+  rationale: string[];
+  linkedCrossSwarms: LinkedCrossSwarmSummary[];
+}
+
+export interface MarketSynthesisHistoryEntry {
+  marketSynthesisId: string;
+  eventType: MarketSynthesisHistoryEventType;
+  linkedCrossSwarmIds?: string[];
+  reason: string;
+  slotReference?: string;
+  eventDedupeKey: string;
+}
+
+export interface MarketSynthesisHistory {
+  marketSynthesisId: string;
+  entries: MarketSynthesisHistoryEntry[];
+}
+
+export interface MarketSynthesisProjection extends MarketSynthesisStatusProjection {
+  historySummary: {
+    totalEvents: number;
+    lastEventType?: MarketSynthesisHistoryEventType;
+    lastEventDedupeKey?: string;
+  };
+  artifactPaths: {
+    dirPath: string;
+    statusJsonPath: string;
+    historyJsonPath: string;
+    reportJsonPath: string;
+    reportMarkdownPath: string;
+  };
+  statusPreview: Record<string, unknown>;
+  reportPreview: Record<string, unknown>;
+}
+
+export class MarketSynthesisError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'MarketSynthesisError';
+    this.code = code;
+  }
+}

--- a/control-plane/market-synthesis/tests/market-synthesis.integration.test.ts
+++ b/control-plane/market-synthesis/tests/market-synthesis.integration.test.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createMarketInspection } from '../market-synthesis-inspection.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-market-synthesis-integration');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeRegistry(id: string) {
+  return {
+    listDefinitions: () => [{
+      marketSynthesisId: id,
+      displayName: 'Test Market Synthesis',
+      synthesisType: 'market_test',
+      enabled: true,
+      crossSwarmMatchingRules: {},
+      scopeConstraints: { minCrossSwarms: 1 }
+    }],
+    getDefinition: () => ({
+      marketSynthesisId: id,
+      displayName: 'Test Market Synthesis',
+      synthesisType: 'market_test',
+      enabled: true,
+      crossSwarmMatchingRules: {},
+      scopeConstraints: { minCrossSwarms: 1 }
+    })
+  } as any;
+}
+
+describe('market-synthesis integration', () => {
+  it('T-MS-I1 positive path groups cross-swarms and produces coherent completed status', () => {
+    const inspection = createMarketInspection({
+      marketSynthesisArtifactsRoot: path.join(tmpRoot, 'artifacts', 'market-synthesis'),
+      registry: makeRegistry('market-risk-synthesis'),
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk Synthesis',
+          synthesisType: 'market_risk',
+          enabled: true,
+          linkedCrossSwarmIds: ['a', 'b'],
+          linkedCrossSwarms: [{
+            crossSwarmId: 'a',
+            displayName: 'A',
+            groupType: 'market_shock_cluster',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionSatisfied: true,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: ['aave'],
+            assetFamilies: [],
+            eventFamilies: ['market'],
+            responseFamilies: ['market']
+          }, {
+            crossSwarmId: 'b',
+            displayName: 'B',
+            groupType: 'protocol_response_cluster',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionSatisfied: true,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: ['aave'],
+            assetFamilies: [],
+            eventFamilies: ['protocol'],
+            responseFamilies: ['protocol']
+          }],
+          rationale: ['a:shared_event_family:market', 'b:shared_response_family:protocol']
+        }]
+      } as any
+    });
+
+    const status = inspection.getMarketStatus('market-risk-synthesis');
+    expect(status.readinessState).toBe('coherent');
+    expect(status.completionState).toBe('completed');
+  });
+
+  it('T-MS-I2 conflict path blocks readiness', () => {
+    const inspection = createMarketInspection({
+      marketSynthesisArtifactsRoot: path.join(tmpRoot, 'artifacts', 'market-synthesis'),
+      registry: makeRegistry('governance-instability-market-synthesis'),
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'governance-instability-market-synthesis',
+          displayName: 'Governance Instability Market Synthesis',
+          synthesisType: 'governance_instability',
+          enabled: true,
+          linkedCrossSwarmIds: ['g-1'],
+          linkedCrossSwarms: [{
+            crossSwarmId: 'g-1',
+            displayName: 'G1',
+            groupType: 'governance_risk_cluster',
+            lifecycleState: 'stabilizing',
+            readinessState: 'blocked',
+            completionSatisfied: false,
+            unresolvedConflictCount: 3,
+            blockers: ['blocked_swarm:g-1'],
+            conflicts: ['swarm_conflicts:g-1:3'],
+            protocolFamilies: ['aave'],
+            assetFamilies: [],
+            eventFamilies: ['governance'],
+            responseFamilies: ['governance']
+          }],
+          rationale: ['g-1:shared_event_family:governance']
+        }]
+      } as any
+    });
+
+    const readiness = inspection.getMarketReadiness('governance-instability-market-synthesis');
+    expect(readiness.readinessState).toBe('blocked');
+  });
+
+  it('T-MS-I3 weak coverage path yields inconclusive completion', () => {
+    const inspection = createMarketInspection({
+      marketSynthesisArtifactsRoot: path.join(tmpRoot, 'artifacts', 'market-synthesis'),
+      registry: {
+        listDefinitions: () => [{
+          marketSynthesisId: 'yield-instability-market-synthesis',
+          displayName: 'Yield Instability',
+          synthesisType: 'yield_instability',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 2 }
+        }],
+        getDefinition: () => ({
+          marketSynthesisId: 'yield-instability-market-synthesis',
+          displayName: 'Yield Instability',
+          synthesisType: 'yield_instability',
+          enabled: true,
+          crossSwarmMatchingRules: {},
+          scopeConstraints: { minCrossSwarms: 2 }
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'yield-instability-market-synthesis',
+          displayName: 'Yield Instability Market Synthesis',
+          synthesisType: 'yield_instability',
+          enabled: true,
+          linkedCrossSwarmIds: ['y-1'],
+          linkedCrossSwarms: [{
+            crossSwarmId: 'y-1',
+            displayName: 'Y1',
+            groupType: 'market_shock_cluster',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionSatisfied: true,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: ['aave'],
+            assetFamilies: [],
+            eventFamilies: ['yield'],
+            responseFamilies: ['market']
+          }],
+          rationale: ['y-1:shared_event_family:yield']
+        }]
+      } as any
+    });
+
+    const status = inspection.getMarketStatus('yield-instability-market-synthesis');
+    expect(status.completionState).toBe('inconclusive');
+  });
+
+  it('T-MS-I4 regression path does not mutate lower-layer snapshot', () => {
+    const lowerLayerSnapshot = {
+      crossSwarmId: 'protocol-response-cluster',
+      lifecycle: 'progressing',
+      readiness: 'analyzing'
+    };
+    const before = JSON.stringify(lowerLayerSnapshot);
+
+    const inspection = createMarketInspection({
+      marketSynthesisArtifactsRoot: path.join(tmpRoot, 'artifacts', 'market-synthesis'),
+      registry: makeRegistry('market-risk-synthesis'),
+      linker: {
+        buildLinks: () => [{
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk Synthesis',
+          synthesisType: 'market_risk',
+          enabled: true,
+          linkedCrossSwarmIds: ['protocol-response-cluster'],
+          linkedCrossSwarms: [{
+            crossSwarmId: lowerLayerSnapshot.crossSwarmId,
+            displayName: 'Protocol Response',
+            groupType: 'protocol_response_cluster',
+            lifecycleState: 'progressing',
+            readinessState: 'analyzing',
+            completionSatisfied: false,
+            unresolvedConflictCount: 0,
+            blockers: [],
+            conflicts: [],
+            protocolFamilies: ['aave'],
+            assetFamilies: [],
+            eventFamilies: ['protocol'],
+            responseFamilies: ['protocol']
+          }],
+          rationale: ['protocol-response-cluster:shared_event_family:protocol']
+        }]
+      } as any
+    });
+
+    inspection.evaluateMarketSynthesis({ marketSynthesisId: 'market-risk-synthesis', slotReference: 'daily:2026-03-11' });
+    inspection.materializeMarketSynthesis('market-risk-synthesis');
+
+    expect(JSON.stringify(lowerLayerSnapshot)).toBe(before);
+  });
+});

--- a/docs/architecture/market-intelligence-synthesis.md
+++ b/docs/architecture/market-intelligence-synthesis.md
@@ -1,0 +1,104 @@
+# Market Intelligence Synthesis Layer
+
+## Scope
+
+Sprint 2.21 adds a bounded market-level intelligence synthesis layer above cross-swarm coordination.
+
+This layer is:
+- deterministic
+- projection-first
+- append-only for market synthesis history
+- CLI-inspectable
+- additive to existing lower layers
+
+This layer is not:
+- portfolio allocation
+- treasury/trading logic
+- orchestration planning
+- dashboards
+- Slack automation
+
+## Layer Position
+
+runtime
+-> scheduler
+-> persistent runtime
+-> signal bus
+-> trigger layer
+-> investigations
+-> synthesis
+-> cohorts
+-> monitoring programs
+-> automation
+-> escalation
+-> research teams
+-> team coordination
+-> research swarms
+-> team-swarm coordination
+-> cross-swarm coordination
+-> market intelligence synthesis
+
+## Definitions
+
+Definitions are stored in:
+- `control-plane/market-synthesis/definitions/*.json`
+
+Each definition provides:
+- `marketSynthesisId`
+- `displayName`
+- `synthesisType`
+- `enabled`
+- `crossSwarmMatchingRules` (event/protocol/asset/response families)
+- `scopeConstraints.minCrossSwarms` (optional)
+
+## Deterministic Linking
+
+Linking consumes cross-swarm inspection outputs and never mutates cross-swarms.
+
+A cross-swarm is linked only when configured rule families match and deterministic rationale is produced.
+Rationale is operator-visible and includes explicit values, for example:
+- `cross_swarm_id:shared_event_family:market`
+- `cross_swarm_id:shared_protocol_family:aave`
+- `cross_swarm_id:shared_response_family:market`
+- `cross_swarm_id:explicit_definition_match:market`
+
+## Readiness And Completion Model
+
+Readiness states:
+- `pending`
+- `analyzing`
+- `coherent`
+- `blocked`
+
+Completion states:
+- `completed`
+- `incomplete`
+- `inconclusive`
+
+Heuristics are conservative:
+- prefer `blocked` when explicit blockers/conflicts/contradictions exist
+- prefer `inconclusive` when coverage is weak or support is insufficient
+- do not infer certainty from partial signals
+
+## Projection vs Materialization
+
+Projection computes truth by:
+- loading market synthesis definitions
+- linking cross-swarm units deterministically
+- evaluating lifecycle/readiness/completion
+- composing status/report previews
+
+Materialization only persists the current projection outputs:
+- `market-synthesis-status.json`
+- `market-synthesis-history.json`
+- `market-synthesis-report.json`
+- `market-synthesis-report.md`
+
+Materialization does not change readiness or lifecycle states.
+
+## Persistence
+
+Artifacts are written under:
+- `artifacts/market-synthesis/<marketSynthesisId>/`
+
+History is append-only and deduped by deterministic fingerprinting over canonical event content (`canonicalStringify` + `sha256`).

--- a/docs/runbooks/market-intelligence-operations.md
+++ b/docs/runbooks/market-intelligence-operations.md
@@ -1,0 +1,87 @@
+# Market Intelligence Operations
+
+## Purpose
+
+This runbook covers deterministic operator inspection and artifact materialization for market intelligence synthesis units.
+
+## Commands
+
+List market synthesis units:
+
+```bash
+npm run market-synthesis:list
+```
+
+Inspect a market synthesis unit:
+
+```bash
+npm run market-synthesis:inspect -- --market <id>
+```
+
+Inspect status summary:
+
+```bash
+npm run market-synthesis:status -- --market <id>
+```
+
+Inspect linked cross-swarms and rationale:
+
+```bash
+npm run market-synthesis:links -- --market <id>
+```
+
+Inspect readiness/completion signals:
+
+```bash
+npm run market-synthesis:readiness -- --market <id>
+```
+
+Inspect append-only history:
+
+```bash
+npm run market-synthesis:history -- --market <id>
+```
+
+Materialize artifacts:
+
+```bash
+npm run market-synthesis:materialize -- --market <id>
+```
+
+## Interpreting Blockers
+
+Readiness:
+- `pending`: no linked cross-swarms or no meaningful progress
+- `analyzing`: linked cross-swarms are active but not yet coherent
+- `coherent`: linked cross-swarms are consistent and non-blocked
+- `blocked`: explicit blockers/conflicts/contradictions exist
+
+Completion:
+- `completed`: coherent and fully satisfied linked completion support
+- `incomplete`: still progressing with no explicit contradiction
+- `inconclusive`: weak coverage or conflicting support prevents reliable conclusion
+
+Always review:
+- `blockingReasons`
+- `limitations`
+- `rationale`
+
+## Artifact Layout
+
+Per market synthesis unit:
+- `artifacts/market-synthesis/<marketSynthesisId>/market-synthesis-status.json`
+- `artifacts/market-synthesis/<marketSynthesisId>/market-synthesis-history.json`
+- `artifacts/market-synthesis/<marketSynthesisId>/market-synthesis-report.json`
+- `artifacts/market-synthesis/<marketSynthesisId>/market-synthesis-report.md`
+
+## Boundary
+
+This runbook is scoped to bounded market intelligence synthesis only.
+
+Out of scope:
+- portfolio intelligence
+- capital allocation
+- treasury or trading logic
+- orchestration planning
+- dashboards
+- Slack automation

--- a/package.json
+++ b/package.json
@@ -157,7 +157,14 @@
     "cross-swarms:links": "node --experimental-strip-types control-plane/cli/cross-swarms-links.ts",
     "cross-swarms:readiness": "node --experimental-strip-types control-plane/cli/cross-swarms-readiness.ts",
     "cross-swarms:history": "node --experimental-strip-types control-plane/cli/cross-swarms-history.ts",
-    "cross-swarms:materialize": "node --experimental-strip-types control-plane/cli/cross-swarms-materialize.ts"
+    "cross-swarms:materialize": "node --experimental-strip-types control-plane/cli/cross-swarms-materialize.ts",
+    "market-synthesis:list": "node --experimental-strip-types control-plane/cli/market-synthesis-list.ts",
+    "market-synthesis:inspect": "node --experimental-strip-types control-plane/cli/market-synthesis-inspect.ts",
+    "market-synthesis:status": "node --experimental-strip-types control-plane/cli/market-synthesis-status.ts",
+    "market-synthesis:links": "node --experimental-strip-types control-plane/cli/market-synthesis-links.ts",
+    "market-synthesis:readiness": "node --experimental-strip-types control-plane/cli/market-synthesis-readiness.ts",
+    "market-synthesis:history": "node --experimental-strip-types control-plane/cli/market-synthesis-history.ts",
+    "market-synthesis:materialize": "node --experimental-strip-types control-plane/cli/market-synthesis-materialize.ts"
   },
   "devDependencies": {
     "typescript": "^5.6.3",


### PR DESCRIPTION
tier-3

## Summary
- add deterministic market-synthesis control-plane layer above cross-swarms
- add definition registry, linker, status evaluator, history store, projection, inspection, and materializer
- add CLI operator surfaces, tests, and documentation for market intelligence synthesis

## Testing
- npm run market-synthesis:list
- npm run market-synthesis:inspect -- --market market-risk-synthesis
- npm run market-synthesis:status -- --market market-risk-synthesis
- npm run market-synthesis:links -- --market market-risk-synthesis
- npm run market-synthesis:readiness -- --market market-risk-synthesis
- npm run market-synthesis:history -- --market market-risk-synthesis
- npm run market-synthesis:materialize -- --market market-risk-synthesis
- npx vitest --run control-plane/cross-swarms control-plane/market-synthesis control-plane/cli/market-synthesis-cli.test.ts

## Notes
- keeps scope bounded to market intelligence synthesis only
- preserves projection-first truth and additive behavior over lower layers
- verified cross-swarm inspection/status/links shape against live CLI output

```evidence
tier-3
branch: sprint-2.21
focus: Productization Phase 21 — Market Intelligence Synthesis Layer
validation:
  - npm run market-synthesis:list
  - npm run market-synthesis:inspect -- --market market-risk-synthesis
  - npm run market-synthesis:status -- --market market-risk-synthesis
  - npm run market-synthesis:links -- --market market-risk-synthesis
  - npm run market-synthesis:readiness -- --market market-risk-synthesis
  - npm run market-synthesis:history -- --market market-risk-synthesis
  - npm run market-synthesis:materialize -- --market market-risk-synthesis
  - npm run cross-swarms:inspect -- --cross-swarm protocol-response-cluster
  - npm run cross-swarms:status -- --cross-swarm protocol-response-cluster
  - npm run cross-swarms:links -- --cross-swarm protocol-response-cluster
  - npx vitest --run control-plane/cross-swarms control-plane/market-synthesis control-plane/cli/market-synthesis-cli.test.ts
results:
  - 12 test files passed
  - 40 tests passed
  - market-synthesis CLI surfaces returned canonical JSON
  - market materialization produced expected artifacts under artifacts/market-synthesis/market-risk-synthesis/
```
