### PR TITLE
Sprint 2.22 — Portfolio Intelligence Layer

### DIFF
--- a/control-plane/cli/portfolio-intelligence-cli.test.ts
+++ b/control-plane/cli/portfolio-intelligence-cli.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { main as historyMain } from './portfolio-intelligence-history.ts';
+import { main as inspectMain } from './portfolio-intelligence-inspect.ts';
+import { main as linksMain } from './portfolio-intelligence-links.ts';
+import { main as listMain } from './portfolio-intelligence-list.ts';
+import { main as materializeMain } from './portfolio-intelligence-materialize.ts';
+import { main as readinessMain } from './portfolio-intelligence-readiness.ts';
+import { main as riskMain } from './portfolio-intelligence-risk.ts';
+import { main as statusMain } from './portfolio-intelligence-status.ts';
+
+const {
+  listPortfolioIntelligenceUnits,
+  inspectPortfolioIntelligence,
+  getPortfolioStatus,
+  getPortfolioLinks,
+  getPortfolioReadiness,
+  getPortfolioRisk,
+  getPortfolioHistory,
+  materializePortfolioIntelligence
+} = vi.hoisted(() => ({
+  listPortfolioIntelligenceUnits: vi.fn(() => [{ portfolioId: 'defi-core-portfolio', displayName: 'DeFi Core Portfolio', portfolioType: 'defi', enabled: true }]),
+  inspectPortfolioIntelligence: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', lifecycleState: 'progressing' })),
+  getPortfolioStatus: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', lifecycleState: 'progressing', readinessState: 'analyzing', completionState: 'incomplete' })),
+  getPortfolioLinks: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', linkedMarketSynthesisIds: ['market-risk-synthesis'] })),
+  getPortfolioReadiness: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', readinessState: 'analyzing' })),
+  getPortfolioRisk: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', riskThemes: ['protocol_exposure_pressure'] })),
+  getPortfolioHistory: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', entries: [] })),
+  materializePortfolioIntelligence: vi.fn(() => ({ portfolioId: 'defi-core-portfolio', statusPath: 'a', reportPath: 'b', markdownPath: 'c', historyPath: 'd' }))
+}));
+
+vi.mock('../portfolio-intelligence/portfolio-inspection.ts', () => ({
+  createPortfolioInspection: vi.fn(() => ({
+    listPortfolioIntelligenceUnits,
+    inspectPortfolioIntelligence,
+    getPortfolioStatus,
+    getPortfolioLinks,
+    getPortfolioReadiness,
+    getPortfolioRisk,
+    getPortfolioHistory,
+    materializePortfolioIntelligence,
+  }))
+}));
+
+describe('portfolio-intelligence CLI commands', () => {
+  it('T-PI-CLI1 portfolio-intelligence:list prints deterministic output', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await listMain([]);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify(listPortfolioIntelligenceUnits())}\n`);
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI2 portfolio-intelligence:inspect requires --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await inspectMain([]);
+
+    expect(code).toBe(1);
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('MISSING_ARGUMENT: --portfolio');
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI3 portfolio-intelligence:status routes --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await statusMain(['--portfolio', 'defi-core-portfolio']);
+
+    expect(code).toBe(0);
+    expect(getPortfolioStatus).toHaveBeenCalledWith('defi-core-portfolio');
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI4 portfolio-intelligence:links routes --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await linksMain(['--portfolio=defi-core-portfolio']);
+
+    expect(code).toBe(0);
+    expect(getPortfolioLinks).toHaveBeenCalledWith('defi-core-portfolio');
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI5 portfolio-intelligence:readiness routes --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await readinessMain(['--portfolio', 'defi-core-portfolio']);
+
+    expect(code).toBe(0);
+    expect(getPortfolioReadiness).toHaveBeenCalledWith('defi-core-portfolio');
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI6 portfolio-intelligence:risk routes --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await riskMain(['--portfolio', 'defi-core-portfolio']);
+
+    expect(code).toBe(0);
+    expect(getPortfolioRisk).toHaveBeenCalledWith('defi-core-portfolio');
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI7 portfolio-intelligence:history routes --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await historyMain(['--portfolio', 'defi-core-portfolio']);
+
+    expect(code).toBe(0);
+    expect(getPortfolioHistory).toHaveBeenCalledWith('defi-core-portfolio');
+    stdout.mockRestore();
+  });
+
+  it('T-PI-CLI8 portfolio-intelligence:materialize routes --portfolio', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await materializeMain(['--portfolio', 'defi-core-portfolio']);
+
+    expect(code).toBe(0);
+    expect(materializePortfolioIntelligence).toHaveBeenCalledWith('defi-core-portfolio');
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify(materializePortfolioIntelligence())}\n`);
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/cli/portfolio-intelligence-history.ts
+++ b/control-plane/cli/portfolio-intelligence-history.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.getPortfolioHistory(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-inspect.ts
+++ b/control-plane/cli/portfolio-intelligence-inspect.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.inspectPortfolioIntelligence(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-links.ts
+++ b/control-plane/cli/portfolio-intelligence-links.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.getPortfolioLinks(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-list.ts
+++ b/control-plane/cli/portfolio-intelligence-list.ts
@@ -1,0 +1,34 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): Record<string, never> {
+  if (argv.length > 0) {
+    throw new Error(`UNKNOWN_ARGUMENT: ${argv[0]}`);
+  }
+  return {};
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.listPortfolioIntelligenceUnits());
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-materialize.ts
+++ b/control-plane/cli/portfolio-intelligence-materialize.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.materializePortfolioIntelligence(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-readiness.ts
+++ b/control-plane/cli/portfolio-intelligence-readiness.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.getPortfolioReadiness(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-risk.ts
+++ b/control-plane/cli/portfolio-intelligence-risk.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.getPortfolioRisk(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/portfolio-intelligence-status.ts
+++ b/control-plane/cli/portfolio-intelligence-status.ts
@@ -1,0 +1,56 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createPortfolioInspection } from '../portfolio-intelligence/portfolio-inspection.ts';
+
+function parseArgs(argv: string[]): { portfolioId: string } {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--portfolio') {
+      const portfolioId = argv[index + 1];
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (index !== argv.length - 2) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[index + 2]}`);
+      }
+      return { portfolioId };
+    }
+    if (arg.startsWith('--portfolio=')) {
+      const portfolioId = arg.slice('--portfolio='.length);
+      if (!portfolioId) {
+        throw new Error('MISSING_ARGUMENT: --portfolio');
+      }
+      if (argv.length > 1) {
+        throw new Error(`UNKNOWN_ARGUMENT: ${argv[1]}`);
+      }
+      return { portfolioId };
+    }
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  throw new Error('MISSING_ARGUMENT: --portfolio');
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createPortfolioInspection();
+    printJson(inspection.getPortfolioStatus(args.portfolioId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/portfolio-intelligence/definitions/defi-core-portfolio.json
+++ b/control-plane/portfolio-intelligence/definitions/defi-core-portfolio.json
@@ -1,0 +1,24 @@
+{
+  "portfolioId": "defi-core-portfolio",
+  "displayName": "DeFi Core Portfolio",
+  "portfolioType": "defi",
+  "enabled": true,
+  "matchingRules": {
+    "protocolFamilies": [
+      "aave",
+      "curve",
+      "uniswap"
+    ],
+    "assetFamilies": [
+      "eth",
+      "stablecoin"
+    ],
+    "eventFamilies": [
+      "market",
+      "protocol"
+    ]
+  },
+  "readinessRules": {
+    "requireAllLinkedSynthesesReady": true
+  }
+}

--- a/control-plane/portfolio-intelligence/definitions/governance-sensitive-portfolio.json
+++ b/control-plane/portfolio-intelligence/definitions/governance-sensitive-portfolio.json
@@ -1,0 +1,18 @@
+{
+  "portfolioId": "governance-sensitive-portfolio",
+  "displayName": "Governance Sensitive Portfolio",
+  "portfolioType": "governance",
+  "enabled": true,
+  "matchingRules": {
+    "eventFamilies": [
+      "governance"
+    ],
+    "synthesisTypes": [
+      "governance_instability",
+      "market_risk"
+    ]
+  },
+  "readinessRules": {
+    "requireAllLinkedSynthesesReady": true
+  }
+}

--- a/control-plane/portfolio-intelligence/definitions/liquidity-sensitive-portfolio.json
+++ b/control-plane/portfolio-intelligence/definitions/liquidity-sensitive-portfolio.json
@@ -1,0 +1,23 @@
+{
+  "portfolioId": "liquidity-sensitive-portfolio",
+  "displayName": "Liquidity Sensitive Portfolio",
+  "portfolioType": "liquidity",
+  "enabled": true,
+  "matchingRules": {
+    "eventFamilies": [
+      "liquidity",
+      "market"
+    ],
+    "assetFamilies": [
+      "stablecoin",
+      "eth"
+    ],
+    "synthesisTypes": [
+      "liquidity_stress",
+      "market_risk"
+    ]
+  },
+  "readinessRules": {
+    "requireAllLinkedSynthesesReady": false
+  }
+}

--- a/control-plane/portfolio-intelligence/definitions/yield-sensitive-portfolio.json
+++ b/control-plane/portfolio-intelligence/definitions/yield-sensitive-portfolio.json
@@ -1,0 +1,22 @@
+{
+  "portfolioId": "yield-sensitive-portfolio",
+  "displayName": "Yield Sensitive Portfolio",
+  "portfolioType": "yield",
+  "enabled": true,
+  "matchingRules": {
+    "eventFamilies": [
+      "yield"
+    ],
+    "synthesisTypes": [
+      "yield_instability",
+      "market_risk"
+    ],
+    "protocolFamilies": [
+      "aave",
+      "curve"
+    ]
+  },
+  "readinessRules": {
+    "requireAllLinkedSynthesesReady": true
+  }
+}

--- a/control-plane/portfolio-intelligence/portfolio-history-store.test.ts
+++ b/control-plane/portfolio-intelligence/portfolio-history-store.test.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  computePortfolioEventDedupeKey,
+  createPortfolioHistoryStore
+} from './portfolio-history-store.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-portfolio-intelligence-history');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('portfolio-intelligence history store', () => {
+  it('T-PI-H1 appends deterministic events and dedupes by fingerprint', () => {
+    const store = createPortfolioHistoryStore({
+      artifactsRoot: path.join(tmpRoot, 'artifacts', 'portfolio-intelligence')
+    });
+
+    const first = store.append({
+      portfolioId: 'defi-core-portfolio',
+      eventType: 'portfolio_initialized',
+      reason: 'portfolio_projection_generated',
+      linkedMarketSynthesisIds: ['b', 'a'],
+      slotReference: 'daily:2026-03-11'
+    });
+
+    const second = store.append({
+      portfolioId: 'defi-core-portfolio',
+      eventType: 'portfolio_initialized',
+      reason: 'portfolio_projection_generated',
+      linkedMarketSynthesisIds: ['a', 'b'],
+      slotReference: 'daily:2026-03-11'
+    });
+
+    expect(first.appended).toBe(true);
+    expect(second.appended).toBe(false);
+    expect(store.load('defi-core-portfolio').entries[0]?.linkedMarketSynthesisIds).toEqual(['a', 'b']);
+  });
+
+  it('T-PI-H2 keeps stable ordering', () => {
+    const store = createPortfolioHistoryStore({
+      artifactsRoot: path.join(tmpRoot, 'artifacts', 'portfolio-intelligence')
+    });
+
+    store.append({
+      portfolioId: 'defi-core-portfolio',
+      eventType: 'portfolio_completed',
+      reason: 'done',
+      linkedMarketSynthesisIds: ['a'],
+      slotReference: 'daily:2026-03-12'
+    });
+
+    store.append({
+      portfolioId: 'defi-core-portfolio',
+      eventType: 'readiness_changed',
+      reason: 'analyzing',
+      linkedMarketSynthesisIds: ['a'],
+      slotReference: 'daily:2026-03-11'
+    });
+
+    const loaded = store.load('defi-core-portfolio');
+    expect(loaded.entries.map((entry) => entry.slotReference)).toEqual(['daily:2026-03-12', 'daily:2026-03-11']);
+  });
+
+  it('T-PI-H3 dedupe fingerprint is deterministic', () => {
+    const input = {
+      portfolioId: 'defi-core-portfolio',
+      eventType: 'portfolio_progressed' as const,
+      reason: 'portfolio_lifecycle_progressing',
+      linkedMarketSynthesisIds: ['a'],
+      slotReference: 'daily:2026-03-11'
+    };
+
+    expect(computePortfolioEventDedupeKey(input)).toBe(computePortfolioEventDedupeKey(input));
+  });
+
+  it('T-PI-H4 appends readiness change event type', () => {
+    const store = createPortfolioHistoryStore({
+      artifactsRoot: path.join(tmpRoot, 'artifacts', 'portfolio-intelligence')
+    });
+
+    const result = store.append({
+      portfolioId: 'defi-core-portfolio',
+      eventType: 'readiness_changed',
+      reason: 'portfolio_readiness_analyzing',
+      linkedMarketSynthesisIds: ['m1']
+    });
+
+    expect(result.appended).toBe(true);
+    expect(result.entry.eventType).toBe('readiness_changed');
+  });
+});

--- a/control-plane/portfolio-intelligence/portfolio-history-store.ts
+++ b/control-plane/portfolio-intelligence/portfolio-history-store.ts
@@ -1,0 +1,239 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { canonicalStringify, sha256 } from '../finance/determinism.ts';
+
+import type {
+  PortfolioIntelligenceHistory,
+  PortfolioIntelligenceHistoryEntry,
+  PortfolioHistoryEventType,
+} from './portfolio-types.ts';
+
+export const DEFAULT_PORTFOLIO_ARTIFACTS_ROOT = path.join('artifacts', 'portfolio-intelligence');
+
+function normalizeRelativeSegment(value: string, fieldName: string): string {
+  const normalized = value.trim().replace(/\\/g, '/').replace(/^\/+/, '');
+  if (normalized.length === 0 || normalized.includes('..') || normalized.includes('/')) {
+    throw new Error(`INVALID_${fieldName.toUpperCase()}: ${value}`);
+  }
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    return [];
+  }
+  return [...value].sort((left, right) => left.localeCompare(right));
+}
+
+function compareEntries(left: PortfolioIntelligenceHistoryEntry, right: PortfolioIntelligenceHistoryEntry): number {
+  const leftSlot = left.slotReference ?? '';
+  const rightSlot = right.slotReference ?? '';
+  const slotCmp = rightSlot.localeCompare(leftSlot);
+  if (slotCmp !== 0) {
+    return slotCmp;
+  }
+  return left.eventDedupeKey.localeCompare(right.eventDedupeKey);
+}
+
+function parseEntry(value: unknown): PortfolioIntelligenceHistoryEntry {
+  if (!isRecord(value)) {
+    throw new Error('PORTFOLIO_INVALID_HISTORY_ENTRY');
+  }
+
+  const portfolioId = asString(value.portfolioId);
+  const eventType = asString(value.eventType) as PortfolioHistoryEventType;
+  const reason = asString(value.reason);
+  const eventDedupeKey = asString(value.eventDedupeKey);
+
+  if (!portfolioId || !eventType || !reason || !eventDedupeKey) {
+    throw new Error('PORTFOLIO_INVALID_HISTORY_ENTRY');
+  }
+
+  return {
+    portfolioId,
+    eventType,
+    reason,
+    eventDedupeKey,
+    linkedMarketSynthesisIds: asStringArray(value.linkedMarketSynthesisIds),
+    ...(asString(value.slotReference) ? { slotReference: asString(value.slotReference)! } : {})
+  };
+}
+
+function readHistoryFile(filePath: string, fallback: PortfolioIntelligenceHistory): PortfolioIntelligenceHistory {
+  if (!fs.existsSync(filePath)) {
+    return fallback;
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('PORTFOLIO_INVALID_HISTORY');
+  }
+
+  const portfolioId = asString(parsed.portfolioId);
+  if (!portfolioId) {
+    throw new Error('PORTFOLIO_INVALID_HISTORY');
+  }
+
+  const entries = Array.isArray(parsed.entries)
+    ? parsed.entries.map((entry) => parseEntry(entry)).sort(compareEntries)
+    : [];
+
+  return {
+    portfolioId,
+    entries,
+  };
+}
+
+export function resolvePortfolioArtifactsRoot(rootDir?: string): string {
+  return path.resolve(rootDir ?? DEFAULT_PORTFOLIO_ARTIFACTS_ROOT);
+}
+
+export function resolvePortfolioArtifactDir(input: { portfolioId: string; rootDir?: string }): string {
+  const portfolioId = normalizeRelativeSegment(input.portfolioId, 'portfolio_id');
+  return path.join(resolvePortfolioArtifactsRoot(input.rootDir), portfolioId);
+}
+
+export function ensurePortfolioArtifactDir(input: { portfolioId: string; rootDir?: string }): string {
+  const dirPath = resolvePortfolioArtifactDir(input);
+  fs.mkdirSync(dirPath, { recursive: true });
+  return dirPath;
+}
+
+export function resolvePortfolioArtifactPaths(input: { portfolioId: string; rootDir?: string }): {
+  dirPath: string;
+  statusJsonPath: string;
+  historyJsonPath: string;
+  reportJsonPath: string;
+  reportMarkdownPath: string;
+} {
+  const dirPath = resolvePortfolioArtifactDir(input);
+
+  return {
+    dirPath,
+    statusJsonPath: path.join(dirPath, 'portfolio-status.json'),
+    historyJsonPath: path.join(dirPath, 'portfolio-history.json'),
+    reportJsonPath: path.join(dirPath, 'portfolio-report.json'),
+    reportMarkdownPath: path.join(dirPath, 'portfolio-report.md'),
+  };
+}
+
+export function computePortfolioEventDedupeKey(input: {
+  portfolioId: string;
+  eventType: PortfolioHistoryEventType;
+  reason: string;
+  linkedMarketSynthesisIds?: string[];
+  slotReference?: string;
+}): string {
+  return sha256(canonicalStringify({
+    portfolioId: input.portfolioId,
+    eventType: input.eventType,
+    reason: input.reason,
+    linkedMarketSynthesisIds: [...(input.linkedMarketSynthesisIds ?? [])].sort((left, right) => left.localeCompare(right)),
+    slotReference: input.slotReference ?? '',
+  }));
+}
+
+export function createPortfolioHistoryStore(options: { artifactsRoot?: string } = {}) {
+  function load(portfolioId: string): PortfolioIntelligenceHistory {
+    const paths = resolvePortfolioArtifactPaths({
+      portfolioId,
+      rootDir: options.artifactsRoot,
+    });
+
+    return readHistoryFile(paths.historyJsonPath, {
+      portfolioId,
+      entries: [],
+    });
+  }
+
+  function append(input: {
+    portfolioId: string;
+    eventType: PortfolioHistoryEventType;
+    reason: string;
+    linkedMarketSynthesisIds?: string[];
+    slotReference?: string;
+  }): {
+    history: PortfolioIntelligenceHistory;
+    appended: boolean;
+    entry: PortfolioIntelligenceHistoryEntry;
+  } {
+    ensurePortfolioArtifactDir({
+      portfolioId: input.portfolioId,
+      rootDir: options.artifactsRoot,
+    });
+
+    const paths = resolvePortfolioArtifactPaths({
+      portfolioId: input.portfolioId,
+      rootDir: options.artifactsRoot,
+    });
+
+    const eventDedupeKey = computePortfolioEventDedupeKey(input);
+    const entry: PortfolioIntelligenceHistoryEntry = {
+      portfolioId: input.portfolioId,
+      eventType: input.eventType,
+      reason: input.reason,
+      eventDedupeKey,
+      linkedMarketSynthesisIds: [...(input.linkedMarketSynthesisIds ?? [])].sort((left, right) => left.localeCompare(right)),
+      ...(input.slotReference ? { slotReference: input.slotReference } : {})
+    };
+
+    const current = load(input.portfolioId);
+    if (current.entries.some((row) => row.eventDedupeKey === eventDedupeKey)) {
+      return {
+        history: current,
+        appended: false,
+        entry,
+      };
+    }
+
+    const next: PortfolioIntelligenceHistory = {
+      portfolioId: input.portfolioId,
+      entries: [...current.entries, entry].sort(compareEntries),
+    };
+
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(next)}\n`, 'utf8');
+
+    return {
+      history: next,
+      appended: true,
+      entry,
+    };
+  }
+
+  function write(history: PortfolioIntelligenceHistory): string {
+    ensurePortfolioArtifactDir({
+      portfolioId: history.portfolioId,
+      rootDir: options.artifactsRoot,
+    });
+
+    const paths = resolvePortfolioArtifactPaths({
+      portfolioId: history.portfolioId,
+      rootDir: options.artifactsRoot,
+    });
+
+    const normalized: PortfolioIntelligenceHistory = {
+      portfolioId: history.portfolioId,
+      entries: [...history.entries].sort(compareEntries)
+    };
+
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(normalized)}\n`, 'utf8');
+    return paths.historyJsonPath;
+  }
+
+  return {
+    load,
+    append,
+    write,
+  };
+}
+
+export type PortfolioHistoryStore = ReturnType<typeof createPortfolioHistoryStore>;

--- a/control-plane/portfolio-intelligence/portfolio-inspection.ts
+++ b/control-plane/portfolio-intelligence/portfolio-inspection.ts
@@ -1,0 +1,393 @@
+import {
+  createPortfolioHistoryStore,
+  type PortfolioHistoryStore,
+} from './portfolio-history-store.ts';
+import {
+  createPortfolioLinker,
+  type PortfolioLinker,
+} from './portfolio-linker.ts';
+import {
+  createPortfolioMaterializer,
+  type PortfolioMaterializer,
+} from './portfolio-materializer.ts';
+import {
+  createPortfolioProjection,
+  type PortfolioProjectionEngine,
+} from './portfolio-projection.ts';
+import {
+  createPortfolioRegistry,
+  type PortfolioRegistry,
+} from './portfolio-registry.ts';
+import {
+  createPortfolioRiskAggregator,
+  type PortfolioRiskAggregator,
+} from './portfolio-risk.ts';
+import {
+  createPortfolioStatusProjection,
+  type PortfolioStatusProjectionEngine,
+} from './portfolio-status.ts';
+
+function toReadinessReason(readinessState: string, blockers: string[]): string {
+  if (readinessState === 'blocked') {
+    return blockers.join('|') || 'portfolio_readiness_blocked';
+  }
+  if (readinessState === 'coherent') {
+    return 'portfolio_readiness_coherent';
+  }
+  if (readinessState === 'analyzing') {
+    return 'portfolio_readiness_analyzing';
+  }
+  return 'portfolio_readiness_pending';
+}
+
+function toLifecycleReason(lifecycleState: string): string {
+  if (lifecycleState === 'progressing') {
+    return 'portfolio_lifecycle_progressing';
+  }
+  if (lifecycleState === 'active') {
+    return 'portfolio_lifecycle_active';
+  }
+  if (lifecycleState === 'initializing') {
+    return 'portfolio_lifecycle_initializing';
+  }
+  return 'portfolio_initialized';
+}
+
+export function createPortfolioInspection(options: {
+  registry?: PortfolioRegistry;
+  linker?: PortfolioLinker;
+  statusProjection?: PortfolioStatusProjectionEngine;
+  riskAggregator?: PortfolioRiskAggregator;
+  projection?: PortfolioProjectionEngine;
+  materializer?: PortfolioMaterializer;
+  historyStore?: PortfolioHistoryStore;
+  definitionsDir?: string;
+  portfolioDefinitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  portfolioArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const definitionsDir = options.definitionsDir ?? options.portfolioDefinitionsDir;
+
+  const registry = options.registry ?? createPortfolioRegistry({ definitionsDir });
+
+  const linker = options.linker ?? createPortfolioLinker({
+    registry,
+    definitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  const statusProjection = options.statusProjection ?? createPortfolioStatusProjection({
+    registry,
+    linker,
+    definitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  const riskAggregator = options.riskAggregator ?? createPortfolioRiskAggregator({
+    registry,
+    linker,
+    definitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  const historyStore = options.historyStore ?? createPortfolioHistoryStore({
+    artifactsRoot: options.portfolioArtifactsRoot,
+  });
+
+  const projection = options.projection ?? createPortfolioProjection({
+    registry,
+    statusProjection,
+    riskAggregator,
+    historyStore,
+    definitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    portfolioArtifactsRoot: options.portfolioArtifactsRoot,
+    now: options.now,
+  });
+
+  const materializer = options.materializer ?? createPortfolioMaterializer({
+    projection,
+    portfolioArtifactsRoot: options.portfolioArtifactsRoot,
+    definitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  function listPortfolioIntelligenceUnits() {
+    return registry.listPortfolioDefinitions().map((entry) => ({
+      portfolioId: entry.portfolioId,
+      displayName: entry.displayName,
+      portfolioType: entry.portfolioType,
+      enabled: entry.enabled,
+    }));
+  }
+
+  function inspectPortfolioIntelligence(portfolioId: string) {
+    return projection.projectOne(portfolioId);
+  }
+
+  function getPortfolioStatus(portfolioId: string) {
+    const projected = inspectPortfolioIntelligence(portfolioId);
+    return {
+      portfolioId,
+      lifecycleState: projected.lifecycleState,
+      readinessState: projected.readinessState,
+      completionState: projected.completionState,
+      linkedMarketSynthesisIds: projected.linkedMarketSynthesisIds,
+      blockingReasons: projected.blockingReasons,
+      strengths: projected.strengths,
+      limitations: projected.limitations,
+      riskThemes: projected.riskThemes,
+      exposureFlags: projected.exposureFlags,
+      concentrationWarnings: projected.concentrationWarnings,
+    };
+  }
+
+  function getPortfolioLinks(portfolioId: string) {
+    const link = linker.buildLinks().find((entry) => entry.portfolioId === portfolioId);
+    if (!link) {
+      throw new Error(`PORTFOLIO_NOT_FOUND: ${portfolioId}`);
+    }
+
+    return {
+      portfolioId,
+      linkedMarketSynthesisIds: link.linkedMarketSynthesisIds,
+      linkedMarketSyntheses: link.linkedMarketSyntheses,
+      rationale: link.rationale,
+    };
+  }
+
+  function getPortfolioReadiness(portfolioId: string) {
+    const projected = inspectPortfolioIntelligence(portfolioId);
+    return {
+      portfolioId,
+      readinessState: projected.readinessState,
+      completionState: projected.completionState,
+      blockingReasons: projected.blockingReasons,
+      strengths: projected.strengths,
+      limitations: projected.limitations,
+    };
+  }
+
+  function getPortfolioRisk(portfolioId: string) {
+    registry.getPortfolioDefinition(portfolioId);
+    return riskAggregator.aggregateOne(portfolioId);
+  }
+
+  function getPortfolioHistory(portfolioId: string) {
+    registry.getPortfolioDefinition(portfolioId);
+    return historyStore.load(portfolioId);
+  }
+
+  function evaluatePortfolioIntelligence(input: { portfolioId: string; slotReference?: string }) {
+    const status = statusProjection.projectOne(input.portfolioId);
+
+    historyStore.append({
+      portfolioId: input.portfolioId,
+      eventType: 'portfolio_initialized',
+      reason: 'portfolio_projection_generated',
+      linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+      ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+    });
+
+    if (status.linkedMarketSynthesisIds.length > 0) {
+      historyStore.append({
+        portfolioId: input.portfolioId,
+        eventType: 'market_synthesis_linked',
+        reason: `linked_market_syntheses:${String(status.linkedMarketSynthesisIds.length)}`,
+        linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+      });
+    }
+
+    historyStore.append({
+      portfolioId: input.portfolioId,
+      eventType: 'readiness_changed',
+      reason: toReadinessReason(status.readinessState, status.blockingReasons),
+      linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+      ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+    });
+
+    if (status.lifecycleState === 'initializing' || status.lifecycleState === 'active' || status.lifecycleState === 'progressing') {
+      historyStore.append({
+        portfolioId: input.portfolioId,
+        eventType: 'portfolio_progressed',
+        reason: toLifecycleReason(status.lifecycleState),
+        linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+      });
+    }
+
+    if (status.lifecycleState === 'stabilizing') {
+      historyStore.append({
+        portfolioId: input.portfolioId,
+        eventType: 'portfolio_stabilized',
+        reason: status.blockingReasons.join('|') || 'portfolio_stabilizing',
+        linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+      });
+    }
+
+    if (status.completionState === 'completed') {
+      historyStore.append({
+        portfolioId: input.portfolioId,
+        eventType: 'portfolio_completed',
+        reason: 'portfolio_completion_requirements_satisfied',
+        linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+      });
+    }
+
+    if (status.completionState === 'inconclusive') {
+      historyStore.append({
+        portfolioId: input.portfolioId,
+        eventType: 'portfolio_marked_inconclusive',
+        reason: status.limitations.join('|') || 'portfolio_completion_inconclusive',
+        linkedMarketSynthesisIds: status.linkedMarketSynthesisIds,
+        ...(input.slotReference ? { slotReference: input.slotReference } : {}),
+      });
+    }
+
+    return {
+      projection: inspectPortfolioIntelligence(input.portfolioId),
+      history: historyStore.load(input.portfolioId),
+    };
+  }
+
+  function materializePortfolioIntelligence(portfolioId: string) {
+    const projected = inspectPortfolioIntelligence(portfolioId);
+    const materialized = materializer.materializeProjection({ projection: projected });
+    historyStore.write(historyStore.load(portfolioId));
+
+    return {
+      ...materialized,
+      historyPath: projected.artifactPaths.historyJsonPath,
+    };
+  }
+
+  return {
+    listPortfolioIntelligenceUnits,
+    inspectPortfolioIntelligence,
+    getPortfolioStatus,
+    getPortfolioLinks,
+    getPortfolioReadiness,
+    getPortfolioRisk,
+    getPortfolioHistory,
+    evaluatePortfolioIntelligence,
+    materializePortfolioIntelligence,
+  };
+}
+
+export type PortfolioInspection = ReturnType<typeof createPortfolioInspection>;

--- a/control-plane/portfolio-intelligence/portfolio-linker.test.ts
+++ b/control-plane/portfolio-intelligence/portfolio-linker.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPortfolioLinker } from './portfolio-linker.ts';
+
+describe('portfolio-intelligence linker', () => {
+  it('T-PI-L1 links syntheses with explicit and shared family rationale', () => {
+    const linker = createPortfolioLinker({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {
+            protocolFamilies: ['aave'],
+            eventFamilies: ['market']
+          }
+        }],
+        getPortfolioDefinition: () => { throw new Error('unused'); }
+      } as any,
+      marketInspection: {
+        listMarketSyntheses: () => [{ marketSynthesisId: 'market-risk-synthesis', displayName: 'Market Risk', synthesisType: 'market_risk', enabled: true }],
+        inspectMarketSynthesis: () => ({
+          marketSynthesisId: 'market-risk-synthesis',
+          displayName: 'Market Risk',
+          synthesisType: 'market_risk',
+          lifecycleState: 'progressing',
+          readinessState: 'analyzing',
+          completionState: 'incomplete',
+          linkedCrossSwarms: [{
+            protocolFamilies: ['aave'],
+            assetFamilies: ['eth'],
+            eventFamilies: ['market']
+          }],
+          blockingReasons: [],
+          limitations: [],
+          rationale: []
+        })
+      } as any
+    });
+
+    const links = linker.buildLinks();
+
+    expect(links[0]?.linkedMarketSynthesisIds).toEqual(['market-risk-synthesis']);
+    expect(links[0]?.rationale).toContain('market-risk-synthesis:shared_protocol_family:aave');
+    expect(links[0]?.rationale).toContain('market-risk-synthesis:shared_event_family:market');
+  });
+
+  it('T-PI-L2 excludes non-matching market syntheses', () => {
+    const linker = createPortfolioLinker({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'governance-sensitive-portfolio',
+          displayName: 'Governance',
+          portfolioType: 'governance',
+          enabled: true,
+          matchingRules: {
+            eventFamilies: ['governance']
+          }
+        }],
+        getPortfolioDefinition: () => { throw new Error('unused'); }
+      } as any,
+      marketInspection: {
+        listMarketSyntheses: () => [{ marketSynthesisId: 'liquidity-stress-market-synthesis', displayName: 'Liquidity', synthesisType: 'liquidity_stress', enabled: true }],
+        inspectMarketSynthesis: () => ({
+          marketSynthesisId: 'liquidity-stress-market-synthesis',
+          displayName: 'Liquidity',
+          synthesisType: 'liquidity_stress',
+          lifecycleState: 'active',
+          readinessState: 'analyzing',
+          completionState: 'incomplete',
+          linkedCrossSwarms: [{
+            protocolFamilies: ['curve'],
+            assetFamilies: ['stablecoin'],
+            eventFamilies: ['liquidity']
+          }],
+          blockingReasons: [],
+          limitations: [],
+          rationale: []
+        })
+      } as any
+    });
+
+    const links = linker.buildLinks();
+    expect(links[0]?.linkedMarketSynthesisIds).toEqual([]);
+  });
+
+  it('T-PI-L3 supports explicit synthesis type matching', () => {
+    const linker = createPortfolioLinker({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'yield-sensitive-portfolio',
+          displayName: 'Yield',
+          portfolioType: 'yield',
+          enabled: true,
+          matchingRules: {
+            synthesisTypes: ['yield_instability']
+          }
+        }],
+        getPortfolioDefinition: () => { throw new Error('unused'); }
+      } as any,
+      marketInspection: {
+        listMarketSyntheses: () => [{ marketSynthesisId: 'yield-instability-market-synthesis', displayName: 'Yield', synthesisType: 'yield_instability', enabled: true }],
+        inspectMarketSynthesis: () => ({
+          marketSynthesisId: 'yield-instability-market-synthesis',
+          displayName: 'Yield',
+          synthesisType: 'yield_instability',
+          lifecycleState: 'completed',
+          readinessState: 'coherent',
+          completionState: 'completed',
+          linkedCrossSwarms: [],
+          blockingReasons: [],
+          limitations: [],
+          rationale: []
+        })
+      } as any
+    });
+
+    const links = linker.buildLinks();
+    expect(links[0]?.linkedMarketSynthesisIds).toEqual(['yield-instability-market-synthesis']);
+    expect(links[0]?.rationale).toContain('yield-instability-market-synthesis:explicit_definition_match:yield_instability');
+  });
+});

--- a/control-plane/portfolio-intelligence/portfolio-linker.ts
+++ b/control-plane/portfolio-intelligence/portfolio-linker.ts
@@ -1,0 +1,284 @@
+import {
+  createMarketInspection,
+  type MarketInspection,
+} from '../market-synthesis/market-synthesis-inspection.ts';
+
+import {
+  createPortfolioRegistry,
+  type PortfolioRegistry,
+} from './portfolio-registry.ts';
+import type {
+  LinkedMarketSynthesisSummary,
+  PortfolioDefinition,
+  PortfolioLinkResult,
+} from './portfolio-types.ts';
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function familyFromDashOrUnderscore(value: string): string {
+  const normalized = normalizeToken(value);
+  return normalized.split(/[-_]/)[0] ?? normalized;
+}
+
+function intersects(left: string[], right: string[]): string[] {
+  const rightSet = new Set(right.map((entry) => normalizeToken(entry)));
+  return left
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => rightSet.has(entry))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function toLifecycle(value: string): LinkedMarketSynthesisSummary['lifecycleState'] {
+  if (value === 'inactive' || value === 'initializing' || value === 'active' || value === 'progressing' || value === 'stabilizing' || value === 'completed') {
+    return value;
+  }
+  return 'inactive';
+}
+
+function toReadiness(value: string): LinkedMarketSynthesisSummary['readinessState'] {
+  if (value === 'pending' || value === 'analyzing' || value === 'coherent' || value === 'blocked') {
+    return value;
+  }
+  return 'pending';
+}
+
+function toCompletion(value: string): LinkedMarketSynthesisSummary['completionState'] {
+  if (value === 'completed' || value === 'incomplete' || value === 'inconclusive') {
+    return value;
+  }
+  return 'incomplete';
+}
+
+type MarketContext = LinkedMarketSynthesisSummary;
+
+function buildMarketContexts(inspection: MarketInspection): MarketContext[] {
+  return inspection
+    .listMarketSyntheses()
+    .map((entry) => {
+      const projection = inspection.inspectMarketSynthesis(entry.marketSynthesisId);
+      const linkedCrossSwarms = Array.isArray(projection.linkedCrossSwarms)
+        ? projection.linkedCrossSwarms as Array<Record<string, unknown>>
+        : [];
+
+      const protocolFamilies = uniqueSorted(linkedCrossSwarms
+        .flatMap((linked) => (Array.isArray(linked.protocolFamilies) ? linked.protocolFamilies : []))
+        .map((value) => String(value).trim().toLowerCase())
+        .filter((value) => value.length > 0));
+
+      const assetFamilies = uniqueSorted(linkedCrossSwarms
+        .flatMap((linked) => (Array.isArray(linked.assetFamilies) ? linked.assetFamilies : []))
+        .map((value) => String(value).trim().toLowerCase())
+        .filter((value) => value.length > 0));
+
+      const eventFamilies = uniqueSorted(linkedCrossSwarms
+        .flatMap((linked) => (Array.isArray(linked.eventFamilies) ? linked.eventFamilies : []))
+        .map((value) => String(value).trim().toLowerCase())
+        .filter((value) => value.length > 0));
+
+      return {
+        marketSynthesisId: entry.marketSynthesisId,
+        displayName: entry.displayName,
+        synthesisType: entry.synthesisType,
+        lifecycleState: toLifecycle(String(projection.lifecycleState ?? 'inactive')),
+        readinessState: toReadiness(String(projection.readinessState ?? 'pending')),
+        completionState: toCompletion(String(projection.completionState ?? 'incomplete')),
+        blockingReasons: Array.isArray(projection.blockingReasons)
+          ? [...projection.blockingReasons as string[]].sort((left, right) => left.localeCompare(right))
+          : [],
+        limitations: Array.isArray(projection.limitations)
+          ? [...projection.limitations as string[]].sort((left, right) => left.localeCompare(right))
+          : [],
+        rationale: Array.isArray(projection.rationale)
+          ? [...projection.rationale as string[]].sort((left, right) => left.localeCompare(right))
+          : [],
+        protocolFamilies,
+        assetFamilies,
+        eventFamilies,
+      } satisfies LinkedMarketSynthesisSummary;
+    })
+    .sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+}
+
+function explicitDefinitionMatch(definition: PortfolioDefinition, context: MarketContext): string[] {
+  const portfolioFamilies = uniqueSorted([
+    familyFromDashOrUnderscore(definition.portfolioId),
+    familyFromDashOrUnderscore(definition.portfolioType),
+  ]);
+  const marketFamilies = uniqueSorted([
+    familyFromDashOrUnderscore(context.marketSynthesisId),
+    familyFromDashOrUnderscore(context.synthesisType),
+  ]);
+
+  return intersects(portfolioFamilies, marketFamilies);
+}
+
+function matchByRules(definition: PortfolioDefinition, context: MarketContext): {
+  matches: boolean;
+  rationale: string[];
+} {
+  const rationale: string[] = [];
+
+  const explicit = explicitDefinitionMatch(definition, context);
+  if (explicit.length > 0) {
+    rationale.push(...explicit.map((entry) => `explicit_definition_match:${entry}`));
+  }
+
+  const marketSynthesisIds = definition.matchingRules.marketSynthesisIds ?? [];
+  if (marketSynthesisIds.length > 0) {
+    const overlap = intersects([context.marketSynthesisId], marketSynthesisIds);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `explicit_definition_match:${entry}`));
+  }
+
+  const synthesisTypes = definition.matchingRules.synthesisTypes ?? [];
+  if (synthesisTypes.length > 0) {
+    const overlap = intersects([context.synthesisType], synthesisTypes);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `explicit_definition_match:${entry}`));
+  }
+
+  const protocolFamilies = definition.matchingRules.protocolFamilies ?? [];
+  if (protocolFamilies.length > 0) {
+    const overlap = intersects(context.protocolFamilies, protocolFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_protocol_family:${entry}`));
+  }
+
+  const assetFamilies = definition.matchingRules.assetFamilies ?? [];
+  if (assetFamilies.length > 0) {
+    const overlap = intersects(context.assetFamilies, assetFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_asset_family:${entry}`));
+  }
+
+  const eventFamilies = definition.matchingRules.eventFamilies ?? [];
+  if (eventFamilies.length > 0) {
+    const overlap = intersects(context.eventFamilies, eventFamilies);
+    if (overlap.length === 0) {
+      return { matches: false, rationale: [] };
+    }
+    rationale.push(...overlap.map((entry) => `shared_event_family:${entry}`));
+  }
+
+  if (rationale.length === 0) {
+    return { matches: false, rationale: [] };
+  }
+
+  return {
+    matches: true,
+    rationale: uniqueSorted(rationale),
+  };
+}
+
+export function createPortfolioLinker(options: {
+  registry?: PortfolioRegistry;
+  marketInspection?: MarketInspection;
+  definitionsDir?: string;
+  portfolioDefinitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createPortfolioRegistry({
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir
+  });
+
+  const marketInspection = options.marketInspection ?? createMarketInspection({
+    definitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  function buildLinks(): PortfolioLinkResult[] {
+    const contexts = buildMarketContexts(marketInspection);
+
+    return registry
+      .listPortfolioDefinitions()
+      .map((definition) => {
+        const linked = definition.enabled
+          ? contexts
+            .map((context) => {
+              const match = matchByRules(definition, context);
+              if (!match.matches) {
+                return null;
+              }
+              return {
+                context,
+                rationale: match.rationale.map((entry) => `${context.marketSynthesisId}:${entry}`)
+              };
+            })
+            .filter((entry): entry is { context: MarketContext; rationale: string[] } => entry !== null)
+          : [];
+
+        const linkedMarketSyntheses = linked
+          .map((entry) => entry.context)
+          .sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId));
+
+        const linkedMarketSynthesisIds = linkedMarketSyntheses
+          .map((entry) => entry.marketSynthesisId)
+          .sort((left, right) => left.localeCompare(right));
+
+        return {
+          portfolioId: definition.portfolioId,
+          linkedMarketSynthesisIds,
+          linkedMarketSyntheses,
+          rationale: uniqueSorted(linked.flatMap((entry) => entry.rationale)),
+        } satisfies PortfolioLinkResult;
+      })
+      .sort((left, right) => left.portfolioId.localeCompare(right.portfolioId));
+  }
+
+  return {
+    buildLinks,
+  };
+}
+
+export type PortfolioLinker = ReturnType<typeof createPortfolioLinker>;

--- a/control-plane/portfolio-intelligence/portfolio-materializer.ts
+++ b/control-plane/portfolio-intelligence/portfolio-materializer.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+
+import {
+  ensurePortfolioArtifactDir,
+  resolvePortfolioArtifactPaths,
+} from './portfolio-history-store.ts';
+import {
+  createPortfolioProjection,
+  type PortfolioProjectionEngine,
+} from './portfolio-projection.ts';
+import type { PortfolioIntelligenceProjection } from './portfolio-types.ts';
+
+function toMarkdownReport(reportPreview: Record<string, unknown>): string {
+  const lines = [
+    '# Portfolio Intelligence Report',
+    '',
+    `${canonicalStringify(reportPreview)}`
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+export interface MaterializedPortfolioIntelligence {
+  portfolioId: string;
+  statusPath: string;
+  reportPath: string;
+  markdownPath: string;
+}
+
+export function createPortfolioMaterializer(options: {
+  projection?: PortfolioProjectionEngine;
+  portfolioArtifactsRoot?: string;
+  definitionsDir?: string;
+  portfolioDefinitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const projection = options.projection ?? createPortfolioProjection({
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    portfolioArtifactsRoot: options.portfolioArtifactsRoot,
+    now: options.now,
+  });
+
+  function materializeProjection(input: { projection: PortfolioIntelligenceProjection }): MaterializedPortfolioIntelligence {
+    ensurePortfolioArtifactDir({
+      portfolioId: input.projection.portfolioId,
+      rootDir: options.portfolioArtifactsRoot,
+    });
+
+    const paths = resolvePortfolioArtifactPaths({
+      portfolioId: input.projection.portfolioId,
+      rootDir: options.portfolioArtifactsRoot,
+    });
+
+    fs.writeFileSync(paths.statusJsonPath, `${canonicalStringify(input.projection.statusPreview)}\n`, 'utf8');
+    fs.writeFileSync(paths.reportJsonPath, `${canonicalStringify(input.projection.reportPreview)}\n`, 'utf8');
+    fs.writeFileSync(paths.reportMarkdownPath, toMarkdownReport(input.projection.reportPreview), 'utf8');
+
+    return {
+      portfolioId: input.projection.portfolioId,
+      statusPath: paths.statusJsonPath,
+      reportPath: paths.reportJsonPath,
+      markdownPath: paths.reportMarkdownPath,
+    };
+  }
+
+  function materializeOne(portfolioId: string): MaterializedPortfolioIntelligence {
+    const projected = projection.projectOne(portfolioId);
+    return materializeProjection({ projection: projected });
+  }
+
+  return {
+    materializeProjection,
+    materializeOne,
+  };
+}
+
+export type PortfolioMaterializer = ReturnType<typeof createPortfolioMaterializer>;

--- a/control-plane/portfolio-intelligence/portfolio-projection.ts
+++ b/control-plane/portfolio-intelligence/portfolio-projection.ts
@@ -1,0 +1,192 @@
+import {
+  createPortfolioHistoryStore,
+  resolvePortfolioArtifactPaths,
+  type PortfolioHistoryStore,
+} from './portfolio-history-store.ts';
+import {
+  createPortfolioRegistry,
+  type PortfolioRegistry,
+} from './portfolio-registry.ts';
+import {
+  createPortfolioRiskAggregator,
+  type PortfolioRiskAggregator,
+} from './portfolio-risk.ts';
+import {
+  createPortfolioStatusProjection,
+  type PortfolioStatusProjectionEngine,
+} from './portfolio-status.ts';
+import type {
+  PortfolioIntelligenceProjection,
+  PortfolioIntelligenceStatusProjection,
+} from './portfolio-types.ts';
+
+function toProjection(input: {
+  status: PortfolioIntelligenceStatusProjection;
+  historyStore: PortfolioHistoryStore;
+  riskAggregator: PortfolioRiskAggregator;
+  artifactsRoot?: string;
+}): PortfolioIntelligenceProjection {
+  const history = input.historyStore.load(input.status.portfolioId);
+  const risk = input.riskAggregator.aggregateOne(input.status.portfolioId);
+
+  const statusWithRisk: PortfolioIntelligenceStatusProjection = {
+    ...input.status,
+    riskThemes: risk.riskThemes,
+    exposureFlags: risk.exposureFlags,
+    concentrationWarnings: risk.concentrationWarnings,
+  };
+
+  const artifactPaths = resolvePortfolioArtifactPaths({
+    portfolioId: input.status.portfolioId,
+    rootDir: input.artifactsRoot
+  });
+
+  const statusPreview = {
+    portfolioId: statusWithRisk.portfolioId,
+    lifecycleState: statusWithRisk.lifecycleState,
+    readinessState: statusWithRisk.readinessState,
+    completionState: statusWithRisk.completionState,
+    linkedMarketSynthesisIds: statusWithRisk.linkedMarketSynthesisIds,
+    blockingReasons: statusWithRisk.blockingReasons,
+    strengths: statusWithRisk.strengths,
+    limitations: statusWithRisk.limitations,
+    riskThemes: statusWithRisk.riskThemes,
+    exposureFlags: statusWithRisk.exposureFlags,
+    concentrationWarnings: statusWithRisk.concentrationWarnings,
+  } as Record<string, unknown>;
+
+  const reportPreview = {
+    ...statusWithRisk,
+    history,
+  } as Record<string, unknown>;
+
+  return {
+    ...statusWithRisk,
+    displayName: input.status.displayName,
+    portfolioType: input.status.portfolioType,
+    enabled: input.status.enabled,
+    rationale: input.status.rationale,
+    linkedMarketSyntheses: input.status.linkedMarketSyntheses,
+    historySummary: {
+      totalEvents: history.entries.length,
+      ...(history.entries[0] ? { lastEventType: history.entries[0].eventType } : {}),
+      ...(history.entries[0] ? { lastEventDedupeKey: history.entries[0].eventDedupeKey } : {}),
+    },
+    artifactPaths,
+    statusPreview,
+    reportPreview,
+  };
+}
+
+export function createPortfolioProjection(options: {
+  registry?: PortfolioRegistry;
+  statusProjection?: PortfolioStatusProjectionEngine;
+  historyStore?: PortfolioHistoryStore;
+  riskAggregator?: PortfolioRiskAggregator;
+  definitionsDir?: string;
+  portfolioDefinitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  portfolioArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createPortfolioRegistry({
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir
+  });
+
+  const statusProjection = options.statusProjection ?? createPortfolioStatusProjection({
+    registry,
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  const historyStore = options.historyStore ?? createPortfolioHistoryStore({
+    artifactsRoot: options.portfolioArtifactsRoot,
+  });
+
+  const riskAggregator = options.riskAggregator ?? createPortfolioRiskAggregator({
+    registry,
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now,
+  });
+
+  function projectOne(portfolioId: string): PortfolioIntelligenceProjection {
+    registry.getPortfolioDefinition(portfolioId);
+    const status = statusProjection.projectOne(portfolioId);
+    return toProjection({
+      status,
+      historyStore,
+      riskAggregator,
+      artifactsRoot: options.portfolioArtifactsRoot,
+    });
+  }
+
+  function projectAll(): PortfolioIntelligenceProjection[] {
+    return registry
+      .listPortfolioDefinitions()
+      .map((entry) => projectOne(entry.portfolioId))
+      .sort((left, right) => left.portfolioId.localeCompare(right.portfolioId));
+  }
+
+  return {
+    projectOne,
+    projectAll,
+  };
+}
+
+export type PortfolioProjectionEngine = ReturnType<typeof createPortfolioProjection>;

--- a/control-plane/portfolio-intelligence/portfolio-registry.test.ts
+++ b/control-plane/portfolio-intelligence/portfolio-registry.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createPortfolioRegistry,
+  loadPortfolioDefinitions,
+} from './portfolio-registry.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-portfolio-intelligence-definitions');
+
+function writeJson(fileName: string, value: unknown): void {
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('portfolio-intelligence registry', () => {
+  it('T-PI-R1 loads valid definitions in deterministic order', () => {
+    writeJson('zeta.json', {
+      portfolioId: 'zeta',
+      displayName: 'Zeta',
+      portfolioType: 'zeta_type',
+      enabled: true,
+      matchingRules: {
+        eventFamilies: ['market']
+      },
+      readinessRules: {
+        requireAllLinkedSynthesesReady: true
+      }
+    });
+    writeJson('alpha.json', {
+      portfolioId: 'alpha',
+      displayName: 'Alpha',
+      portfolioType: 'alpha_type',
+      enabled: true,
+      matchingRules: {
+        protocolFamilies: ['aave']
+      }
+    });
+
+    const loaded = loadPortfolioDefinitions({ definitionsDir: tmpRoot });
+    expect(loaded.map((entry) => entry.portfolioId)).toEqual(['alpha', 'zeta']);
+  });
+
+  it('T-PI-R2 rejects invalid schema', () => {
+    writeJson('invalid.json', {
+      portfolioId: 'bad',
+      displayName: 'Bad',
+      portfolioType: 'bad_type',
+      enabled: true,
+      matchingRules: {
+        eventFamilies: [123]
+      }
+    });
+
+    expect(() => loadPortfolioDefinitions({ definitionsDir: tmpRoot })).toThrow(/matchingRules.eventFamilies/);
+  });
+
+  it('T-PI-R3 rejects duplicate portfolio ids', () => {
+    const payload = {
+      portfolioId: 'dup',
+      displayName: 'Dup',
+      portfolioType: 'dup_type',
+      enabled: true,
+      matchingRules: {
+        eventFamilies: ['market']
+      }
+    };
+
+    writeJson('a.json', payload);
+    writeJson('b.json', payload);
+
+    expect(() => createPortfolioRegistry({ definitionsDir: tmpRoot })).toThrow(/Duplicate portfolioId detected/);
+  });
+});

--- a/control-plane/portfolio-intelligence/portfolio-registry.ts
+++ b/control-plane/portfolio-intelligence/portfolio-registry.ts
@@ -1,0 +1,219 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  PortfolioIntelligenceError,
+  type PortfolioDefinition,
+} from './portfolio-types.ts';
+
+export const DEFAULT_PORTFOLIO_DEFINITIONS_DIR = 'control-plane/portfolio-intelligence/definitions';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asTrimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function asUniqueStringArray(value: unknown, sourceLabel: string, fieldName: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} ${fieldName} must be an array of non-empty strings.`
+    );
+  }
+
+  const normalized = value.map((entry) => asTrimmedString(entry));
+  if (normalized.some((entry) => !entry)) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} ${fieldName} must be an array of non-empty strings.`
+    );
+  }
+
+  return Array.from(new Set(normalized as string[])).sort((left, right) => left.localeCompare(right));
+}
+
+function validateMatchingRules(
+  value: unknown,
+  sourceLabel: string,
+): PortfolioDefinition['matchingRules'] {
+  if (!isRecord(value)) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} matchingRules must be an object.`
+    );
+  }
+
+  const protocolFamilies = value.protocolFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.protocolFamilies, sourceLabel, 'matchingRules.protocolFamilies');
+
+  const assetFamilies = value.assetFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.assetFamilies, sourceLabel, 'matchingRules.assetFamilies');
+
+  const eventFamilies = value.eventFamilies === undefined
+    ? undefined
+    : asUniqueStringArray(value.eventFamilies, sourceLabel, 'matchingRules.eventFamilies');
+
+  const synthesisTypes = value.synthesisTypes === undefined
+    ? undefined
+    : asUniqueStringArray(value.synthesisTypes, sourceLabel, 'matchingRules.synthesisTypes');
+
+  const marketSynthesisIds = value.marketSynthesisIds === undefined
+    ? undefined
+    : asUniqueStringArray(value.marketSynthesisIds, sourceLabel, 'matchingRules.marketSynthesisIds');
+
+  return {
+    ...(protocolFamilies ? { protocolFamilies } : {}),
+    ...(assetFamilies ? { assetFamilies } : {}),
+    ...(eventFamilies ? { eventFamilies } : {}),
+    ...(synthesisTypes ? { synthesisTypes } : {}),
+    ...(marketSynthesisIds ? { marketSynthesisIds } : {})
+  };
+}
+
+function validateReadinessRules(
+  value: unknown,
+  sourceLabel: string,
+): PortfolioDefinition['readinessRules'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} readinessRules must be an object.`
+    );
+  }
+
+  if (value.requireAllLinkedSynthesesReady === undefined) {
+    return undefined;
+  }
+
+  if (typeof value.requireAllLinkedSynthesesReady !== 'boolean') {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} readinessRules.requireAllLinkedSynthesesReady must be a boolean.`
+    );
+  }
+
+  return {
+    requireAllLinkedSynthesesReady: value.requireAllLinkedSynthesesReady
+  };
+}
+
+export function validatePortfolioDefinition(value: unknown, sourceLabel = '<inline>'): PortfolioDefinition {
+  if (!isRecord(value)) {
+    throw new PortfolioIntelligenceError('PORTFOLIO_INVALID_DEFINITION', `Portfolio definition ${sourceLabel} must be an object.`);
+  }
+
+  const portfolioId = asTrimmedString(value.portfolioId);
+  const displayName = asTrimmedString(value.displayName);
+  const portfolioType = asTrimmedString(value.portfolioType);
+  const enabled = asBoolean(value.enabled);
+  const matchingRules = validateMatchingRules(value.matchingRules, sourceLabel);
+  const readinessRules = validateReadinessRules(value.readinessRules, sourceLabel);
+
+  if (!portfolioId) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} portfolioId must be a non-empty string.`
+    );
+  }
+  if (!displayName) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} displayName must be a non-empty string.`
+    );
+  }
+  if (!portfolioType) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} portfolioType must be a non-empty string.`
+    );
+  }
+  if (enabled === null) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_INVALID_DEFINITION',
+      `Portfolio definition ${sourceLabel} enabled must be a boolean.`
+    );
+  }
+
+  return {
+    portfolioId,
+    displayName,
+    portfolioType,
+    enabled,
+    matchingRules,
+    ...(readinessRules ? { readinessRules } : {})
+  };
+}
+
+export function loadPortfolioDefinitions(options: { definitionsDir?: string } = {}): PortfolioDefinition[] {
+  const definitionsDir = path.resolve(options.definitionsDir ?? DEFAULT_PORTFOLIO_DEFINITIONS_DIR);
+  if (!fs.existsSync(definitionsDir)) {
+    throw new PortfolioIntelligenceError(
+      'PORTFOLIO_DEFINITIONS_NOT_FOUND',
+      `Portfolio definitions directory not found: ${definitionsDir}`
+    );
+  }
+
+  const files = fs.readdirSync(definitionsDir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort((left, right) => left.localeCompare(right));
+
+  return files
+    .map((entry) => {
+      const filePath = path.join(definitionsDir, entry);
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+      return validatePortfolioDefinition(parsed, entry);
+    })
+    .sort((left, right) => left.portfolioId.localeCompare(right.portfolioId));
+}
+
+export function createPortfolioRegistry(options: { definitionsDir?: string } = {}) {
+  const definitions = loadPortfolioDefinitions({ definitionsDir: options.definitionsDir });
+  const byId = new Map<string, PortfolioDefinition>();
+
+  for (const definition of definitions) {
+    if (byId.has(definition.portfolioId)) {
+      throw new PortfolioIntelligenceError(
+        'PORTFOLIO_DUPLICATE_DEFINITION',
+        `Duplicate portfolioId detected: ${definition.portfolioId}`
+      );
+    }
+    byId.set(definition.portfolioId, definition);
+  }
+
+  function listPortfolioDefinitions(): PortfolioDefinition[] {
+    return Array.from(byId.values()).sort((left, right) => left.portfolioId.localeCompare(right.portfolioId));
+  }
+
+  function getPortfolioDefinition(portfolioId: string): PortfolioDefinition {
+    const found = byId.get(portfolioId);
+    if (!found) {
+      throw new PortfolioIntelligenceError('PORTFOLIO_NOT_FOUND', `Portfolio definition not found: ${portfolioId}`);
+    }
+    return found;
+  }
+
+  return {
+    listPortfolioDefinitions,
+    getPortfolioDefinition,
+    listDefinitions: listPortfolioDefinitions,
+    getDefinition: getPortfolioDefinition,
+  };
+}
+
+export type PortfolioRegistry = ReturnType<typeof createPortfolioRegistry>;

--- a/control-plane/portfolio-intelligence/portfolio-risk.test.ts
+++ b/control-plane/portfolio-intelligence/portfolio-risk.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPortfolioRiskAggregator } from './portfolio-risk.ts';
+
+describe('portfolio-intelligence risk aggregator', () => {
+  it('T-PI-K1 aggregates deterministic themes and flags', () => {
+    const aggregator = createPortfolioRiskAggregator({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {}
+        }],
+        getPortfolioDefinition: () => ({
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {}
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          portfolioId: 'defi-core-portfolio',
+          linkedMarketSynthesisIds: ['m1', 'm2'],
+          rationale: [],
+          linkedMarketSyntheses: [{
+            marketSynthesisId: 'm1',
+            displayName: 'M1',
+            synthesisType: 'governance_instability',
+            lifecycleState: 'stabilizing',
+            readinessState: 'blocked',
+            completionState: 'inconclusive',
+            blockingReasons: ['governance_blocker'],
+            limitations: ['governance_limit'],
+            rationale: ['shared_event_family:governance'],
+            protocolFamilies: ['aave'],
+            assetFamilies: ['eth'],
+            eventFamilies: ['governance']
+          }, {
+            marketSynthesisId: 'm2',
+            displayName: 'M2',
+            synthesisType: 'liquidity_stress',
+            lifecycleState: 'progressing',
+            readinessState: 'analyzing',
+            completionState: 'incomplete',
+            blockingReasons: [],
+            limitations: ['yield_instability_signal'],
+            rationale: ['shared_event_family:liquidity'],
+            protocolFamilies: ['aave'],
+            assetFamilies: ['stablecoin'],
+            eventFamilies: ['liquidity', 'yield']
+          }]
+        }]
+      } as any
+    });
+
+    const risk = aggregator.aggregateOne('defi-core-portfolio');
+
+    expect(risk.riskThemes).toEqual([
+      'governance_risk_rising',
+      'liquidity_stress',
+      'protocol_exposure_pressure',
+      'yield_instability'
+    ]);
+    expect(risk.exposureFlags).toContain('blocked_market_synthesis:m1');
+    expect(risk.exposureFlags).toContain('protocol_exposure:aave');
+    expect(risk.concentrationWarnings).toContain('protocol_concentration:aave:2');
+  });
+});

--- a/control-plane/portfolio-intelligence/portfolio-risk.ts
+++ b/control-plane/portfolio-intelligence/portfolio-risk.ts
@@ -1,0 +1,201 @@
+import {
+  createPortfolioLinker,
+  type PortfolioLinker,
+} from './portfolio-linker.ts';
+import {
+  createPortfolioRegistry,
+  type PortfolioRegistry,
+} from './portfolio-registry.ts';
+import type { LinkedMarketSynthesisSummary, PortfolioRiskSurface } from './portfolio-types.ts';
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function hasToken(values: string[], token: string): boolean {
+  const normalizedToken = normalizeToken(token);
+  return values.some((value) => normalizeToken(value).includes(normalizedToken));
+}
+
+function flattenSignals(linked: LinkedMarketSynthesisSummary): string[] {
+  return uniqueSorted([
+    linked.marketSynthesisId,
+    linked.synthesisType,
+    ...linked.eventFamilies,
+    ...linked.protocolFamilies,
+    ...linked.assetFamilies,
+    ...linked.blockingReasons,
+    ...linked.limitations,
+    ...linked.rationale,
+  ]);
+}
+
+function buildRiskThemes(linkedSyntheses: LinkedMarketSynthesisSummary[]): string[] {
+  const themes: string[] = [];
+
+  for (const linked of linkedSyntheses) {
+    const signals = flattenSignals(linked);
+    if (hasToken(signals, 'governance')) {
+      themes.push('governance_risk_rising');
+    }
+    if (hasToken(signals, 'liquidity')) {
+      themes.push('liquidity_stress');
+    }
+    if (hasToken(signals, 'yield')) {
+      themes.push('yield_instability');
+    }
+    if (linked.protocolFamilies.length > 0) {
+      themes.push('protocol_exposure_pressure');
+    }
+  }
+
+  return uniqueSorted(themes);
+}
+
+function buildExposureFlags(linkedSyntheses: LinkedMarketSynthesisSummary[]): string[] {
+  const flags: string[] = [];
+
+  for (const linked of linkedSyntheses) {
+    if (linked.readinessState === 'blocked') {
+      flags.push(`blocked_market_synthesis:${linked.marketSynthesisId}`);
+    }
+    if (linked.completionState === 'inconclusive') {
+      flags.push(`inconclusive_market_synthesis:${linked.marketSynthesisId}`);
+    }
+
+    for (const protocolFamily of linked.protocolFamilies) {
+      flags.push(`protocol_exposure:${protocolFamily}`);
+    }
+    for (const assetFamily of linked.assetFamilies) {
+      flags.push(`asset_exposure:${assetFamily}`);
+    }
+    for (const eventFamily of linked.eventFamilies) {
+      flags.push(`event_exposure:${eventFamily}`);
+    }
+  }
+
+  return uniqueSorted(flags);
+}
+
+function buildConcentrationWarnings(linkedSyntheses: LinkedMarketSynthesisSummary[]): string[] {
+  const warnings: string[] = [];
+
+  if (linkedSyntheses.length === 1) {
+    warnings.push('single_synthesis_dependency');
+  }
+
+  const protocolCounts = new Map<string, number>();
+  const eventCounts = new Map<string, number>();
+
+  for (const linked of linkedSyntheses) {
+    for (const protocolFamily of uniqueSorted(linked.protocolFamilies)) {
+      protocolCounts.set(protocolFamily, (protocolCounts.get(protocolFamily) ?? 0) + 1);
+    }
+    for (const eventFamily of uniqueSorted(linked.eventFamilies)) {
+      eventCounts.set(eventFamily, (eventCounts.get(eventFamily) ?? 0) + 1);
+    }
+  }
+
+  for (const [protocolFamily, count] of Array.from(protocolCounts.entries()).sort((left, right) => left[0].localeCompare(right[0]))) {
+    if (count > 1) {
+      warnings.push(`protocol_concentration:${protocolFamily}:${String(count)}`);
+    }
+  }
+
+  for (const [eventFamily, count] of Array.from(eventCounts.entries()).sort((left, right) => left[0].localeCompare(right[0]))) {
+    if (count > 1) {
+      warnings.push(`event_concentration:${eventFamily}:${String(count)}`);
+    }
+  }
+
+  return uniqueSorted(warnings);
+}
+
+export function createPortfolioRiskAggregator(options: {
+  registry?: PortfolioRegistry;
+  linker?: PortfolioLinker;
+  definitionsDir?: string;
+  portfolioDefinitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createPortfolioRegistry({
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir
+  });
+
+  const linker = options.linker ?? createPortfolioLinker({
+    registry,
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now
+  });
+
+  function aggregateOne(portfolioId: string): PortfolioRiskSurface {
+    registry.getPortfolioDefinition(portfolioId);
+    const link = linker.buildLinks().find((entry) => entry.portfolioId === portfolioId);
+    if (!link) {
+      throw new Error(`PORTFOLIO_NOT_FOUND: ${portfolioId}`);
+    }
+
+    return {
+      portfolioId,
+      riskThemes: buildRiskThemes(link.linkedMarketSyntheses),
+      exposureFlags: buildExposureFlags(link.linkedMarketSyntheses),
+      concentrationWarnings: buildConcentrationWarnings(link.linkedMarketSyntheses),
+    };
+  }
+
+  function aggregateAll(): PortfolioRiskSurface[] {
+    return registry
+      .listPortfolioDefinitions()
+      .map((entry) => aggregateOne(entry.portfolioId))
+      .sort((left, right) => left.portfolioId.localeCompare(right.portfolioId));
+  }
+
+  return {
+    aggregateOne,
+    aggregateAll,
+  };
+}
+
+export type PortfolioRiskAggregator = ReturnType<typeof createPortfolioRiskAggregator>;

--- a/control-plane/portfolio-intelligence/portfolio-status.test.ts
+++ b/control-plane/portfolio-intelligence/portfolio-status.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPortfolioStatusProjection } from './portfolio-status.ts';
+
+describe('portfolio-intelligence status projection', () => {
+  it('T-PI-S1 classifies blocked readiness when linked blockers exist', () => {
+    const projection = createPortfolioStatusProjection({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {},
+          readinessRules: { requireAllLinkedSynthesesReady: true }
+        }],
+        getPortfolioDefinition: () => ({
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {},
+          readinessRules: { requireAllLinkedSynthesesReady: true }
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          portfolioId: 'defi-core-portfolio',
+          linkedMarketSynthesisIds: ['m1'],
+          rationale: [],
+          linkedMarketSyntheses: [{
+            marketSynthesisId: 'm1',
+            displayName: 'M1',
+            synthesisType: 'market_risk',
+            lifecycleState: 'stabilizing',
+            readinessState: 'blocked',
+            completionState: 'inconclusive',
+            blockingReasons: ['linked_cross_swarm_blocked:m1'],
+            limitations: ['lim1'],
+            rationale: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: []
+          }]
+        }]
+      } as any
+    });
+
+    const status = projection.projectOne('defi-core-portfolio');
+    expect(status.readinessState).toBe('blocked');
+    expect(status.completionState).toBe('inconclusive');
+  });
+
+  it('T-PI-S2 classifies coherent and completed when all linked syntheses are complete and coherent', () => {
+    const projection = createPortfolioStatusProjection({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {}
+        }],
+        getPortfolioDefinition: () => ({
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {}
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          portfolioId: 'defi-core-portfolio',
+          linkedMarketSynthesisIds: ['m1', 'm2'],
+          rationale: [],
+          linkedMarketSyntheses: [{
+            marketSynthesisId: 'm1',
+            displayName: 'M1',
+            synthesisType: 'market_risk',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionState: 'completed',
+            blockingReasons: [],
+            limitations: [],
+            rationale: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: []
+          }, {
+            marketSynthesisId: 'm2',
+            displayName: 'M2',
+            synthesisType: 'liquidity_stress',
+            lifecycleState: 'completed',
+            readinessState: 'coherent',
+            completionState: 'completed',
+            blockingReasons: [],
+            limitations: [],
+            rationale: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: []
+          }]
+        }]
+      } as any
+    });
+
+    const status = projection.projectOne('defi-core-portfolio');
+    expect(status.readinessState).toBe('coherent');
+    expect(status.completionState).toBe('completed');
+    expect(status.lifecycleState).toBe('completed');
+  });
+
+  it('T-PI-S3 keeps incomplete when syntheses are still analyzing without explicit blockers', () => {
+    const projection = createPortfolioStatusProjection({
+      registry: {
+        listPortfolioDefinitions: () => [{
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {}
+        }],
+        getPortfolioDefinition: () => ({
+          portfolioId: 'defi-core-portfolio',
+          displayName: 'DeFi Core',
+          portfolioType: 'defi',
+          enabled: true,
+          matchingRules: {}
+        })
+      } as any,
+      linker: {
+        buildLinks: () => [{
+          portfolioId: 'defi-core-portfolio',
+          linkedMarketSynthesisIds: ['m1'],
+          rationale: [],
+          linkedMarketSyntheses: [{
+            marketSynthesisId: 'm1',
+            displayName: 'M1',
+            synthesisType: 'market_risk',
+            lifecycleState: 'progressing',
+            readinessState: 'analyzing',
+            completionState: 'incomplete',
+            blockingReasons: [],
+            limitations: [],
+            rationale: [],
+            protocolFamilies: [],
+            assetFamilies: [],
+            eventFamilies: []
+          }]
+        }]
+      } as any
+    });
+
+    const status = projection.projectOne('defi-core-portfolio');
+    expect(status.readinessState).toBe('analyzing');
+    expect(status.completionState).toBe('incomplete');
+  });
+});

--- a/control-plane/portfolio-intelligence/portfolio-status.ts
+++ b/control-plane/portfolio-intelligence/portfolio-status.ts
@@ -1,0 +1,296 @@
+import {
+  createPortfolioLinker,
+  type PortfolioLinkResult,
+  type PortfolioLinker,
+} from './portfolio-linker.ts';
+import {
+  createPortfolioRegistry,
+  type PortfolioRegistry,
+} from './portfolio-registry.ts';
+import type {
+  PortfolioCompletionState,
+  PortfolioDefinition,
+  PortfolioLifecycleState,
+  PortfolioReadinessState,
+  PortfolioIntelligenceStatusProjection,
+} from './portfolio-types.ts';
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function evaluateLifecycleState(link: PortfolioLinkResult): PortfolioLifecycleState {
+  if (link.linkedMarketSyntheses.length === 0) {
+    return 'inactive';
+  }
+
+  const states = link.linkedMarketSyntheses.map((entry) => entry.lifecycleState);
+
+  if (states.every((state) => state === 'completed')) {
+    return 'completed';
+  }
+  if (states.some((state) => state === 'stabilizing')) {
+    return 'stabilizing';
+  }
+  if (states.some((state) => state === 'progressing')) {
+    return 'progressing';
+  }
+  if (states.some((state) => state === 'active')) {
+    return 'active';
+  }
+
+  return 'initializing';
+}
+
+function buildBlockingReasons(input: {
+  definition: PortfolioDefinition;
+  link: PortfolioLinkResult;
+}): string[] {
+  const reasons: string[] = [];
+
+  if (!input.definition.enabled) {
+    reasons.push('portfolio_disabled');
+  }
+
+  if (input.link.linkedMarketSynthesisIds.length === 0) {
+    reasons.push('no_linked_market_syntheses');
+  }
+
+  const requireAllReady = input.definition.readinessRules?.requireAllLinkedSynthesesReady === true;
+
+  for (const linked of input.link.linkedMarketSyntheses) {
+    if (linked.readinessState === 'blocked') {
+      reasons.push(`linked_market_synthesis_blocked:${linked.marketSynthesisId}`);
+    }
+
+    if (linked.completionState === 'inconclusive') {
+      reasons.push(`linked_market_synthesis_inconclusive:${linked.marketSynthesisId}`);
+    }
+
+    if (requireAllReady && linked.readinessState !== 'coherent') {
+      reasons.push(`linked_market_synthesis_not_coherent:${linked.marketSynthesisId}`);
+    }
+
+    reasons.push(...linked.blockingReasons.map((reason) => `linked_market_synthesis_blocker:${linked.marketSynthesisId}:${reason}`));
+  }
+
+  return uniqueSorted(reasons);
+}
+
+function evaluateReadinessState(input: {
+  definition: PortfolioDefinition;
+  link: PortfolioLinkResult;
+  blockingReasons: string[];
+}): PortfolioReadinessState {
+  if (!input.definition.enabled || input.link.linkedMarketSyntheses.length === 0) {
+    return 'pending';
+  }
+
+  if (input.blockingReasons.length > 0) {
+    return 'blocked';
+  }
+
+  const states = input.link.linkedMarketSyntheses.map((entry) => entry.readinessState);
+  if (states.every((state) => state === 'coherent')) {
+    return 'coherent';
+  }
+
+  if (states.some((state) => state === 'analyzing' || state === 'coherent')) {
+    return 'analyzing';
+  }
+
+  return 'pending';
+}
+
+function evaluateCompletionState(input: {
+  definition: PortfolioDefinition;
+  link: PortfolioLinkResult;
+  readinessState: PortfolioReadinessState;
+  blockingReasons: string[];
+}): PortfolioCompletionState {
+  if (!input.definition.enabled) {
+    return 'incomplete';
+  }
+
+  if (input.readinessState === 'blocked' || input.blockingReasons.length > 0) {
+    return 'inconclusive';
+  }
+
+  if (input.link.linkedMarketSyntheses.some((entry) => entry.completionState === 'inconclusive')) {
+    return 'inconclusive';
+  }
+
+  const allComplete = input.link.linkedMarketSyntheses.length > 0
+    && input.link.linkedMarketSyntheses.every((entry) => entry.completionState === 'completed');
+
+  if (allComplete && input.readinessState === 'coherent') {
+    return 'completed';
+  }
+
+  return 'incomplete';
+}
+
+function buildStrengths(link: PortfolioLinkResult): string[] {
+  const strengths: string[] = [];
+
+  if (link.linkedMarketSyntheses.length > 0) {
+    strengths.push(`linked_market_syntheses:${String(link.linkedMarketSyntheses.length)}`);
+  }
+
+  const coherentCount = link.linkedMarketSyntheses.filter((entry) => entry.readinessState === 'coherent').length;
+  if (coherentCount > 0) {
+    strengths.push(`coherent_market_syntheses:${String(coherentCount)}`);
+  }
+
+  const completedCount = link.linkedMarketSyntheses.filter((entry) => entry.completionState === 'completed').length;
+  if (completedCount > 0) {
+    strengths.push(`completed_market_syntheses:${String(completedCount)}`);
+  }
+
+  return uniqueSorted(strengths);
+}
+
+function buildLimitations(input: {
+  link: PortfolioLinkResult;
+  blockingReasons: string[];
+  completionState: PortfolioCompletionState;
+}): string[] {
+  const limitations: string[] = [...input.blockingReasons];
+
+  if (input.link.linkedMarketSyntheses.some((entry) => entry.lifecycleState !== 'completed')) {
+    limitations.push('linked_market_syntheses_still_progressing');
+  }
+
+  if (input.completionState === 'inconclusive') {
+    limitations.push('completion_inconclusive');
+  }
+
+  for (const linked of input.link.linkedMarketSyntheses) {
+    limitations.push(...linked.limitations.map((reason) => `linked_market_synthesis_limitation:${linked.marketSynthesisId}:${reason}`));
+  }
+
+  return uniqueSorted(limitations);
+}
+
+export function createPortfolioStatusProjection(options: {
+  registry?: PortfolioRegistry;
+  linker?: PortfolioLinker;
+  definitionsDir?: string;
+  portfolioDefinitionsDir?: string;
+  marketSynthesisDefinitionsDir?: string;
+  crossSwarmDefinitionsDir?: string;
+  swarmDefinitionsDir?: string;
+  teamDefinitionsDir?: string;
+  cohortDefinitionsDir?: string;
+  cohortProgramDefinitionsDir?: string;
+  cohortArtifactsRoot?: string;
+  investigationsRootDir?: string;
+  investigationArtifactsRoot?: string;
+  investigationDefinitionsDir?: string;
+  signalsRootDir?: string;
+  synthesisDefinitionsDir?: string;
+  synthesisArtifactsRoot?: string;
+  policyDefinitionsDir?: string;
+  coordinationArtifactsRoot?: string;
+  teamSwarmArtifactsRoot?: string;
+  swarmArtifactsRoot?: string;
+  crossSwarmArtifactsRoot?: string;
+  marketSynthesisArtifactsRoot?: string;
+  now?: () => Date;
+} = {}) {
+  const registry = options.registry ?? createPortfolioRegistry({
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir
+  });
+
+  const linker = options.linker ?? createPortfolioLinker({
+    registry,
+    definitionsDir: options.definitionsDir ?? options.portfolioDefinitionsDir,
+    marketSynthesisDefinitionsDir: options.marketSynthesisDefinitionsDir,
+    crossSwarmDefinitionsDir: options.crossSwarmDefinitionsDir,
+    swarmDefinitionsDir: options.swarmDefinitionsDir,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    cohortDefinitionsDir: options.cohortDefinitionsDir,
+    cohortProgramDefinitionsDir: options.cohortProgramDefinitionsDir,
+    cohortArtifactsRoot: options.cohortArtifactsRoot,
+    investigationsRootDir: options.investigationsRootDir,
+    investigationArtifactsRoot: options.investigationArtifactsRoot,
+    investigationDefinitionsDir: options.investigationDefinitionsDir,
+    signalsRootDir: options.signalsRootDir,
+    synthesisDefinitionsDir: options.synthesisDefinitionsDir,
+    synthesisArtifactsRoot: options.synthesisArtifactsRoot,
+    policyDefinitionsDir: options.policyDefinitionsDir,
+    coordinationArtifactsRoot: options.coordinationArtifactsRoot,
+    teamSwarmArtifactsRoot: options.teamSwarmArtifactsRoot,
+    swarmArtifactsRoot: options.swarmArtifactsRoot,
+    crossSwarmArtifactsRoot: options.crossSwarmArtifactsRoot,
+    marketSynthesisArtifactsRoot: options.marketSynthesisArtifactsRoot,
+    now: options.now
+  });
+
+  function projectOne(portfolioId: string): PortfolioIntelligenceStatusProjection {
+    const definition = registry.getPortfolioDefinition(portfolioId);
+    const link = linker.buildLinks().find((entry) => entry.portfolioId === portfolioId);
+    if (!link) {
+      throw new Error(`PORTFOLIO_NOT_FOUND: ${portfolioId}`);
+    }
+
+    const blockingReasons = buildBlockingReasons({
+      definition,
+      link,
+    });
+
+    const lifecycleState = evaluateLifecycleState(link);
+    const readinessState = evaluateReadinessState({
+      definition,
+      link,
+      blockingReasons,
+    });
+
+    const completionState = evaluateCompletionState({
+      definition,
+      link,
+      readinessState,
+      blockingReasons,
+    });
+
+    const strengths = buildStrengths(link);
+    const limitations = buildLimitations({
+      link,
+      blockingReasons,
+      completionState,
+    });
+
+    return {
+      portfolioId,
+      displayName: definition.displayName,
+      portfolioType: definition.portfolioType,
+      enabled: definition.enabled,
+      lifecycleState,
+      readinessState,
+      completionState,
+      linkedMarketSynthesisIds: [...link.linkedMarketSynthesisIds].sort((left, right) => left.localeCompare(right)),
+      linkedMarketSyntheses: [...link.linkedMarketSyntheses].sort((left, right) => left.marketSynthesisId.localeCompare(right.marketSynthesisId)),
+      blockingReasons,
+      strengths,
+      limitations,
+      rationale: [...link.rationale].sort((left, right) => left.localeCompare(right)),
+      riskThemes: [],
+      exposureFlags: [],
+      concentrationWarnings: [],
+    };
+  }
+
+  function projectAll(): PortfolioIntelligenceStatusProjection[] {
+    return registry
+      .listPortfolioDefinitions()
+      .map((entry) => projectOne(entry.portfolioId))
+      .sort((left, right) => left.portfolioId.localeCompare(right.portfolioId));
+  }
+
+  return {
+    projectOne,
+    projectAll,
+  };
+}
+
+export type PortfolioStatusProjectionEngine = ReturnType<typeof createPortfolioStatusProjection>;

--- a/control-plane/portfolio-intelligence/portfolio-types.ts
+++ b/control-plane/portfolio-intelligence/portfolio-types.ts
@@ -1,0 +1,153 @@
+export const PORTFOLIO_LIFECYCLE_STATES = [
+  'inactive',
+  'initializing',
+  'active',
+  'progressing',
+  'stabilizing',
+  'completed'
+] as const;
+
+export const PORTFOLIO_READINESS_STATES = [
+  'pending',
+  'analyzing',
+  'coherent',
+  'blocked'
+] as const;
+
+export const PORTFOLIO_COMPLETION_STATES = [
+  'completed',
+  'incomplete',
+  'inconclusive'
+] as const;
+
+export const PORTFOLIO_HISTORY_EVENT_TYPES = [
+  'portfolio_initialized',
+  'market_synthesis_linked',
+  'readiness_changed',
+  'portfolio_progressed',
+  'portfolio_stabilized',
+  'portfolio_completed',
+  'portfolio_marked_inconclusive'
+] as const;
+
+export type PortfolioLifecycleState = typeof PORTFOLIO_LIFECYCLE_STATES[number];
+export type PortfolioReadinessState = typeof PORTFOLIO_READINESS_STATES[number];
+export type PortfolioCompletionState = typeof PORTFOLIO_COMPLETION_STATES[number];
+export type PortfolioHistoryEventType = typeof PORTFOLIO_HISTORY_EVENT_TYPES[number];
+
+export interface PortfolioIntelligenceUnit {
+  portfolioId: string;
+  displayName: string;
+  portfolioType: string;
+  enabled: boolean;
+  linkedMarketSynthesisIds: string[];
+}
+
+export interface PortfolioDefinition {
+  portfolioId: string;
+  displayName: string;
+  portfolioType: string;
+  enabled: boolean;
+  matchingRules: {
+    protocolFamilies?: string[];
+    assetFamilies?: string[];
+    eventFamilies?: string[];
+    synthesisTypes?: string[];
+    marketSynthesisIds?: string[];
+  };
+  readinessRules?: {
+    requireAllLinkedSynthesesReady?: boolean;
+  };
+}
+
+export interface LinkedMarketSynthesisSummary {
+  marketSynthesisId: string;
+  displayName: string;
+  synthesisType: string;
+  lifecycleState: PortfolioLifecycleState;
+  readinessState: PortfolioReadinessState;
+  completionState: PortfolioCompletionState;
+  blockingReasons: string[];
+  limitations: string[];
+  rationale: string[];
+  protocolFamilies: string[];
+  assetFamilies: string[];
+  eventFamilies: string[];
+}
+
+export interface PortfolioLinkResult {
+  portfolioId: string;
+  linkedMarketSynthesisIds: string[];
+  rationale: string[];
+  linkedMarketSyntheses: LinkedMarketSynthesisSummary[];
+}
+
+export interface PortfolioIntelligenceStatus {
+  portfolioId: string;
+  lifecycleState: PortfolioLifecycleState;
+  readinessState: PortfolioReadinessState;
+  completionState: PortfolioCompletionState;
+  linkedMarketSynthesisIds: string[];
+  blockingReasons: string[];
+  strengths: string[];
+  limitations: string[];
+  riskThemes: string[];
+  exposureFlags: string[];
+  concentrationWarnings: string[];
+}
+
+export interface PortfolioIntelligenceStatusProjection extends PortfolioIntelligenceStatus {
+  displayName: string;
+  portfolioType: string;
+  enabled: boolean;
+  rationale: string[];
+  linkedMarketSyntheses: LinkedMarketSynthesisSummary[];
+}
+
+export interface PortfolioRiskSurface {
+  portfolioId: string;
+  riskThemes: string[];
+  exposureFlags: string[];
+  concentrationWarnings: string[];
+}
+
+export interface PortfolioIntelligenceHistoryEntry {
+  portfolioId: string;
+  eventType: PortfolioHistoryEventType;
+  linkedMarketSynthesisIds?: string[];
+  reason: string;
+  slotReference?: string;
+  eventDedupeKey: string;
+}
+
+export interface PortfolioIntelligenceHistory {
+  portfolioId: string;
+  entries: PortfolioIntelligenceHistoryEntry[];
+}
+
+export interface PortfolioIntelligenceProjection extends PortfolioIntelligenceStatusProjection {
+  historySummary: {
+    totalEvents: number;
+    lastEventType?: PortfolioHistoryEventType;
+    lastEventDedupeKey?: string;
+  };
+  artifactPaths: {
+    dirPath: string;
+    statusJsonPath: string;
+    historyJsonPath: string;
+    reportJsonPath: string;
+    reportMarkdownPath: string;
+  };
+  statusPreview: Record<string, unknown>;
+  reportPreview: Record<string, unknown>;
+}
+
+export class PortfolioIntelligenceError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'PortfolioIntelligenceError';
+    this.code = code;
+  }
+}

--- a/docs/architecture/portfolio-intelligence.md
+++ b/docs/architecture/portfolio-intelligence.md
@@ -1,0 +1,122 @@
+# Portfolio Intelligence Layer
+
+## Scope
+
+Sprint 2.22 adds a bounded portfolio-level intelligence layer above market intelligence synthesis.
+
+This layer is:
+- deterministic
+- projection-first
+- append-only for portfolio history
+- CLI-inspectable
+- additive to existing upstream and downstream layers
+
+This layer is not:
+- capital allocation
+- trading or treasury logic
+- orchestration/action systems
+- dashboards
+- Slack automation
+
+## Layer Position
+
+runtime
+-> scheduler
+-> persistent runtime
+-> signal bus
+-> trigger layer
+-> investigations
+-> synthesis
+-> cohorts
+-> monitoring programs
+-> automation
+-> escalation
+-> research teams
+-> team coordination
+-> research swarms
+-> team-swarm coordination
+-> cross-swarm coordination
+-> market intelligence synthesis
+-> portfolio intelligence
+
+## Definitions
+
+Definitions are stored in:
+- `control-plane/portfolio-intelligence/definitions/*.json`
+
+Each definition provides:
+- `portfolioId`
+- `displayName`
+- `portfolioType`
+- `enabled`
+- `matchingRules` (protocol/asset/event families and explicit synthesis/id matches)
+- `readinessRules.requireAllLinkedSynthesesReady` (optional)
+
+## Deterministic Linking
+
+Linking consumes market synthesis inspection outputs and never mutates market synthesis state.
+
+A market synthesis is linked only when configured deterministic family/type/id matches are satisfied and rationale is produced.
+
+Operator-visible rationale includes:
+- `shared_protocol_family:<value>`
+- `shared_asset_family:<value>`
+- `shared_event_family:<value>`
+- `explicit_definition_match:<value>`
+
+## Readiness And Completion Model
+
+Readiness states:
+- `pending`
+- `analyzing`
+- `coherent`
+- `blocked`
+
+Completion states:
+- `completed`
+- `incomplete`
+- `inconclusive`
+
+Heuristics are conservative:
+- explicit blockers produce `blocked`/`inconclusive`
+- weak or conflicting support avoids optimistic completion
+- completion requires coherent linked market synthesis coverage
+
+## Risk Aggregation
+
+Portfolio risk remains descriptive only.
+
+Computed outputs:
+- `riskThemes`
+- `exposureFlags`
+- `concentrationWarnings`
+
+Example themes:
+- `protocol_exposure_pressure`
+- `governance_risk_rising`
+- `liquidity_stress`
+- `yield_instability`
+
+## Projection vs Materialization
+
+Projection (`portfolio-projection.ts`) computes truth by:
+- loading definitions
+- linking market syntheses deterministically
+- evaluating lifecycle/readiness/completion
+- aggregating risk surface
+- composing status/report previews
+
+Materialization (`portfolio-materializer.ts`) only persists already-computed outputs:
+- `portfolio-status.json`
+- `portfolio-history.json`
+- `portfolio-report.json`
+- `portfolio-report.md`
+
+Materialization does not mutate lifecycle, readiness, or completion.
+
+## Persistence
+
+Artifacts are written under:
+- `artifacts/portfolio-intelligence/<portfolioId>/`
+
+History is append-only and deduped by deterministic fingerprinting over canonical event content (`canonicalStringify` + `sha256`).

--- a/docs/runbooks/portfolio-intelligence-operations.md
+++ b/docs/runbooks/portfolio-intelligence-operations.md
@@ -1,0 +1,100 @@
+# Portfolio Intelligence Operations
+
+## Purpose
+
+This runbook covers deterministic operator inspection and artifact materialization for portfolio intelligence units.
+
+## Commands
+
+List portfolio intelligence units:
+
+```bash
+npm run portfolio-intelligence:list
+```
+
+Inspect a portfolio intelligence unit:
+
+```bash
+npm run portfolio-intelligence:inspect -- --portfolio <id>
+```
+
+Inspect lifecycle/readiness/completion and blockers:
+
+```bash
+npm run portfolio-intelligence:status -- --portfolio <id>
+```
+
+Inspect linked market syntheses and rationale:
+
+```bash
+npm run portfolio-intelligence:links -- --portfolio <id>
+```
+
+Inspect readiness/completion signals:
+
+```bash
+npm run portfolio-intelligence:readiness -- --portfolio <id>
+```
+
+Inspect risk surface:
+
+```bash
+npm run portfolio-intelligence:risk -- --portfolio <id>
+```
+
+Inspect append-only history:
+
+```bash
+npm run portfolio-intelligence:history -- --portfolio <id>
+```
+
+Materialize artifacts:
+
+```bash
+npm run portfolio-intelligence:materialize -- --portfolio <id>
+```
+
+## Interpreting Readiness States
+
+Readiness:
+- `pending`: no linked market synthesis coverage or no meaningful progress
+- `analyzing`: linked market syntheses are active but not coherent yet
+- `coherent`: linked market syntheses are coherent with no blocking reasons
+- `blocked`: explicit blockers/conflicts/inconclusive dependencies exist
+
+Completion:
+- `completed`: coherent and all linked market syntheses completed
+- `incomplete`: still progressing without explicit contradiction
+- `inconclusive`: blockers/conflicts/insufficiently reliable support
+
+Always review:
+- `blockingReasons`
+- `limitations`
+- `rationale`
+
+## Interpreting Risk Surfaces
+
+`riskThemes` provide bounded descriptive themes, not actions.
+
+`exposureFlags` identify observed exposure signals (protocol/asset/event and blocked/inconclusive dependencies).
+
+`concentrationWarnings` identify clustered dependency patterns (for example repeated protocol/event concentration).
+
+## Artifact Locations
+
+Per portfolio intelligence unit:
+- `artifacts/portfolio-intelligence/<portfolioId>/portfolio-status.json`
+- `artifacts/portfolio-intelligence/<portfolioId>/portfolio-history.json`
+- `artifacts/portfolio-intelligence/<portfolioId>/portfolio-report.json`
+- `artifacts/portfolio-intelligence/<portfolioId>/portfolio-report.md`
+
+## Boundary
+
+These commands are for bounded portfolio intelligence only.
+
+Out of scope:
+- capital allocation
+- trading or treasury logic
+- orchestration/action systems
+- dashboards
+- Slack automation

--- a/package.json
+++ b/package.json
@@ -164,7 +164,15 @@
     "market-synthesis:links": "node --experimental-strip-types control-plane/cli/market-synthesis-links.ts",
     "market-synthesis:readiness": "node --experimental-strip-types control-plane/cli/market-synthesis-readiness.ts",
     "market-synthesis:history": "node --experimental-strip-types control-plane/cli/market-synthesis-history.ts",
-    "market-synthesis:materialize": "node --experimental-strip-types control-plane/cli/market-synthesis-materialize.ts"
+    "market-synthesis:materialize": "node --experimental-strip-types control-plane/cli/market-synthesis-materialize.ts",
+    "portfolio-intelligence:list": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-list.ts",
+    "portfolio-intelligence:inspect": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-inspect.ts",
+    "portfolio-intelligence:status": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-status.ts",
+    "portfolio-intelligence:links": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-links.ts",
+    "portfolio-intelligence:readiness": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-readiness.ts",
+    "portfolio-intelligence:risk": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-risk.ts",
+    "portfolio-intelligence:history": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-history.ts",
+    "portfolio-intelligence:materialize": "node --experimental-strip-types control-plane/cli/portfolio-intelligence-materialize.ts"
   },
   "devDependencies": {
     "typescript": "^5.6.3",


### PR DESCRIPTION
## Summary
- add deterministic portfolio intelligence layer above market synthesis
- add definition-driven registry, linker, projection, status/risk evaluation, history, inspection, and materialization
- add CLI surfaces, tests, and docs for portfolio intelligence operations

## Testing
- npm test
- npx vitest run control-plane/portfolio-intelligence control-plane/cli/portfolio-intelligence-cli.test.ts
- npm run lint
- npm run typecheck
- npm run portfolio-intelligence:list
- npm run portfolio-intelligence:inspect -- --portfolio defi-core-portfolio
- npm run portfolio-intelligence:status -- --portfolio defi-core-portfolio
- npm run portfolio-intelligence:links -- --portfolio defi-core-portfolio
- npm run portfolio-intelligence:readiness -- --portfolio defi-core-portfolio
- npm run portfolio-intelligence:risk -- --portfolio defi-core-portfolio
- npm run portfolio-intelligence:history -- --portfolio defi-core-portfolio
- npm run portfolio-intelligence:materialize -- --portfolio defi-core-portfolio

```evidence
tier-3
workspace npm test path-filter behavior was non-authoritative for this sprint; direct vitest passed for the new suite, and full npm test/lint/typecheck passed.
projection/materialization boundary preserved: portfolio-projection computes truth; portfolio-materializer only persists artifacts.
no allocation, trading, treasury, orchestration, or action logic added.
```
