### PR TITLE
Sprint 3.2 — Mission Templates Layer

### DIFF
--- a/control-plane/__tests__/missions/templates/template-cli.test.ts
+++ b/control-plane/__tests__/missions/templates/template-cli.test.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../../../finance/determinism.ts';
+import { main as inspectMain } from '../../../cli/mission-templates-inspect.ts';
+import { main as instantiateMain } from '../../../cli/mission-templates-instantiate.ts';
+import { main as listMain } from '../../../cli/mission-templates-list.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-mission-template-cli');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function captureStdout(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+}
+
+function getPrintedJson(stdout: ReturnType<typeof vi.spyOn>): unknown {
+  const joined = stdout.mock.calls.map((call) => String(call[0])).join('');
+  return JSON.parse(joined) as unknown;
+}
+
+describe('mission template CLI integration', () => {
+  it('T-MTPL-C1 mission-templates:list outputs expected summaries', async () => {
+    const stdout = captureStdout();
+
+    const code = await listMain([]);
+
+    expect(code).toBe(0);
+    const payload = getPrintedJson(stdout) as Array<Record<string, string>>;
+    expect(payload.length).toBeGreaterThan(0);
+    expect(payload.find((entry) => entry.templateId === 'evaluate-startup-opportunity')).toMatchObject({
+      templateId: 'evaluate-startup-opportunity',
+      displayName: 'Evaluate Startup Opportunity',
+    });
+
+    const templateIds = payload.map((entry) => entry.templateId);
+    expect(templateIds).toEqual([...templateIds].sort((left, right) => left.localeCompare(right)));
+
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-C2 mission-templates:inspect returns normalized template', async () => {
+    const stdout = captureStdout();
+
+    const code = await inspectMain(['--template', 'evaluate-startup-opportunity']);
+
+    expect(code).toBe(0);
+    const payload = getPrintedJson(stdout) as Record<string, unknown>;
+    expect(payload.templateId).toBe('evaluate-startup-opportunity');
+    expect(Array.isArray(payload.defaultDeliverablesTemplate)).toBe(true);
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-C3 mission-templates:instantiate returns normalized mission payload and instance', async () => {
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const paramsFile = path.join(tmpRoot, 'params.json');
+    fs.writeFileSync(paramsFile, `${JSON.stringify({ sector: 'AI agent payments' }, null, 2)}\n`, 'utf8');
+
+    const stdout = captureStdout();
+
+    const code = await instantiateMain([
+      '--template',
+      'evaluate-startup-opportunity',
+      '--params-file',
+      paramsFile,
+      '--founder-instructions',
+      'Use conservative assumptions',
+    ]);
+
+    expect(code).toBe(0);
+    const payload = getPrintedJson(stdout) as Record<string, unknown>;
+    expect((payload.missionInstance as Record<string, unknown>).missionType).toBe('evaluate-startup-opportunity');
+    expect((payload.missionIdentityPayload as Record<string, unknown>).missionType).toBe('evaluate-startup-opportunity');
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-C4 missing flags produce deterministic errors', async () => {
+    const stdout = captureStdout();
+
+    const code = await instantiateMain(['--template', 'evaluate-startup-opportunity']);
+
+    expect(code).toBe(1);
+    expect(getPrintedJson(stdout)).toEqual({ error: 'MISSING_ARGUMENT: --params-file' });
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-C5 invalid params file content is rejected', async () => {
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const paramsFile = path.join(tmpRoot, 'invalid.json');
+    fs.writeFileSync(paramsFile, `${JSON.stringify(['not-an-object'])}\n`, 'utf8');
+
+    const stdout = captureStdout();
+
+    const code = await instantiateMain([
+      '--template',
+      'evaluate-startup-opportunity',
+      '--params-file',
+      paramsFile,
+    ]);
+
+    expect(code).toBe(1);
+    expect(getPrintedJson(stdout)).toEqual({ error: 'Invalid params file: expected JSON object' });
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-C6 unknown template is rejected', async () => {
+    const stdout = captureStdout();
+
+    const code = await inspectMain(['--template', 'unknown-template']);
+
+    expect(code).toBe(1);
+    expect(getPrintedJson(stdout)).toEqual({ error: 'Unknown mission template: unknown-template' });
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-C7 list output remains canonical across repeated calls', async () => {
+    const stdoutOne = captureStdout();
+    const firstCode = await listMain([]);
+    const firstPayload = getPrintedJson(stdoutOne);
+    stdoutOne.mockRestore();
+
+    const stdoutTwo = captureStdout();
+    const secondCode = await listMain([]);
+    const secondPayload = getPrintedJson(stdoutTwo);
+    stdoutTwo.mockRestore();
+
+    expect(firstCode).toBe(0);
+    expect(secondCode).toBe(0);
+    expect(canonicalStringify(firstPayload)).toBe(canonicalStringify(secondPayload));
+  });
+});

--- a/control-plane/__tests__/missions/templates/template-determinism.test.ts
+++ b/control-plane/__tests__/missions/templates/template-determinism.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { canonicalStringify } from '../../../finance/determinism.ts';
+import { instantiateMissionTemplate } from '../../../missions/templates/mission-template-engine.ts';
+import { listMissionTemplates } from '../../../missions/templates/mission-template-registry.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-mission-template-determinism');
+
+function writeJson(fileName: string, value: unknown): void {
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('mission template determinism', () => {
+  it('T-MTPL-D1 identical inputs yield identical mission id', () => {
+    const first = instantiateMissionTemplate('evaluate-startup-opportunity', {
+      sector: 'AI agent payments',
+      target_customer: 'developer platforms',
+      trigger_event: 'API growth',
+    });
+
+    const second = instantiateMissionTemplate('evaluate-startup-opportunity', {
+      sector: 'AI agent payments',
+      target_customer: 'developer platforms',
+      trigger_event: 'API growth',
+    });
+
+    expect(first.missionId).toBe(second.missionId);
+    expect(canonicalStringify(first)).toBe(canonicalStringify(second));
+  });
+
+  it('T-MTPL-D2 input parameter order does not affect mission id', () => {
+    const first = instantiateMissionTemplate('evaluate-startup-opportunity', {
+      sector: 'AI agent payments',
+      target_customer: 'developer platforms',
+      trigger_event: 'API growth',
+    });
+
+    const second = instantiateMissionTemplate('evaluate-startup-opportunity', {
+      trigger_event: 'API growth',
+      sector: 'AI agent payments',
+      target_customer: 'developer platforms',
+    });
+
+    expect(first.missionId).toBe(second.missionId);
+    expect(canonicalStringify(first.missionIdentityPayload)).toBe(canonicalStringify(second.missionIdentityPayload));
+  });
+
+  it('T-MTPL-D3 registry results are stable regardless of file insertion order', () => {
+    writeJson('z-last.json', {
+      templateId: 'z-last',
+      missionType: 'z-last',
+      displayName: 'Z Last',
+      description: 'desc',
+      parameters: {
+        alpha: { type: 'string', required: true },
+      },
+      defaultObjectiveTemplate: 'Evaluate {{alpha}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    writeJson('a-first.json', {
+      templateId: 'a-first',
+      missionType: 'a-first',
+      displayName: 'A First',
+      description: 'desc',
+      parameters: {
+        alpha: { type: 'string', required: true },
+      },
+      defaultObjectiveTemplate: 'Evaluate {{alpha}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    const first = listMissionTemplates({ definitionsDir: tmpRoot }).map((entry) => entry.templateId);
+    const second = listMissionTemplates({ definitionsDir: tmpRoot }).map((entry) => entry.templateId);
+
+    expect(first).toEqual(['a-first', 'z-last']);
+    expect(second).toEqual(first);
+  });
+
+  it('T-MTPL-D4 canonical output is stable across repeated instantiation calls', () => {
+    const one = instantiateMissionTemplate('produce-market-memo', {
+      market_topic: 'tokenized treasuries',
+    });
+
+    const two = instantiateMissionTemplate('produce-market-memo', {
+      market_topic: 'tokenized treasuries',
+    });
+
+    expect(canonicalStringify(one)).toBe(canonicalStringify(two));
+  });
+
+  it('T-MTPL-D5 optional omitted fields remain deterministic', () => {
+    const first = instantiateMissionTemplate('evaluate-startup-opportunity', {
+      sector: 'stablecoins',
+    });
+
+    const second = instantiateMissionTemplate('evaluate-startup-opportunity', {
+      sector: 'stablecoins',
+    });
+
+    expect(first.missionInstance.objective).toBe('Evaluate whether developments in stablecoins create a scalable startup opportunity.');
+    expect(first.missionId).toBe(second.missionId);
+  });
+});

--- a/control-plane/__tests__/missions/templates/template-engine.test.ts
+++ b/control-plane/__tests__/missions/templates/template-engine.test.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as missionIdentity from '../../../missions/mission-identity.ts';
+import { instantiateMissionTemplate } from '../../../missions/templates/mission-template-engine.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-mission-template-engine');
+
+function writeTemplate(fileName: string, value: unknown): void {
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('mission template engine', () => {
+  it('T-MTPL-E1 performs exact substitution for required string parameter', () => {
+    writeTemplate('string-template.json', {
+      templateId: 'string-template',
+      missionType: 'string-template',
+      displayName: 'String Template',
+      description: 'desc',
+      parameters: {
+        topic: {
+          type: 'string',
+          required: true,
+        },
+      },
+      defaultObjectiveTemplate: 'Analyze {{topic}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    const result = instantiateMissionTemplate('string-template', { topic: 'stablecoins' }, undefined, {
+      definitionsDir: tmpRoot,
+    });
+
+    expect(result.missionInstance.objective).toBe('Analyze stablecoins');
+  });
+
+  it('T-MTPL-E2 missing optional parameter substitutes to empty string', () => {
+    writeTemplate('optional-template.json', {
+      templateId: 'optional-template',
+      missionType: 'optional-template',
+      displayName: 'Optional Template',
+      description: 'desc',
+      parameters: {
+        sector: { type: 'string', required: true },
+        target: { type: 'string', required: false },
+      },
+      defaultObjectiveTemplate: 'Analyze {{sector}} for {{target}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    const result = instantiateMissionTemplate('optional-template', { sector: 'payments' }, undefined, {
+      definitionsDir: tmpRoot,
+    });
+
+    expect(result.missionInstance.objective).toBe('Analyze payments for ');
+  });
+
+  it('T-MTPL-E3 supports number and boolean substitution', () => {
+    writeTemplate('typed-template.json', {
+      templateId: 'typed-template',
+      missionType: 'typed-template',
+      displayName: 'Typed Template',
+      description: 'desc',
+      parameters: {
+        confidence: { type: 'number', required: true },
+        include_risks: { type: 'boolean', required: true },
+      },
+      defaultObjectiveTemplate: 'Confidence {{confidence}} include_risks {{include_risks}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    const result = instantiateMissionTemplate('typed-template', {
+      confidence: 0.7,
+      include_risks: true,
+    }, undefined, {
+      definitionsDir: tmpRoot,
+    });
+
+    expect(result.missionInstance.objective).toBe('Confidence 0.7 include_risks true');
+  });
+
+  it('T-MTPL-E4 copies deliverables and founder instructions deterministically', () => {
+    writeTemplate('deliverables-template.json', {
+      templateId: 'deliverables-template',
+      missionType: 'deliverables-template',
+      displayName: 'Deliverables Template',
+      description: 'desc',
+      parameters: {
+        topic: { type: 'string', required: true },
+      },
+      defaultObjectiveTemplate: 'Topic {{topic}}',
+      defaultDeliverablesTemplate: ['one', 'two'],
+      allowedSourceKinds: ['market-intelligence'],
+      recommendedTeams: ['team-a'],
+    });
+
+    const result = instantiateMissionTemplate('deliverables-template', { topic: 'alpha' }, '  keep concise  ', {
+      definitionsDir: tmpRoot,
+    });
+
+    expect(result.missionInstance.founderInstructions).toBe('keep concise');
+    expect(result.missionInstance.requestedDeliverables).toEqual([
+      { deliverableId: 'one' },
+      { deliverableId: 'two' },
+    ]);
+    expect(result.missionInstance.recommendedTeamIds).toEqual(['team-a']);
+  });
+
+  it('T-MTPL-E5 populates createdFrom provenance with existing mission semantics', () => {
+    writeTemplate('created-from-template.json', {
+      templateId: 'created-from-template',
+      missionType: 'created-from-template',
+      displayName: 'Created From Template',
+      description: 'desc',
+      parameters: {
+        topic: { type: 'string', required: true },
+      },
+      defaultObjectiveTemplate: 'Topic {{topic}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    const result = instantiateMissionTemplate('created-from-template', { topic: 'x' }, undefined, {
+      definitionsDir: tmpRoot,
+    });
+
+    expect(result.missionInstance.createdFrom).toEqual({
+      kind: 'template',
+      referenceId: 'created-from-template',
+    });
+  });
+
+  it('T-MTPL-E6 reuses existing mission identity generation path', () => {
+    writeTemplate('identity-template.json', {
+      templateId: 'identity-template',
+      missionType: 'identity-template',
+      displayName: 'Identity Template',
+      description: 'desc',
+      parameters: {
+        topic: { type: 'string', required: true },
+      },
+      defaultObjectiveTemplate: 'Topic {{topic}}',
+      defaultDeliverablesTemplate: ['report'],
+      allowedSourceKinds: ['market-intelligence'],
+    });
+
+    const deriveSpy = vi.spyOn(missionIdentity, 'deriveMissionIdFromPayload');
+    const result = instantiateMissionTemplate('identity-template', { topic: 'x' }, undefined, {
+      definitionsDir: tmpRoot,
+    });
+
+    expect(deriveSpy).toHaveBeenCalledTimes(1);
+    expect(result.missionInstance.missionId).toBe(result.missionId);
+    expect(result.missionInstance.missionType).toBe('identity-template');
+    expect(result.missionIdentityPayload.createdFrom.kind).toBe('template');
+
+    deriveSpy.mockRestore();
+  });
+});

--- a/control-plane/__tests__/missions/templates/template-registry.test.ts
+++ b/control-plane/__tests__/missions/templates/template-registry.test.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getMissionTemplate,
+  listMissionTemplates,
+  loadMissionTemplates,
+} from '../../../missions/templates/mission-template-registry.ts';
+
+const tmpRoot = path.join('control-plane', '__tests__', 'tmp-mission-templates-registry');
+
+function writeJson(fileName: string, value: unknown): void {
+  fs.mkdirSync(tmpRoot, { recursive: true });
+  fs.writeFileSync(path.join(tmpRoot, fileName), `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function validTemplate(templateId: string, missionType = templateId): Record<string, unknown> {
+  return {
+    templateId,
+    missionType,
+    displayName: templateId,
+    description: `${templateId} description`,
+    parameters: {
+      alpha: {
+        type: 'string',
+        required: true,
+      },
+    },
+    defaultObjectiveTemplate: 'Evaluate {{alpha}}',
+    defaultDeliverablesTemplate: ['memo'],
+    allowedSourceKinds: ['market-intelligence'],
+  };
+}
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('mission template registry', () => {
+  it('T-MTPL-R0 loads all shipped template definitions', () => {
+    const loaded = loadMissionTemplates();
+    expect(loaded.map((template) => template.templateId)).toEqual([
+      'analyze-agent-economy-development',
+      'evaluate-startup-opportunity',
+      'generate-product-spec',
+      'produce-market-memo',
+      'structure-tokenized-offering',
+    ]);
+  });
+
+  it('T-MTPL-R1 loads templates in deterministic templateId order', () => {
+    writeJson('zeta.json', validTemplate('zeta'));
+    writeJson('alpha.json', validTemplate('alpha'));
+
+    const loaded = loadMissionTemplates({ definitionsDir: tmpRoot });
+
+    expect(loaded.map((template) => template.templateId)).toEqual(['alpha', 'zeta']);
+  });
+
+  it('T-MTPL-R2 rejects duplicate template ids', () => {
+    writeJson('one.json', validTemplate('duplicate', 'type-a'));
+    writeJson('two.json', validTemplate('duplicate', 'type-b'));
+
+    expect(() => loadMissionTemplates({ definitionsDir: tmpRoot })).toThrow('Duplicate mission template: duplicate');
+  });
+
+  it('T-MTPL-R3 getMissionTemplate rejects unknown template id', () => {
+    writeJson('alpha.json', validTemplate('alpha'));
+
+    expect(() => getMissionTemplate('unknown', { definitionsDir: tmpRoot })).toThrow('Unknown mission template: unknown');
+  });
+
+  it('T-MTPL-R4 filename loading order does not affect deterministic results', () => {
+    writeJson('zzz.json', validTemplate('gamma'));
+    writeJson('aaa.json', validTemplate('beta'));
+    writeJson('mmm.json', validTemplate('alpha'));
+
+    const first = listMissionTemplates({ definitionsDir: tmpRoot }).map((entry) => entry.templateId);
+    const second = listMissionTemplates({ definitionsDir: tmpRoot }).map((entry) => entry.templateId);
+
+    expect(first).toEqual(['alpha', 'beta', 'gamma']);
+    expect(second).toEqual(first);
+  });
+});

--- a/control-plane/__tests__/missions/templates/template-validation.test.ts
+++ b/control-plane/__tests__/missions/templates/template-validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  validateMissionTemplateDefinition,
+  validateMissionTemplateParameters,
+} from '../../../missions/templates/mission-template-validator.ts';
+
+function validDefinition(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    templateId: 'evaluate-startup-opportunity',
+    missionType: 'evaluate-startup-opportunity',
+    displayName: 'Evaluate Startup Opportunity',
+    description: 'Evaluate a startup opportunity.',
+    parameters: {
+      alpha: {
+        type: 'string',
+        required: true,
+      },
+      beta: {
+        type: 'number',
+        required: false,
+      },
+      gamma: {
+        type: 'boolean',
+        required: false,
+      },
+    },
+    defaultObjectiveTemplate: 'Evaluate {{alpha}}',
+    defaultDeliverablesTemplate: ['memo'],
+    allowedSourceKinds: ['market-intelligence'],
+    ...overrides,
+  };
+}
+
+describe('mission template validation', () => {
+  it('T-MTPL-V1 accepts a valid template definition', () => {
+    const validated = validateMissionTemplateDefinition(validDefinition());
+
+    expect(validated.templateId).toBe('evaluate-startup-opportunity');
+    expect(Object.keys(validated.parameters)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('T-MTPL-V2 rejects invalid parameter type', () => {
+    expect(() => validateMissionTemplateDefinition(validDefinition({
+      parameters: {
+        alpha: {
+          type: 'date',
+          required: true,
+        },
+      },
+    }))).toThrow(/parameters.alpha.type/);
+  });
+
+  it('T-MTPL-V3 rejects missing required definition field', () => {
+    expect(() => validateMissionTemplateDefinition(validDefinition({ displayName: '' }))).toThrow(/displayName/);
+  });
+
+  it('T-MTPL-V4 rejects unknown token references in objective template', () => {
+    expect(() => validateMissionTemplateDefinition(validDefinition({
+      defaultObjectiveTemplate: 'Evaluate {{unknown_token}}',
+    }))).toThrow(/references unknown parameter: unknown_token/);
+  });
+
+  it('T-MTPL-V5 rejects unknown instantiation parameter', () => {
+    const template = validateMissionTemplateDefinition(validDefinition());
+
+    expect(() => validateMissionTemplateParameters(template, {
+      alpha: 'a',
+      unknown: 'b',
+    })).toThrow('Unknown template parameter: unknown');
+  });
+
+  it('T-MTPL-V6 rejects missing required instantiation parameter', () => {
+    const template = validateMissionTemplateDefinition(validDefinition());
+
+    expect(() => validateMissionTemplateParameters(template, {})).toThrow('Missing required template parameter: alpha');
+  });
+
+  it('T-MTPL-V7 rejects wrong instantiation parameter type without coercion', () => {
+    const template = validateMissionTemplateDefinition(validDefinition());
+
+    expect(() => validateMissionTemplateParameters(template, {
+      alpha: 'ok',
+      beta: '123',
+    })).toThrow('Invalid template parameter type for beta: expected number');
+  });
+
+  it('T-MTPL-V8 normalizes parameter ordering deterministically', () => {
+    const template = validateMissionTemplateDefinition(validDefinition());
+
+    const normalized = validateMissionTemplateParameters(template, {
+      gamma: true,
+      alpha: 'sector',
+      beta: 2,
+    });
+
+    expect(Object.keys(normalized)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+});

--- a/control-plane/cli/mission-templates-cli.test.ts
+++ b/control-plane/cli/mission-templates-cli.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { main as inspectMain } from './mission-templates-inspect.ts';
+import { main as instantiateMain } from './mission-templates-instantiate.ts';
+import { main as listMain } from './mission-templates-list.ts';
+
+const {
+  listMissionTemplates,
+  getMissionTemplate,
+  instantiateMissionTemplate,
+} = vi.hoisted(() => ({
+  listMissionTemplates: vi.fn(() => [
+    {
+      templateId: 'evaluate-startup-opportunity',
+      displayName: 'Evaluate Startup Opportunity',
+      description: 'Evaluate whether a development creates a scalable venture opportunity.',
+    },
+  ]),
+  getMissionTemplate: vi.fn(() => ({
+    templateId: 'evaluate-startup-opportunity',
+    missionType: 'evaluate-startup-opportunity',
+    displayName: 'Evaluate Startup Opportunity',
+    description: 'Evaluate whether a development creates a scalable venture opportunity.',
+    parameters: {
+      sector: { type: 'string', required: true },
+    },
+    defaultObjectiveTemplate: 'Evaluate {{sector}}',
+    defaultDeliverablesTemplate: ['executive-summary'],
+    allowedSourceKinds: ['market-intelligence'],
+  })),
+  instantiateMissionTemplate: vi.fn(() => ({
+    missionId: 'mission-1',
+    missionIdentityPayload: {
+      missionType: 'evaluate-startup-opportunity',
+      objective: 'Evaluate AI',
+      requestedDeliverables: [{ deliverableId: 'executive-summary' }],
+      sourceReferences: [],
+      linkedActionPlanIds: [],
+      founderInstructions: '',
+      createdFrom: { kind: 'template' },
+    },
+    missionInstance: {
+      missionId: 'mission-1',
+      missionType: 'evaluate-startup-opportunity',
+      displayName: 'Evaluate Startup Opportunity',
+      objective: 'Evaluate AI',
+      founderInstructions: '',
+      requestedDeliverables: [{ deliverableId: 'executive-summary' }],
+      sourceReferences: [],
+      linkedActionPlanIds: [],
+      linkedPortfolioIds: [],
+      linkedMarketSynthesisIds: [],
+      recommendedTeamIds: [],
+      assignedTeamIds: [],
+      approvalState: 'pending_review',
+      lifecycleState: 'draft',
+      readinessState: 'pending',
+      completionState: 'not_started',
+      blockingReasons: [],
+      limitations: [],
+      createdFrom: { kind: 'template', referenceId: 'evaluate-startup-opportunity' },
+      historyDigest: '',
+    },
+    parameters: {
+      sector: 'AI',
+    },
+  })),
+}));
+
+const readFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('../missions/templates/mission-template-registry.ts', () => ({
+  listMissionTemplates,
+  getMissionTemplate,
+}));
+
+vi.mock('../missions/templates/mission-template-engine.ts', () => ({
+  instantiateMissionTemplate,
+}));
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync,
+  },
+}));
+
+describe('mission templates CLI', () => {
+  it('T-MTPL-CLI1 mission-templates:list outputs canonical summaries', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await listMain([]);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify(listMissionTemplates())}\n`);
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-CLI2 mission-templates:inspect requires --template', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await inspectMain([]);
+
+    expect(code).toBe(1);
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('MISSING_ARGUMENT: --template');
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-CLI3 mission-templates:instantiate routes parsed args', async () => {
+    readFileSync.mockReturnValueOnce(JSON.stringify({ sector: 'AI' }));
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await instantiateMain([
+      '--template',
+      'evaluate-startup-opportunity',
+      '--params-file',
+      'tmp.json',
+      '--founder-instructions',
+      'Focus on moats',
+    ]);
+
+    expect(code).toBe(0);
+    expect(instantiateMissionTemplate).toHaveBeenCalledWith(
+      'evaluate-startup-opportunity',
+      { sector: 'AI' },
+      'Focus on moats',
+    );
+    expect(stdout).toHaveBeenCalledWith(`${canonicalStringify(instantiateMissionTemplate())}\n`);
+    stdout.mockRestore();
+  });
+
+  it('T-MTPL-CLI4 mission-templates:instantiate rejects non-object params file', async () => {
+    readFileSync.mockReturnValueOnce(JSON.stringify(['bad']));
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await instantiateMain([
+      '--template',
+      'evaluate-startup-opportunity',
+      '--params-file',
+      'tmp.json',
+    ]);
+
+    expect(code).toBe(1);
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('Invalid params file: expected JSON object');
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/cli/mission-templates-inspect.ts
+++ b/control-plane/cli/mission-templates-inspect.ts
@@ -1,0 +1,60 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { getMissionTemplate } from '../missions/templates/mission-template-registry.ts';
+
+function parseArgs(argv: string[]): { templateId: string } {
+  let templateId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--template') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --template');
+      }
+      templateId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--template=')) {
+      templateId = arg.slice('--template='.length);
+      if (!templateId) {
+        throw new Error('MISSING_ARGUMENT: --template');
+      }
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!templateId) {
+    throw new Error('MISSING_ARGUMENT: --template');
+  }
+
+  return { templateId };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(getMissionTemplate(args.templateId));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-templates-instantiate.ts
+++ b/control-plane/cli/mission-templates-instantiate.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+import { instantiateMissionTemplate } from '../missions/templates/mission-template-engine.ts';
+
+interface ParsedArgs {
+  founderInstructions?: string;
+  paramsFile: string;
+  templateId: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let templateId: string | null = null;
+  let paramsFile: string | null = null;
+  let founderInstructions: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--template') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --template');
+      }
+      templateId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--template=')) {
+      templateId = arg.slice('--template='.length);
+      if (!templateId) {
+        throw new Error('MISSING_ARGUMENT: --template');
+      }
+      continue;
+    }
+
+    if (arg === '--params-file') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --params-file');
+      }
+      paramsFile = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--params-file=')) {
+      paramsFile = arg.slice('--params-file='.length);
+      if (!paramsFile) {
+        throw new Error('MISSING_ARGUMENT: --params-file');
+      }
+      continue;
+    }
+
+    if (arg === '--founder-instructions') {
+      const value = argv[index + 1];
+      if (value === undefined) {
+        throw new Error('MISSING_ARGUMENT: --founder-instructions');
+      }
+      founderInstructions = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--founder-instructions=')) {
+      founderInstructions = arg.slice('--founder-instructions='.length);
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!templateId) {
+    throw new Error('MISSING_ARGUMENT: --template');
+  }
+  if (!paramsFile) {
+    throw new Error('MISSING_ARGUMENT: --params-file');
+  }
+
+  return {
+    templateId,
+    paramsFile,
+    ...(founderInstructions === undefined ? {} : { founderInstructions }),
+  };
+}
+
+function readParamsFile(filePath: string): Record<string, unknown> {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isPlainObject(parsed)) {
+    throw new Error('Invalid params file: expected JSON object');
+  }
+
+  return parsed;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const parameters = readParamsFile(args.paramsFile);
+    printJson(instantiateMissionTemplate(args.templateId, parameters, args.founderInstructions));
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-templates-list.ts
+++ b/control-plane/cli/mission-templates-list.ts
@@ -1,0 +1,43 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { listMissionTemplates } from '../missions/templates/mission-template-registry.ts';
+
+function parseArgs(argv: string[]): Record<string, never> {
+  if (argv.length > 0) {
+    throw new Error(`UNKNOWN_ARGUMENT: ${argv[0]}`);
+  }
+
+  return {};
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    parseArgs(argv);
+
+    const summaries = listMissionTemplates()
+      .map((template) => ({
+        templateId: template.templateId,
+        displayName: template.displayName,
+        description: template.description,
+      }))
+      .sort((left, right) => left.templateId.localeCompare(right.templateId));
+
+    printJson(summaries);
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'unexpected_runtime_error' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/missions/templates/definitions/analyze-agent-economy-development.json
+++ b/control-plane/missions/templates/definitions/analyze-agent-economy-development.json
@@ -1,0 +1,38 @@
+{
+  "templateId": "analyze-agent-economy-development",
+  "missionType": "analyze-agent-economy-development",
+  "displayName": "Analyze Agent Economy Development",
+  "description": "Analyze an agent economy development for strategic implications and monetization viability.",
+  "parameters": {
+    "development_topic": {
+      "type": "string",
+      "required": true
+    },
+    "ecosystem": {
+      "type": "string",
+      "required": false
+    },
+    "monetization_model": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "defaultObjectiveTemplate": "Analyze the implications of {{development_topic}} in the agent economy.",
+  "defaultDeliverablesTemplate": [
+    "executive-summary",
+    "ecosystem-map",
+    "monetization-analysis"
+  ],
+  "allowedSourceKinds": [
+    "market-intelligence",
+    "research-synthesis",
+    "portfolio-action"
+  ],
+  "recommendedTeams": [
+    "agent-economy-team"
+  ],
+  "tags": [
+    "agent-economy",
+    "analysis"
+  ]
+}

--- a/control-plane/missions/templates/definitions/evaluate-startup-opportunity.json
+++ b/control-plane/missions/templates/definitions/evaluate-startup-opportunity.json
@@ -1,0 +1,37 @@
+{
+  "templateId": "evaluate-startup-opportunity",
+  "missionType": "evaluate-startup-opportunity",
+  "displayName": "Evaluate Startup Opportunity",
+  "description": "Evaluate whether a development creates a scalable venture opportunity.",
+  "parameters": {
+    "sector": {
+      "type": "string",
+      "required": true
+    },
+    "target_customer": {
+      "type": "string",
+      "required": false
+    },
+    "trigger_event": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "defaultObjectiveTemplate": "Evaluate whether developments in {{sector}} create a scalable startup opportunity.",
+  "defaultDeliverablesTemplate": [
+    "executive-summary",
+    "market-map",
+    "product-concept"
+  ],
+  "allowedSourceKinds": [
+    "market-intelligence",
+    "portfolio-action"
+  ],
+  "recommendedTeams": [
+    "venture-opportunity-team"
+  ],
+  "tags": [
+    "analysis",
+    "venture"
+  ]
+}

--- a/control-plane/missions/templates/definitions/generate-product-spec.json
+++ b/control-plane/missions/templates/definitions/generate-product-spec.json
@@ -1,0 +1,38 @@
+{
+  "templateId": "generate-product-spec",
+  "missionType": "generate-product-spec",
+  "displayName": "Generate Product Spec",
+  "description": "Generate a structured product specification from a scoped product concept.",
+  "parameters": {
+    "platform": {
+      "type": "string",
+      "required": false
+    },
+    "product_concept": {
+      "type": "string",
+      "required": true
+    },
+    "target_user": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "defaultObjectiveTemplate": "Generate a product specification for {{product_concept}}.",
+  "defaultDeliverablesTemplate": [
+    "product-spec",
+    "mvp-scope",
+    "architecture-outline"
+  ],
+  "allowedSourceKinds": [
+    "startup-evaluation",
+    "market-intelligence",
+    "portfolio-action"
+  ],
+  "recommendedTeams": [
+    "product-design-team"
+  ],
+  "tags": [
+    "product",
+    "specification"
+  ]
+}

--- a/control-plane/missions/templates/definitions/produce-market-memo.json
+++ b/control-plane/missions/templates/definitions/produce-market-memo.json
@@ -1,0 +1,37 @@
+{
+  "templateId": "produce-market-memo",
+  "missionType": "produce-market-memo",
+  "displayName": "Produce Market Memo",
+  "description": "Produce a bounded market memo from founder-selected market inputs.",
+  "parameters": {
+    "geography": {
+      "type": "string",
+      "required": false
+    },
+    "market_topic": {
+      "type": "string",
+      "required": true
+    },
+    "timeframe": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "defaultObjectiveTemplate": "Produce a structured market memo on {{market_topic}}.",
+  "defaultDeliverablesTemplate": [
+    "executive-summary",
+    "market-map",
+    "risks-and-drivers"
+  ],
+  "allowedSourceKinds": [
+    "market-intelligence",
+    "research-synthesis"
+  ],
+  "recommendedTeams": [
+    "market-intelligence-team"
+  ],
+  "tags": [
+    "market",
+    "research"
+  ]
+}

--- a/control-plane/missions/templates/definitions/structure-tokenized-offering.json
+++ b/control-plane/missions/templates/definitions/structure-tokenized-offering.json
@@ -1,0 +1,38 @@
+{
+  "templateId": "structure-tokenized-offering",
+  "missionType": "structure-tokenized-offering",
+  "displayName": "Structure Tokenized Offering",
+  "description": "Structure a tokenized offering blueprint from core issuer constraints.",
+  "parameters": {
+    "asset_type": {
+      "type": "string",
+      "required": true
+    },
+    "investor_type": {
+      "type": "string",
+      "required": false
+    },
+    "jurisdiction": {
+      "type": "string",
+      "required": false
+    }
+  },
+  "defaultObjectiveTemplate": "Structure a tokenized offering for {{asset_type}}.",
+  "defaultDeliverablesTemplate": [
+    "structure-memo",
+    "risk-summary",
+    "issuance-outline"
+  ],
+  "allowedSourceKinds": [
+    "portfolio-action",
+    "venture-brief",
+    "market-intelligence"
+  ],
+  "recommendedTeams": [
+    "tokenization-structuring-team"
+  ],
+  "tags": [
+    "tokenization",
+    "structuring"
+  ]
+}

--- a/control-plane/missions/templates/mission-template-engine.ts
+++ b/control-plane/missions/templates/mission-template-engine.ts
@@ -1,0 +1,143 @@
+import {
+  deriveMissionIdFromPayload,
+  normalizeMissionIdentityPayload,
+  type MissionIdentityPayload,
+} from '../mission-identity.ts';
+import type { MissionInstance } from '../mission-instance-types.ts';
+import type {
+  MissionTemplateInstantiationResult,
+  NormalizedTemplateParameters,
+} from './mission-template-types.ts';
+import { getMissionTemplate } from './mission-template-registry.ts';
+import {
+  renderTemplateString,
+  validateMissionTemplateParameters,
+} from './mission-template-validator.ts';
+
+function asTrimmedString(value: string | undefined): string {
+  return (value ?? '').trim();
+}
+
+function toRequestedDeliverables(deliverableIds: string[]): MissionIdentityPayload['requestedDeliverables'] {
+  return deliverableIds.map((deliverableId) => ({ deliverableId }));
+}
+
+function toMissionIdentityPayload(input: {
+  missionType: string;
+  objective: string;
+  deliverableIds: string[];
+  founderInstructions: string;
+}): MissionIdentityPayload {
+  return normalizeMissionIdentityPayload({
+    missionType: input.missionType,
+    objective: input.objective,
+    requestedDeliverables: toRequestedDeliverables(input.deliverableIds),
+    sourceReferences: [],
+    linkedActionPlanIds: [],
+    founderInstructions: input.founderInstructions,
+    createdFrom: {
+      kind: 'template',
+    },
+  });
+}
+
+function toMissionInstance(input: {
+  missionId: string;
+  missionType: string;
+  displayName: string;
+  objective: string;
+  founderInstructions: string;
+  deliverableIds: string[];
+  recommendedTeams: string[];
+  templateId: string;
+}): MissionInstance {
+  return {
+    missionId: input.missionId,
+    missionType: input.missionType,
+    displayName: input.displayName,
+    objective: input.objective,
+    founderInstructions: input.founderInstructions,
+    requestedDeliverables: toRequestedDeliverables(input.deliverableIds),
+    sourceReferences: [],
+    linkedActionPlanIds: [],
+    linkedPortfolioIds: [],
+    linkedMarketSynthesisIds: [],
+    recommendedTeamIds: [...input.recommendedTeams],
+    assignedTeamIds: [],
+    approvalState: 'pending_review',
+    lifecycleState: 'draft',
+    readinessState: 'pending',
+    completionState: 'not_started',
+    blockingReasons: [],
+    limitations: [],
+    createdFrom: {
+      kind: 'template',
+      referenceId: input.templateId,
+    },
+    historyDigest: '',
+  };
+}
+
+function buildRenderedParameters(input: {
+  templateParameters: Record<string, { required: boolean }>;
+  normalizedParameters: NormalizedTemplateParameters;
+}): NormalizedTemplateParameters {
+  const rendered: NormalizedTemplateParameters = {};
+
+  for (const parameterName of Object.keys(input.templateParameters).sort((left, right) => left.localeCompare(right))) {
+    if (Object.prototype.hasOwnProperty.call(input.normalizedParameters, parameterName)) {
+      rendered[parameterName] = input.normalizedParameters[parameterName];
+      continue;
+    }
+
+    if (!input.templateParameters[parameterName].required) {
+      rendered[parameterName] = '';
+    }
+  }
+
+  return rendered;
+}
+
+export function instantiateMissionTemplate(
+  templateId: string,
+  parameters: Record<string, unknown>,
+  founderInstructions?: string,
+  options: { definitionsDir?: string } = {},
+): MissionTemplateInstantiationResult {
+  const template = getMissionTemplate(templateId, { definitionsDir: options.definitionsDir });
+  const normalizedParameters = validateMissionTemplateParameters(template, parameters);
+  const renderedParameters = buildRenderedParameters({
+    templateParameters: template.parameters,
+    normalizedParameters,
+  });
+
+  const objective = renderTemplateString(template.defaultObjectiveTemplate, renderedParameters);
+  const normalizedFounderInstructions = asTrimmedString(founderInstructions);
+
+  const missionIdentityPayload = toMissionIdentityPayload({
+    missionType: template.missionType,
+    objective,
+    deliverableIds: template.defaultDeliverablesTemplate,
+    founderInstructions: normalizedFounderInstructions,
+  });
+
+  const missionId = deriveMissionIdFromPayload(missionIdentityPayload);
+
+  const missionInstance = toMissionInstance({
+    missionId,
+    missionType: template.missionType,
+    displayName: template.displayName,
+    objective,
+    founderInstructions: normalizedFounderInstructions,
+    deliverableIds: template.defaultDeliverablesTemplate,
+    recommendedTeams: template.recommendedTeams ?? [],
+    templateId: template.templateId,
+  });
+
+  return {
+    missionId,
+    missionIdentityPayload,
+    missionInstance,
+    parameters: normalizedParameters,
+  };
+}

--- a/control-plane/missions/templates/mission-template-registry.ts
+++ b/control-plane/missions/templates/mission-template-registry.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { MissionTemplateDefinition } from './mission-template-types.ts';
+import { validateMissionTemplateDefinition } from './mission-template-validator.ts';
+
+export const DEFAULT_MISSION_TEMPLATE_DEFINITIONS_DIR = 'control-plane/missions/templates/definitions';
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+}
+
+export function loadMissionTemplates(options: { definitionsDir?: string } = {}): MissionTemplateDefinition[] {
+  const definitionsDir = path.resolve(options.definitionsDir ?? DEFAULT_MISSION_TEMPLATE_DEFINITIONS_DIR);
+  if (!fs.existsSync(definitionsDir)) {
+    throw new Error(`MISSION_TEMPLATE_DEFINITIONS_NOT_FOUND: ${definitionsDir}`);
+  }
+
+  const files = fs.readdirSync(definitionsDir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort((left, right) => left.localeCompare(right));
+
+  const loaded = files.map((fileName) => {
+    const filePath = path.join(definitionsDir, fileName);
+    return validateMissionTemplateDefinition(readJson(filePath), fileName);
+  });
+
+  const seenTemplateIds = new Set<string>();
+  for (const definition of loaded) {
+    if (seenTemplateIds.has(definition.templateId)) {
+      throw new Error(`Duplicate mission template: ${definition.templateId}`);
+    }
+    seenTemplateIds.add(definition.templateId);
+  }
+
+  return loaded.sort((left, right) => left.templateId.localeCompare(right.templateId));
+}
+
+export function listMissionTemplates(options: { definitionsDir?: string } = {}): MissionTemplateDefinition[] {
+  return loadMissionTemplates(options).sort((left, right) => left.templateId.localeCompare(right.templateId));
+}
+
+export function getMissionTemplate(templateId: string, options: { definitionsDir?: string } = {}): MissionTemplateDefinition {
+  const template = listMissionTemplates(options).find((entry) => entry.templateId === templateId);
+  if (!template) {
+    throw new Error(`Unknown mission template: ${templateId}`);
+  }
+
+  return template;
+}

--- a/control-plane/missions/templates/mission-template-types.ts
+++ b/control-plane/missions/templates/mission-template-types.ts
@@ -1,0 +1,40 @@
+import type { MissionIdentityPayload } from '../mission-identity.ts';
+import type { MissionInstance } from '../mission-instance-types.ts';
+
+export type TemplateParameterType = 'string' | 'number' | 'boolean';
+
+export interface TemplateParameter {
+  type: TemplateParameterType;
+  required: boolean;
+  description?: string;
+}
+
+export interface MissionTemplateDefinition {
+  templateId: string;
+  missionType: string;
+  displayName: string;
+  description: string;
+  parameters: Record<string, TemplateParameter>;
+  defaultObjectiveTemplate: string;
+  defaultDeliverablesTemplate: string[];
+  allowedSourceKinds: string[];
+  recommendedTeams?: string[];
+  tags?: string[];
+}
+
+export type NormalizedTemplateParameterValue = string | number | boolean;
+
+export type NormalizedTemplateParameters = Record<string, NormalizedTemplateParameterValue>;
+
+export interface MissionTemplateInstantiationInput {
+  templateId: string;
+  parameters: Record<string, unknown>;
+  founderInstructions?: string;
+}
+
+export interface MissionTemplateInstantiationResult {
+  missionId: string;
+  missionIdentityPayload: MissionIdentityPayload;
+  missionInstance: MissionInstance;
+  parameters: NormalizedTemplateParameters;
+}

--- a/control-plane/missions/templates/mission-template-validator.ts
+++ b/control-plane/missions/templates/mission-template-validator.ts
@@ -1,0 +1,211 @@
+import type {
+  MissionTemplateDefinition,
+  NormalizedTemplateParameters,
+  NormalizedTemplateParameterValue,
+  TemplateParameter,
+  TemplateParameterType,
+} from './mission-template-types.ts';
+
+const TEMPLATE_PARAMETER_TYPES: TemplateParameterType[] = ['string', 'number', 'boolean'];
+const TOKEN_PATTERN = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeParameterDefinition(
+  key: string,
+  value: unknown,
+  sourceLabel: string,
+): TemplateParameter {
+  if (!isPlainObject(value)) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} parameters.${key} must be an object.`);
+  }
+
+  const type = value.type;
+  if (!TEMPLATE_PARAMETER_TYPES.includes(type as TemplateParameterType)) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} parameters.${key}.type must be one of string, number, boolean.`);
+  }
+
+  if (typeof value.required !== 'boolean') {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} parameters.${key}.required must be a boolean.`);
+  }
+
+  const description = asNonEmptyString(value.description);
+
+  return {
+    type: type as TemplateParameterType,
+    required: value.required,
+    ...(description ? { description } : {}),
+  };
+}
+
+function asStringArray(value: unknown, sourceLabel: string, fieldName: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} ${fieldName} must be an array of non-empty strings.`);
+  }
+
+  const normalized = value.map((entry) => asNonEmptyString(entry));
+  if (normalized.some((entry) => !entry)) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} ${fieldName} must be an array of non-empty strings.`);
+  }
+
+  return normalized as string[];
+}
+
+export function extractTemplateTokens(template: string): string[] {
+  const tokens = new Set<string>();
+  for (const match of template.matchAll(TOKEN_PATTERN)) {
+    tokens.add(match[1]);
+  }
+
+  return Array.from(tokens).sort((left, right) => left.localeCompare(right));
+}
+
+export function validateTemplateReferences(definition: MissionTemplateDefinition): void {
+  const parameterKeys = new Set(Object.keys(definition.parameters));
+  const objectiveTokens = extractTemplateTokens(definition.defaultObjectiveTemplate);
+
+  for (const token of objectiveTokens) {
+    if (!parameterKeys.has(token)) {
+      throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${definition.templateId} defaultObjectiveTemplate references unknown parameter: ${token}`);
+    }
+  }
+}
+
+export function renderTemplateString(template: string, parameters: NormalizedTemplateParameters): string {
+  return template.replace(TOKEN_PATTERN, (full: string, token: string) => {
+    if (!Object.prototype.hasOwnProperty.call(parameters, token)) {
+      return full;
+    }
+
+    return String(parameters[token]);
+  });
+}
+
+export function validateMissionTemplateDefinition(value: unknown, sourceLabel = '<inline>'): MissionTemplateDefinition {
+  if (!isPlainObject(value)) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} template must be an object.`);
+  }
+
+  const templateId = asNonEmptyString(value.templateId);
+  const missionType = asNonEmptyString(value.missionType);
+  const displayName = asNonEmptyString(value.displayName);
+  const description = asNonEmptyString(value.description);
+  const defaultObjectiveTemplate = asNonEmptyString(value.defaultObjectiveTemplate);
+
+  if (!templateId) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} templateId must be a non-empty string.`);
+  }
+  if (!missionType) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} missionType must be a non-empty string.`);
+  }
+  if (!displayName) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} displayName must be a non-empty string.`);
+  }
+  if (!description) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} description must be a non-empty string.`);
+  }
+  if (!defaultObjectiveTemplate) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} defaultObjectiveTemplate must be a non-empty string.`);
+  }
+
+  if (!isPlainObject(value.parameters)) {
+    throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} parameters must be an object.`);
+  }
+
+  const parameterEntries = Object.entries(value.parameters)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  const normalizedParameters: Record<string, TemplateParameter> = {};
+  for (const [parameterName, parameterDefinition] of parameterEntries) {
+    if (asNonEmptyString(parameterName) === null) {
+      throw new Error(`MISSION_TEMPLATE_INVALID_SCHEMA: ${sourceLabel} parameters keys must be non-empty strings.`);
+    }
+
+    normalizedParameters[parameterName] = normalizeParameterDefinition(parameterName, parameterDefinition, sourceLabel);
+  }
+
+  const definition: MissionTemplateDefinition = {
+    templateId,
+    missionType,
+    displayName,
+    description,
+    parameters: normalizedParameters,
+    defaultObjectiveTemplate,
+    defaultDeliverablesTemplate: asStringArray(value.defaultDeliverablesTemplate, sourceLabel, 'defaultDeliverablesTemplate'),
+    allowedSourceKinds: asStringArray(value.allowedSourceKinds, sourceLabel, 'allowedSourceKinds'),
+    ...(value.recommendedTeams === undefined
+      ? {}
+      : { recommendedTeams: asStringArray(value.recommendedTeams, sourceLabel, 'recommendedTeams') }),
+    ...(value.tags === undefined ? {} : { tags: asStringArray(value.tags, sourceLabel, 'tags') }),
+  };
+
+  validateTemplateReferences(definition);
+
+  return definition;
+}
+
+function assertTemplateParameterType(name: string, expectedType: TemplateParameterType, value: unknown): NormalizedTemplateParameterValue {
+  if (expectedType === 'string') {
+    if (typeof value === 'string') {
+      return value;
+    }
+    throw new Error(`Invalid template parameter type for ${name}: expected string`);
+  }
+
+  if (expectedType === 'number') {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    throw new Error(`Invalid template parameter type for ${name}: expected number`);
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  throw new Error(`Invalid template parameter type for ${name}: expected boolean`);
+}
+
+export function validateMissionTemplateParameters(
+  template: MissionTemplateDefinition,
+  parameters: Record<string, unknown>,
+): NormalizedTemplateParameters {
+  if (!isPlainObject(parameters)) {
+    throw new Error('Template parameters must be an object.');
+  }
+
+  const templateParameterNames = Object.keys(template.parameters);
+  const providedParameterNames = Object.keys(parameters).sort((left, right) => left.localeCompare(right));
+
+  for (const providedName of providedParameterNames) {
+    if (!Object.prototype.hasOwnProperty.call(template.parameters, providedName)) {
+      throw new Error(`Unknown template parameter: ${providedName}`);
+    }
+  }
+
+  for (const parameterName of templateParameterNames) {
+    const definition = template.parameters[parameterName];
+    if (definition.required && !Object.prototype.hasOwnProperty.call(parameters, parameterName)) {
+      throw new Error(`Missing required template parameter: ${parameterName}`);
+    }
+  }
+
+  const normalized: NormalizedTemplateParameters = {};
+
+  for (const parameterName of providedParameterNames) {
+    const definition = template.parameters[parameterName];
+    normalized[parameterName] = assertTemplateParameterType(parameterName, definition.type, parameters[parameterName]);
+  }
+
+  return normalized;
+}

--- a/package.json
+++ b/package.json
@@ -193,7 +193,10 @@
     "missions:inspect": "node --experimental-strip-types control-plane/cli/missions-inspect.ts",
     "missions:status": "node --experimental-strip-types control-plane/cli/missions-status.ts",
     "missions:history": "node --experimental-strip-types control-plane/cli/missions-history.ts",
-    "missions:materialize": "node --experimental-strip-types control-plane/cli/missions-materialize.ts"
+    "missions:materialize": "node --experimental-strip-types control-plane/cli/missions-materialize.ts",
+    "mission-templates:list": "node --experimental-strip-types control-plane/cli/mission-templates-list.ts",
+    "mission-templates:inspect": "node --experimental-strip-types control-plane/cli/mission-templates-inspect.ts",
+    "mission-templates:instantiate": "node --experimental-strip-types control-plane/cli/mission-templates-instantiate.ts"
   },
   "devDependencies": {
     "typescript": "^5.6.3",


### PR DESCRIPTION
tier-3

## Summary
- add deterministic Mission Templates layer under `control-plane/missions/templates/*`
- add template validation, registry loading, and template instantiation engine reusing existing mission identity semantics
- add five deterministic mission template definitions for founder workflow bootstrapping
- add CLI surfaces for list, inspect, and instantiate
- add full Vitest coverage for registry, validation, engine, CLI, and determinism behavior

## Testing
- npx vitest run control-plane/__tests__/missions/templates/template-registry.test.ts control-plane/__tests__/missions/templates/template-validation.test.ts control-plane/__tests__/missions/templates/template-engine.test.ts control-plane/__tests__/missions/templates/template-cli.test.ts control-plane/__tests__/missions/templates/template-determinism.test.ts control-plane/cli/mission-templates-cli.test.ts
- npm run mission-templates:list
- npm run mission-templates:inspect -- --template evaluate-startup-opportunity
- npm run mission-templates:instantiate -- --template evaluate-startup-opportunity --params-file <temp-json>
- npm run typecheck
- npm run lint

## Notes
- strictly additive Sprint 3.2 implementation isolated under `control-plane/missions/templates/*` plus new CLI files
- existing mission identity path reused via `normalizeMissionIdentityPayload` and `deriveMissionIdFromPayload`
- deterministic guarantees preserved: sorted filename loading, lexicographic parameter normalization, canonical JSON output, stable repeated mission IDs

```evidence
npx vitest run control-plane/__tests__/missions/templates/template-registry.test.ts control-plane/__tests__/missions/templates/template-validation.test.ts control-plane/__tests__/missions/templates/template-engine.test.ts control-plane/__tests__/missions/templates/template-cli.test.ts control-plane/__tests__/missions/templates/template-determinism.test.ts control-plane/cli/mission-templates-cli.test.ts
npm run mission-templates:list
npm run mission-templates:inspect -- --template evaluate-startup-opportunity
npm run mission-templates:instantiate -- --template evaluate-startup-opportunity --params-file <temp-json>
npm run typecheck
npm run lint
```
