### PR TITLE
Sprint 8.1: Controlled Execution Handoff & Activation

### DIFF
--- a/control-plane/__tests__/mission-control/mission-execution-activation-cli.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-cli.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { canonicalStringify } from '../../finance/determinism.ts';
+import { main as listMain } from '../../cli/mission-control-activation-list.ts';
+import { main as inspectMain } from '../../cli/mission-control-activation-inspect.ts';
+import { main as mappingsMain } from '../../cli/mission-control-activation-mappings.ts';
+import { main as eligibilityMain } from '../../cli/mission-control-activation-eligibility.ts';
+import { main as queueMain } from '../../cli/mission-control-activation-queue.ts';
+import { main as feedbackMain } from '../../cli/mission-control-activation-feedback.ts';
+import { main as statusMain } from '../../cli/mission-control-activation-status.ts';
+import { main as historyMain } from '../../cli/mission-control-activation-history.ts';
+import { main as materializeMain } from '../../cli/mission-control-activation-materialize.ts';
+import { main as deferMain } from '../../cli/mission-control-activation-defer.ts';
+import { main as markSubmittedMain } from '../../cli/mission-control-activation-mark-submitted.ts';
+import { main as markCompleteMain } from '../../cli/mission-control-activation-mark-complete.ts';
+
+const {
+  listActivationRecords,
+  inspectActivationRecord,
+  inspectRequestActivationMappings,
+  inspectActivationEligibility,
+  inspectActivationQueue,
+  inspectActivationFeedbackLinks,
+  inspectActivationStatus,
+  inspectActivationHistory,
+  materializeExecutionActivationRecord,
+  deferExecutionActivationRecord,
+  markExecutionActivationSubmitted,
+  markExecutionActivationComplete,
+} = vi.hoisted(() => ({
+  listActivationRecords: vi.fn(() => [{ executionActivationRecordId: 'activation-1', queueState: 'queued', priority: 'high' }]),
+  inspectActivationRecord: vi.fn(() => ({ executionActivationRecordId: 'activation-1' })),
+  inspectRequestActivationMappings: vi.fn(() => ({ executionActivationRecordId: 'activation-1' })),
+  inspectActivationEligibility: vi.fn(() => ({ executionActivationRecordId: 'activation-1', eligibilityStatus: 'eligible' })),
+  inspectActivationQueue: vi.fn(() => ({ executionActivationRecordId: 'activation-1', queueState: 'queued' })),
+  inspectActivationFeedbackLinks: vi.fn(() => []),
+  inspectActivationStatus: vi.fn(() => ({ executionActivationRecordId: 'activation-1', status: 'pending_activation' })),
+  inspectActivationHistory: vi.fn(() => ({ executionActivationRecordId: 'activation-1', entries: [] })),
+  materializeExecutionActivationRecord: vi.fn(() => ({ executionActivationRecordId: 'activation-1' })),
+  deferExecutionActivationRecord: vi.fn(() => ({ statusPreview: { executionActivationRecordId: 'activation-1', status: 'activation_deferred' } })),
+  markExecutionActivationSubmitted: vi.fn(() => ({ statusPreview: { executionActivationRecordId: 'activation-1', status: 'handoff_submitted' } })),
+  markExecutionActivationComplete: vi.fn(() => ({ statusPreview: { executionActivationRecordId: 'activation-1', status: 'activation_completed' } })),
+}));
+
+vi.mock('../../mission-control/mission-execution-activation-inspection.ts', () => ({
+  createMissionExecutionActivationInspection: vi.fn(() => ({
+    listActivationRecords,
+    inspectActivationRecord,
+    inspectRequestActivationMappings,
+    inspectActivationEligibility,
+    inspectActivationQueue,
+    inspectActivationFeedbackLinks,
+    inspectActivationStatus,
+    inspectActivationHistory,
+  })),
+}));
+
+vi.mock('../../mission-control/mission-execution-activation-manager.ts', () => ({
+  createMissionExecutionActivationManager: vi.fn(() => ({
+    materializeExecutionActivationRecord,
+    deferExecutionActivationRecord,
+    markExecutionActivationSubmitted,
+    markExecutionActivationComplete,
+  })),
+}));
+
+describe('mission execution activation cli', () => {
+  it('T-MEA-CLI1 command routing is deterministic', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await listMain([]);
+    await inspectMain(['--activation', 'activation-1']);
+    await mappingsMain(['--activation=activation-1']);
+    await eligibilityMain(['--activation=activation-1']);
+    await queueMain(['--activation=activation-1']);
+    await feedbackMain(['--activation=activation-1']);
+    await statusMain(['--activation=activation-1']);
+    await historyMain(['--activation=activation-1']);
+    await materializeMain(['--activation=activation-1']);
+    await deferMain(['--activation=activation-1']);
+    await markSubmittedMain(['--activation=activation-1']);
+    await markCompleteMain(['--activation=activation-1']);
+
+    expect(listActivationRecords).toHaveBeenCalled();
+    expect(inspectActivationRecord).toHaveBeenCalledWith({ executionActivationRecordId: 'activation-1' });
+    expect(materializeExecutionActivationRecord).toHaveBeenCalledWith({ executionActivationRecordId: 'activation-1' });
+
+    stdout.mockRestore();
+  });
+
+  it('T-MEA-CLI2 parse failures return stable JSON errors', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await inspectMain([]);
+
+    expect(code).toBe(1);
+    expect(stdout).toHaveBeenLastCalledWith(`${canonicalStringify({ error: 'MISSING_ARGUMENT: --activation' })}\n`);
+
+    stdout.mockRestore();
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation-eligibility.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-eligibility.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveExecutionActivationEligibility } from '../../mission-control/execution-activation-eligibility.ts';
+import type {
+  ExecutionRequestRecord,
+  MissionExecutionCoordinationProjection,
+} from '../../mission-control/mission-execution-coordination-types.ts';
+
+function request(state: ExecutionRequestRecord['state'], domain = 'mission_execution'): ExecutionRequestRecord {
+  return {
+    executionRequestRecordId: 'request-1',
+    missionExecutionCoordinationPlanId: 'plan-1',
+    missionControlOrchestrationActionItemId: 'action-1',
+    executionIntentId: 'intent-1',
+    requestClass: 'task_execution_request',
+    targetExecutionDomain: domain,
+    priority: 'high',
+    state,
+    reasonTokens: [],
+  };
+}
+
+function projection(status: MissionExecutionCoordinationProjection['status']['status']): MissionExecutionCoordinationProjection {
+  return {
+    missionExecutionCoordinationPlanId: 'plan-1',
+    missionControlInterventionPlanId: 'intervention-1',
+    executionIntentSummaries: [],
+    executionRequestSummaries: [],
+    feedbackLinkSummaries: [],
+    status: { missionExecutionCoordinationPlanId: 'plan-1', status, reasonTokens: [] },
+    outcome: { missionExecutionCoordinationPlanId: 'plan-1', outcome: 'pending', reasonTokens: [] },
+    priority: 'high',
+    linkedActionItemIds: [],
+    linkedExecutionAttemptIds: [],
+    coordinationHistory: { missionExecutionCoordinationPlanId: 'plan-1', entries: [] },
+    plan: {
+      missionExecutionCoordinationPlanId: 'plan-1',
+      missionControlInterventionPlanId: 'intervention-1',
+      displayName: 'Plan',
+      strategyClass: 'strategy',
+      executionIntentIds: [],
+      executionRequestIds: [],
+      priority: 'high',
+      state: 'queued',
+      outcome: 'pending',
+    },
+    statusPreview: {},
+    reportPreview: {},
+  };
+}
+
+describe('mission execution activation eligibility', () => {
+  it('T-MEA-E1 derives eligible status', () => {
+    const result = deriveExecutionActivationEligibility({
+      request: request('submitted'),
+      missionExecutionCoordinationProjection: projection('execution_active'),
+      runtimeCapabilities: [{ targetExecutionDomain: 'mission_execution', capabilityStatus: 'enabled' }],
+    });
+
+    expect(result.eligibilityStatus).toBe('eligible');
+  });
+
+  it('T-MEA-E2 derives blocked status when runtime capability is disabled', () => {
+    const result = deriveExecutionActivationEligibility({
+      request: request('submitted'),
+      missionExecutionCoordinationProjection: projection('execution_active'),
+      runtimeCapabilities: [{ targetExecutionDomain: 'mission_execution', capabilityStatus: 'disabled' }],
+    });
+
+    expect(result.eligibilityStatus).toBe('blocked_from_activation');
+    expect(result.blockingConditionTokens).toContain('runtime_capability_disabled:mission_execution');
+  });
+
+  it('T-MEA-E3 derives conditionally eligible for queued request', () => {
+    const result = deriveExecutionActivationEligibility({
+      request: request('queued'),
+      missionExecutionCoordinationProjection: projection('pending_execution'),
+      runtimeCapabilities: [{ targetExecutionDomain: 'mission_execution', capabilityStatus: 'enabled' }],
+    });
+
+    expect(result.eligibilityStatus).toBe('conditionally_eligible');
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation-feedback-link.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-feedback-link.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { createExecutionActivationRecord } from '../../mission-control/execution-activation-record.ts';
+import { deriveExecutionActivationFeedbackLinks } from '../../mission-control/execution-activation-feedback-link.ts';
+import type { ExecutionRequestRecord } from '../../mission-control/mission-execution-coordination-types.ts';
+
+function request(id: string): ExecutionRequestRecord {
+  return {
+    executionRequestRecordId: id,
+    missionExecutionCoordinationPlanId: 'plan-1',
+    missionControlOrchestrationActionItemId: 'action-1',
+    executionIntentId: 'intent-1',
+    requestClass: 'task_execution_request',
+    targetExecutionDomain: 'mission_execution',
+    priority: 'high',
+    state: 'submitted',
+    reasonTokens: [],
+  };
+}
+
+describe('mission execution activation feedback links', () => {
+  it('T-MEA-F1 links request -> activation -> runtime IDs and dedupes deterministically', () => {
+    const activation = createExecutionActivationRecord({ request: request('request-1') });
+
+    const links = deriveExecutionActivationFeedbackLinks({
+      activationRecords: [activation],
+      feedbackRecords: [
+        {
+          executionRequestRecordId: 'request-1',
+          executionAttemptId: 'attempt-1',
+          taskExecutionRunId: 'run-1',
+          workerResultId: 'worker-1',
+          feedbackClass: 'execution_started',
+        },
+        {
+          executionRequestRecordId: 'request-1',
+          executionAttemptId: 'attempt-1',
+          taskExecutionRunId: 'run-1',
+          workerResultId: 'worker-1',
+          feedbackClass: 'execution_started',
+        },
+      ],
+    });
+
+    expect(links).toHaveLength(1);
+    expect(links[0]!.executionActivationRecordId).toBe(activation.executionActivationRecordId);
+    expect(links[0]!.executionAttemptId).toBe('attempt-1');
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation-identity.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-identity.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveExecutionActivationEligibilityId,
+  deriveExecutionActivationFeedbackLinkId,
+  deriveExecutionActivationRecordId,
+  deriveExecutionRequestActivationMappingId,
+  deriveMissionExecutionActivationQueueEntryId,
+} from '../../mission-control/mission-execution-activation-identity.ts';
+
+describe('mission execution activation identity', () => {
+  it('T-MEA-ID1 deterministic activation identities are stable across token ordering', () => {
+    const recordOne = deriveExecutionActivationRecordId({
+      executionRequestRecordId: 'request-1',
+      missionExecutionCoordinationPlanId: 'plan-1',
+      executionIntentId: 'intent-1',
+      targetExecutionDomain: 'mission_execution',
+      priority: 'high',
+    });
+
+    const recordTwo = deriveExecutionActivationRecordId({
+      executionRequestRecordId: 'request-1',
+      missionExecutionCoordinationPlanId: 'plan-1',
+      executionIntentId: 'intent-1',
+      targetExecutionDomain: 'mission_execution',
+      priority: 'high',
+    });
+
+    const mappingOne = deriveExecutionRequestActivationMappingId({
+      executionRequestRecordId: 'request-1',
+      executionActivationRecordId: 'activation-1',
+      activationRule: 'standard_task_activation',
+      reasonTokens: ['b', 'a'],
+    });
+
+    const mappingTwo = deriveExecutionRequestActivationMappingId({
+      executionRequestRecordId: 'request-1',
+      executionActivationRecordId: 'activation-1',
+      activationRule: 'standard_task_activation',
+      reasonTokens: ['a', 'b'],
+    });
+
+    const eligibilityOne = deriveExecutionActivationEligibilityId({
+      executionRequestRecordId: 'request-1',
+      eligibilityStatus: 'eligible',
+      reasonTokens: ['z', 'a'],
+      blockingConditionTokens: [],
+    });
+
+    const eligibilityTwo = deriveExecutionActivationEligibilityId({
+      executionRequestRecordId: 'request-1',
+      eligibilityStatus: 'eligible',
+      reasonTokens: ['a', 'z'],
+      blockingConditionTokens: [],
+    });
+
+    const queueOne = deriveMissionExecutionActivationQueueEntryId({
+      executionActivationRecordId: 'activation-1',
+      priority: 'high',
+      queueState: 'queued',
+      reasonTokens: ['q2', 'q1'],
+    });
+
+    const queueTwo = deriveMissionExecutionActivationQueueEntryId({
+      executionActivationRecordId: 'activation-1',
+      priority: 'high',
+      queueState: 'queued',
+      reasonTokens: ['q1', 'q2'],
+    });
+
+    const feedbackOne = deriveExecutionActivationFeedbackLinkId({
+      executionActivationRecordId: 'activation-1',
+      executionRequestRecordId: 'request-1',
+      executionAttemptId: 'attempt-1',
+      taskExecutionRunId: 'run-1',
+      workerResultId: null,
+      feedbackClass: 'execution_started',
+    });
+
+    const feedbackTwo = deriveExecutionActivationFeedbackLinkId({
+      executionActivationRecordId: 'activation-1',
+      executionRequestRecordId: 'request-1',
+      executionAttemptId: 'attempt-1',
+      taskExecutionRunId: 'run-1',
+      workerResultId: null,
+      feedbackClass: 'execution_started',
+    });
+
+    expect(recordTwo).toBe(recordOne);
+    expect(mappingTwo).toBe(mappingOne);
+    expect(eligibilityTwo).toBe(eligibilityOne);
+    expect(queueTwo).toBe(queueOne);
+    expect(feedbackTwo).toBe(feedbackOne);
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation-mapping.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-mapping.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveExecutionRequestActivationMappings } from '../../mission-control/execution-request-activation-mapping.ts';
+import { createExecutionActivationRecord } from '../../mission-control/execution-activation-record.ts';
+import type { ExecutionRequestRecord } from '../../mission-control/mission-execution-coordination-types.ts';
+
+function request(requestClass: ExecutionRequestRecord['requestClass']): ExecutionRequestRecord {
+  return {
+    executionRequestRecordId: `${requestClass}-request`,
+    missionExecutionCoordinationPlanId: 'plan-1',
+    missionControlOrchestrationActionItemId: 'action-1',
+    executionIntentId: 'intent-1',
+    requestClass,
+    targetExecutionDomain: 'mission_execution',
+    priority: 'high',
+    state: 'queued',
+    reasonTokens: ['seed:1'],
+  };
+}
+
+describe('mission execution activation mapping', () => {
+  it('T-MEA-M1 maps requests to deterministic activation rules with explainable reasons', () => {
+    const requests = [
+      request('task_execution_request'),
+      request('monitoring_request'),
+      request('review_execution_request'),
+      request('stabilization_request'),
+    ];
+
+    const activationRecords = requests.map((entry) => createExecutionActivationRecord({ request: entry }));
+
+    const mappings = deriveExecutionRequestActivationMappings({
+      requests,
+      activationRecords,
+    });
+
+    expect(mappings).toHaveLength(4);
+    expect(new Set(mappings.map((entry) => entry.activationRule))).toEqual(new Set([
+      'monitoring_activation',
+      'review_activation',
+      'stabilization_followup_activation',
+      'standard_task_activation',
+    ]));
+    expect(mappings.every((entry) => entry.reasonTokens.some((token) => token.startsWith('activation_rule:')))).toBe(true);
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation-projection.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-projection.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createMissionExecutionActivationMaterializer } from '../../mission-control/mission-execution-activation-materializer.ts';
+import { createMissionExecutionActivationProjection } from '../../mission-control/mission-execution-activation-projection.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-mission-execution-activation-projection');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('mission execution activation projection', () => {
+  it('T-MEA-PR1 projection and materialization are replay-stable and deterministic', () => {
+    const projection = createMissionExecutionActivationProjection({
+      coordinationProjection: {
+        projectAll: () => [{
+          missionExecutionCoordinationPlanId: 'exec-plan-1',
+          missionControlInterventionPlanId: 'plan-1',
+          executionIntentSummaries: [],
+          executionRequestSummaries: [{
+            executionRequestRecordId: 'request-1',
+            missionExecutionCoordinationPlanId: 'exec-plan-1',
+            missionControlOrchestrationActionItemId: 'action-1',
+            executionIntentId: 'intent-1',
+            requestClass: 'task_execution_request',
+            targetExecutionDomain: 'mission_execution',
+            priority: 'high',
+            state: 'submitted',
+            reasonTokens: ['seed:a'],
+          }],
+          feedbackLinkSummaries: [],
+          status: { missionExecutionCoordinationPlanId: 'exec-plan-1', status: 'execution_active', reasonTokens: [] },
+          outcome: { missionExecutionCoordinationPlanId: 'exec-plan-1', outcome: 'active', reasonTokens: [] },
+          priority: 'high',
+          linkedActionItemIds: ['action-1'],
+          linkedExecutionAttemptIds: [],
+          coordinationHistory: { missionExecutionCoordinationPlanId: 'exec-plan-1', entries: [] },
+          plan: {
+            missionExecutionCoordinationPlanId: 'exec-plan-1',
+            missionControlInterventionPlanId: 'plan-1',
+            displayName: 'Exec Plan',
+            strategyClass: 'systemic_watch_strategy',
+            executionIntentIds: [],
+            executionRequestIds: ['request-1'],
+            priority: 'high',
+            state: 'active',
+            outcome: 'active',
+          },
+          statusPreview: {},
+          reportPreview: {},
+        }],
+        projectOne: () => ({}) as never,
+        listExecutionCoordinationPlans: () => [],
+      } as never,
+      missionControlArtifactsRoot: path.join(tmpRoot, 'artifacts', 'mission-control'),
+    });
+
+    const one = projection.projectAll();
+    const two = projection.projectAll();
+
+    expect(two).toEqual(one);
+    expect(two[0]!.status.status).toBe('handoff_submitted');
+
+    const materializer = createMissionExecutionActivationMaterializer({
+      projection,
+      missionControlArtifactsRoot: path.join(tmpRoot, 'artifacts', 'mission-control'),
+    });
+
+    const first = materializer.materializeOne({ executionActivationRecordId: one[0]!.executionActivationRecordId });
+    const second = materializer.materializeOne({ executionActivationRecordId: one[0]!.executionActivationRecordId });
+
+    expect(fs.readFileSync(first.statusPath, 'utf8')).toBe(fs.readFileSync(second.statusPath, 'utf8'));
+    expect(fs.readFileSync(first.reportPath, 'utf8')).toBe(fs.readFileSync(second.reportPath, 'utf8'));
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation-queue.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation-queue.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { createExecutionActivationRecord } from '../../mission-control/execution-activation-record.ts';
+import { deriveMissionExecutionActivationQueueEntry, sortMissionExecutionActivationQueue } from '../../mission-control/mission-execution-activation-queue.ts';
+import type { ExecutionActivationEligibility } from '../../mission-control/mission-execution-activation-types.ts';
+import type { ExecutionRequestRecord } from '../../mission-control/mission-execution-coordination-types.ts';
+
+function request(id: string, priority: string): ExecutionRequestRecord {
+  return {
+    executionRequestRecordId: id,
+    missionExecutionCoordinationPlanId: 'plan-1',
+    missionControlOrchestrationActionItemId: 'action-1',
+    executionIntentId: 'intent-1',
+    requestClass: 'task_execution_request',
+    targetExecutionDomain: 'mission_execution',
+    priority,
+    state: 'queued',
+    reasonTokens: [],
+  };
+}
+
+function eligibility(requestId: string, status: ExecutionActivationEligibility['eligibilityStatus']): ExecutionActivationEligibility {
+  return {
+    executionActivationEligibilityId: `${requestId}-${status}`,
+    executionRequestRecordId: requestId,
+    eligibilityStatus: status,
+    reasonTokens: [],
+    blockingConditionTokens: [],
+    state: 'active',
+  };
+}
+
+describe('mission execution activation queue', () => {
+  it('T-MEA-Q1 queue ordering is deterministic by priority then activationRecordId', () => {
+    const lowRecord = createExecutionActivationRecord({ request: request('request-low', 'low') });
+    const highRecord = createExecutionActivationRecord({ request: request('request-high', 'high') });
+
+    const lowQueue = deriveMissionExecutionActivationQueueEntry({
+      activationRecord: lowRecord,
+      eligibility: eligibility('request-low', 'eligible'),
+      feedbackLinks: [],
+      historyEntries: [],
+    });
+
+    const highQueue = deriveMissionExecutionActivationQueueEntry({
+      activationRecord: highRecord,
+      eligibility: eligibility('request-high', 'eligible'),
+      feedbackLinks: [],
+      historyEntries: [],
+    });
+
+    const sorted = sortMissionExecutionActivationQueue([lowQueue, highQueue]);
+    expect(sorted[0]!.executionActivationRecordId).toBe(highRecord.executionActivationRecordId);
+  });
+
+  it('T-MEA-Q2 blocked eligibility maps to blocked queue state', () => {
+    const record = createExecutionActivationRecord({ request: request('request-1', 'high') });
+
+    const queue = deriveMissionExecutionActivationQueueEntry({
+      activationRecord: record,
+      eligibility: eligibility('request-1', 'blocked_from_activation'),
+      feedbackLinks: [],
+      historyEntries: [],
+    });
+
+    expect(queue.queueState).toBe('blocked');
+  });
+});

--- a/control-plane/__tests__/mission-control/mission-execution-activation.integration.test.ts
+++ b/control-plane/__tests__/mission-control/mission-execution-activation.integration.test.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createMissionExecutionActivationManager } from '../../mission-control/mission-execution-activation-manager.ts';
+import { createMissionExecutionActivationProjection } from '../../mission-control/mission-execution-activation-projection.ts';
+
+const tmpRoot = path.join('control-plane', 'tests', 'tmp-mission-execution-activation-integration');
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('mission execution activation integration', () => {
+  it('T-MEA-I1 full execution coordination -> activation bridge is deterministic and additive', () => {
+    const projection = createMissionExecutionActivationProjection({
+      coordinationProjection: {
+        projectAll: () => [{
+          missionExecutionCoordinationPlanId: 'exec-plan-1',
+          missionControlInterventionPlanId: 'plan-1',
+          executionIntentSummaries: [],
+          executionRequestSummaries: [
+            {
+              executionRequestRecordId: 'request-1',
+              missionExecutionCoordinationPlanId: 'exec-plan-1',
+              missionControlOrchestrationActionItemId: 'action-1',
+              executionIntentId: 'intent-1',
+              requestClass: 'task_execution_request',
+              targetExecutionDomain: 'mission_execution',
+              priority: 'high',
+              state: 'submitted',
+              reasonTokens: ['seed:a'],
+            },
+          ],
+          feedbackLinkSummaries: [],
+          status: { missionExecutionCoordinationPlanId: 'exec-plan-1', status: 'execution_active', reasonTokens: [] },
+          outcome: { missionExecutionCoordinationPlanId: 'exec-plan-1', outcome: 'active', reasonTokens: [] },
+          priority: 'high',
+          linkedActionItemIds: ['action-1'],
+          linkedExecutionAttemptIds: [],
+          coordinationHistory: { missionExecutionCoordinationPlanId: 'exec-plan-1', entries: [] },
+          plan: {
+            missionExecutionCoordinationPlanId: 'exec-plan-1',
+            missionControlInterventionPlanId: 'plan-1',
+            displayName: 'Exec Plan',
+            strategyClass: 'dependency_relief_strategy',
+            executionIntentIds: [],
+            executionRequestIds: ['request-1'],
+            priority: 'high',
+            state: 'active',
+            outcome: 'active',
+          },
+          statusPreview: {},
+          reportPreview: {},
+        }],
+        projectOne: () => ({}) as never,
+        listExecutionCoordinationPlans: () => [],
+      } as never,
+      missionControlArtifactsRoot: path.join(tmpRoot, 'artifacts', 'mission-control'),
+    });
+
+    const firstProjection = projection.projectAll()[0];
+    expect(firstProjection).toBeDefined();
+
+    const manager = createMissionExecutionActivationManager({
+      projection,
+      missionControlArtifactsRoot: path.join(tmpRoot, 'artifacts', 'mission-control'),
+    });
+
+    const first = manager.materializeExecutionActivationRecord({
+      executionActivationRecordId: firstProjection!.executionActivationRecordId,
+    });
+
+    const second = manager.materializeExecutionActivationRecord({
+      executionActivationRecordId: firstProjection!.executionActivationRecordId,
+    });
+
+    expect(fs.readFileSync(first.statusPath, 'utf8')).toBe(fs.readFileSync(second.statusPath, 'utf8'));
+    expect(fs.readFileSync(first.historyPath, 'utf8')).toBe(fs.readFileSync(second.historyPath, 'utf8'));
+
+    const projected = projection.projectOne({ executionActivationRecordId: firstProjection!.executionActivationRecordId });
+    expect(projected.executionRequestRecordId).toBe('request-1');
+    expect(projected.missionExecutionCoordinationPlanId).toBe('exec-plan-1');
+  });
+});

--- a/control-plane/cli/mission-control-activation-defer.ts
+++ b/control-plane/cli/mission-control-activation-defer.ts
@@ -1,0 +1,67 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationManager } from '../mission-control/mission-execution-activation-manager.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const result = createMissionExecutionActivationManager().deferExecutionActivationRecord(args);
+    printJson(result.statusPreview);
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_DEFER_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-eligibility.ts
+++ b/control-plane/cli/mission-control-activation-eligibility.ts
@@ -1,0 +1,66 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(createMissionExecutionActivationInspection().inspectActivationEligibility(args));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_ELIGIBILITY_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-feedback.ts
+++ b/control-plane/cli/mission-control-activation-feedback.ts
@@ -1,0 +1,66 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(createMissionExecutionActivationInspection().inspectActivationFeedbackLinks(args));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_FEEDBACK_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-history.ts
+++ b/control-plane/cli/mission-control-activation-history.ts
@@ -1,0 +1,66 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(createMissionExecutionActivationInspection().inspectActivationHistory(args));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_HISTORY_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-inspect.ts
+++ b/control-plane/cli/mission-control-activation-inspect.ts
@@ -1,0 +1,78 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--activation' || arg === '--activationId') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    if (arg.startsWith('--activationId=')) {
+      const value = arg.slice('--activationId='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  const message = error instanceof Error ? error.message : 'unknown_error';
+  return message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const result = createMissionExecutionActivationInspection().inspectActivationRecord(args);
+    printJson(result);
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_INSPECT_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-list.ts
+++ b/control-plane/cli/mission-control-activation-list.ts
@@ -1,0 +1,29 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    if (argv.length > 0) {
+      throw new Error(`UNKNOWN_ARGUMENT: ${argv[0]}`);
+    }
+
+    printJson(createMissionExecutionActivationInspection().listActivationRecords());
+    return 0;
+  } catch (error) {
+    printJson({ error: (error as Error).message });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_LIST_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-mappings.ts
+++ b/control-plane/cli/mission-control-activation-mappings.ts
@@ -1,0 +1,66 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(createMissionExecutionActivationInspection().inspectRequestActivationMappings(args));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_MAPPINGS_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-mark-complete.ts
+++ b/control-plane/cli/mission-control-activation-mark-complete.ts
@@ -1,0 +1,67 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationManager } from '../mission-control/mission-execution-activation-manager.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const result = createMissionExecutionActivationManager().markExecutionActivationComplete(args);
+    printJson(result.statusPreview);
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_MARK_COMPLETE_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-mark-submitted.ts
+++ b/control-plane/cli/mission-control-activation-mark-submitted.ts
@@ -1,0 +1,67 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationManager } from '../mission-control/mission-execution-activation-manager.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const result = createMissionExecutionActivationManager().markExecutionActivationSubmitted(args);
+    printJson(result.statusPreview);
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_MARK_SUBMITTED_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-materialize.ts
+++ b/control-plane/cli/mission-control-activation-materialize.ts
@@ -1,0 +1,66 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationManager } from '../mission-control/mission-execution-activation-manager.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(createMissionExecutionActivationManager().materializeExecutionActivationRecord(args));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_MATERIALIZE_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-queue.ts
+++ b/control-plane/cli/mission-control-activation-queue.ts
@@ -1,0 +1,74 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId?: string } {
+  let executionActivationRecordId: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  return { executionActivationRecordId };
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    const inspection = createMissionExecutionActivationInspection();
+
+    if (args.executionActivationRecordId) {
+      printJson(inspection.inspectActivationQueue({ executionActivationRecordId: args.executionActivationRecordId }));
+      return 0;
+    }
+
+    printJson(inspection.listActivationRecords().map((entry) => ({
+      executionActivationRecordId: entry.executionActivationRecordId,
+      queueState: entry.queueState,
+      priority: entry.priority,
+    })));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_QUEUE_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/cli/mission-control-activation-status.ts
+++ b/control-plane/cli/mission-control-activation-status.ts
@@ -1,0 +1,66 @@
+import { canonicalStringify } from '../finance/determinism.ts';
+import { createMissionExecutionActivationInspection } from '../mission-control/mission-execution-activation-inspection.ts';
+
+function parseArgs(argv: string[]): { executionActivationRecordId: string } {
+  let executionActivationRecordId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--activation') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--activation=')) {
+      const value = arg.slice('--activation='.length);
+      if (!value) {
+        throw new Error('MISSING_ARGUMENT: --activation');
+      }
+      executionActivationRecordId = value;
+      continue;
+    }
+
+    throw new Error(`UNKNOWN_ARGUMENT: ${arg}`);
+  }
+
+  if (!executionActivationRecordId) {
+    throw new Error('MISSING_ARGUMENT: --activation');
+  }
+
+  return { executionActivationRecordId };
+}
+
+function toStableError(error: unknown): string {
+  return (error as Error).message === 'EXECUTION_ACTIVATION_RECORD_NOT_FOUND'
+    ? 'execution_activation_record_not_found'
+    : (error as Error).message;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${canonicalStringify(value)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    const args = parseArgs(argv);
+    printJson(createMissionExecutionActivationInspection().inspectActivationStatus(args));
+    return 0;
+  } catch (error) {
+    printJson({ error: toStableError(error) });
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  }).catch(() => {
+    process.stdout.write(`${canonicalStringify({ error: 'MISSION_CONTROL_ACTIVATION_STATUS_UNEXPECTED_RUNTIME_ERROR' })}\n`);
+    process.exit(2);
+  });
+}

--- a/control-plane/mission-control/execution-activation-eligibility.ts
+++ b/control-plane/mission-control/execution-activation-eligibility.ts
@@ -1,0 +1,146 @@
+import {
+  deriveExecutionActivationEligibilityId,
+  uniqueSortedStrings,
+} from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationEligibility,
+  ExecutionActivationEligibilityValue,
+} from './mission-execution-activation-types.ts';
+import type {
+  ExecutionRequestRecord,
+  MissionExecutionCoordinationProjection,
+} from './mission-execution-coordination-types.ts';
+
+export interface RuntimeCapabilitySurface {
+  targetExecutionDomain: string;
+  capabilityStatus: 'enabled' | 'degraded' | 'disabled' | 'inconclusive';
+  reasonTokens?: string[];
+}
+
+function evaluateEligibility(input: {
+  request: ExecutionRequestRecord;
+  missionExecutionCoordinationProjection: MissionExecutionCoordinationProjection;
+  runtimeCapability: RuntimeCapabilitySurface | null;
+}): {
+  eligibilityStatus: ExecutionActivationEligibilityValue;
+  reasonTokens: string[];
+  blockingConditionTokens: string[];
+  state: ExecutionActivationEligibility['state'];
+} {
+  const blockingConditionTokens: string[] = [];
+  const reasonTokens: string[] = [
+    `request_state:${input.request.state}`,
+    `coordination_status:${input.missionExecutionCoordinationProjection.status.status}`,
+  ];
+
+  if (input.missionExecutionCoordinationProjection.status.status === 'inconclusive' || input.request.state === 'inconclusive') {
+    return {
+      eligibilityStatus: 'inconclusive',
+      reasonTokens: uniqueSortedStrings([...reasonTokens, 'eligibility:inconclusive']),
+      blockingConditionTokens: [],
+      state: 'inconclusive',
+    };
+  }
+
+  if (input.request.state === 'failed') {
+    blockingConditionTokens.push('request_failed');
+  }
+
+  if (input.missionExecutionCoordinationProjection.status.status === 'execution_failed') {
+    blockingConditionTokens.push('coordination_failed');
+  }
+
+  if (input.runtimeCapability?.capabilityStatus === 'disabled') {
+    blockingConditionTokens.push(`runtime_capability_disabled:${input.request.targetExecutionDomain}`);
+  }
+
+  if (blockingConditionTokens.length > 0) {
+    return {
+      eligibilityStatus: 'blocked_from_activation',
+      reasonTokens: uniqueSortedStrings([
+        ...reasonTokens,
+        ...blockingConditionTokens,
+        ...(input.runtimeCapability?.reasonTokens ?? []),
+      ]),
+      blockingConditionTokens: uniqueSortedStrings(blockingConditionTokens),
+      state: 'resolved',
+    };
+  }
+
+  if (input.request.state === 'deferred' || input.missionExecutionCoordinationProjection.status.status === 'execution_deferred') {
+    return {
+      eligibilityStatus: 'not_eligible',
+      reasonTokens: uniqueSortedStrings([
+        ...reasonTokens,
+        'deferred',
+      ]),
+      blockingConditionTokens: [],
+      state: 'resolved',
+    };
+  }
+
+  if (input.runtimeCapability?.capabilityStatus === 'degraded') {
+    return {
+      eligibilityStatus: 'conditionally_eligible',
+      reasonTokens: uniqueSortedStrings([
+        ...reasonTokens,
+        `runtime_capability_degraded:${input.request.targetExecutionDomain}`,
+        ...(input.runtimeCapability.reasonTokens ?? []),
+      ]),
+      blockingConditionTokens: [],
+      state: 'active',
+    };
+  }
+
+  if (input.request.state === 'created' || input.request.state === 'queued') {
+    return {
+      eligibilityStatus: 'conditionally_eligible',
+      reasonTokens: uniqueSortedStrings([
+        ...reasonTokens,
+        'request_not_submitted',
+      ]),
+      blockingConditionTokens: [],
+      state: 'active',
+    };
+  }
+
+  return {
+    eligibilityStatus: 'eligible',
+    reasonTokens: uniqueSortedStrings([
+      ...reasonTokens,
+      ...(input.runtimeCapability?.reasonTokens ?? []),
+      'eligible',
+    ]),
+    blockingConditionTokens: [],
+    state: 'active',
+  };
+}
+
+export function deriveExecutionActivationEligibility(input: {
+  request: ExecutionRequestRecord;
+  missionExecutionCoordinationProjection: MissionExecutionCoordinationProjection;
+  runtimeCapabilities?: RuntimeCapabilitySurface[];
+}): ExecutionActivationEligibility {
+  const runtimeCapability = (input.runtimeCapabilities ?? [])
+    .find((entry) => entry.targetExecutionDomain === input.request.targetExecutionDomain) ?? null;
+
+  const evaluated = evaluateEligibility({
+    request: input.request,
+    missionExecutionCoordinationProjection: input.missionExecutionCoordinationProjection,
+    runtimeCapability,
+  });
+
+  return {
+    executionActivationEligibilityId: deriveExecutionActivationEligibilityId({
+      executionRequestRecordId: input.request.executionRequestRecordId,
+      eligibilityStatus: evaluated.eligibilityStatus,
+      reasonTokens: evaluated.reasonTokens,
+      blockingConditionTokens: evaluated.blockingConditionTokens,
+    }),
+    executionRequestRecordId: input.request.executionRequestRecordId,
+    eligibilityStatus: evaluated.eligibilityStatus,
+    reasonTokens: evaluated.reasonTokens,
+    blockingConditionTokens: evaluated.blockingConditionTokens,
+    state: evaluated.state,
+  };
+}

--- a/control-plane/mission-control/execution-activation-feedback-link.ts
+++ b/control-plane/mission-control/execution-activation-feedback-link.ts
@@ -1,0 +1,65 @@
+import {
+  deriveExecutionActivationFeedbackLinkId,
+  uniqueSortedStrings,
+} from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationFeedbackClass,
+  ExecutionActivationFeedbackLink,
+} from './mission-execution-activation-types.ts';
+import type { ExecutionActivationRecord } from './mission-execution-activation-types.ts';
+
+export function deriveExecutionActivationFeedbackLinks(input: {
+  activationRecords: ExecutionActivationRecord[];
+  feedbackRecords?: Array<{
+    executionActivationRecordId?: string;
+    executionRequestRecordId: string;
+    executionAttemptId?: string | null;
+    taskExecutionRunId?: string | null;
+    workerResultId?: string | null;
+    feedbackClass: ExecutionActivationFeedbackClass;
+  }>;
+}): ExecutionActivationFeedbackLink[] {
+  const activationByRequestId = new Map(
+    input.activationRecords.map((entry) => [entry.executionRequestRecordId, entry])
+  );
+
+  const links = (input.feedbackRecords ?? [])
+    .map((record) => {
+      const activation = record.executionActivationRecordId
+        ? input.activationRecords.find((entry) => entry.executionActivationRecordId === record.executionActivationRecordId) ?? null
+        : (activationByRequestId.get(record.executionRequestRecordId) ?? null);
+
+      if (!activation) {
+        return null;
+      }
+
+      return {
+        executionActivationFeedbackLinkId: deriveExecutionActivationFeedbackLinkId({
+          executionActivationRecordId: activation.executionActivationRecordId,
+          executionRequestRecordId: activation.executionRequestRecordId,
+          executionAttemptId: record.executionAttemptId ?? null,
+          taskExecutionRunId: record.taskExecutionRunId ?? null,
+          workerResultId: record.workerResultId ?? null,
+          feedbackClass: record.feedbackClass,
+        }),
+        executionActivationRecordId: activation.executionActivationRecordId,
+        executionRequestRecordId: activation.executionRequestRecordId,
+        executionAttemptId: record.executionAttemptId ?? null,
+        taskExecutionRunId: record.taskExecutionRunId ?? null,
+        workerResultId: record.workerResultId ?? null,
+        feedbackClass: record.feedbackClass,
+        state: 'linked',
+      } satisfies ExecutionActivationFeedbackLink;
+    })
+    .filter((entry): entry is ExecutionActivationFeedbackLink => entry !== null);
+
+  const deduped = new Map(links.map((entry) => [entry.executionActivationFeedbackLinkId, entry]));
+  return Array.from(deduped.values())
+    .sort((left, right) => left.executionActivationFeedbackLinkId.localeCompare(right.executionActivationFeedbackLinkId));
+}
+
+export function summarizeLinkedExecutionAttemptIds(links: ExecutionActivationFeedbackLink[]): string[] {
+  return uniqueSortedStrings(
+    links.map((entry) => entry.executionAttemptId ?? '').filter((entry) => entry.length > 0)
+  );
+}

--- a/control-plane/mission-control/execution-activation-outcome.ts
+++ b/control-plane/mission-control/execution-activation-outcome.ts
@@ -1,0 +1,40 @@
+import { uniqueSortedStrings } from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationFeedbackLink,
+  ExecutionActivationOutcome,
+  ExecutionActivationStatusRecord,
+} from './mission-execution-activation-types.ts';
+
+export function deriveExecutionActivationOutcome(input: {
+  executionActivationRecordId: string;
+  status: ExecutionActivationStatusRecord;
+  feedbackLinks: ExecutionActivationFeedbackLink[];
+}): ExecutionActivationOutcome {
+  const feedbackClasses = input.feedbackLinks.map((entry) => entry.feedbackClass);
+
+  let outcome: ExecutionActivationOutcome['outcome'] = 'pending';
+
+  if (input.status.status === 'inconclusive' || feedbackClasses.includes('execution_inconclusive')) {
+    outcome = 'inconclusive';
+  } else if (input.status.status === 'activation_failed' || feedbackClasses.includes('execution_failed') || feedbackClasses.includes('execution_blocked')) {
+    outcome = 'failed';
+  } else if (input.status.status === 'activation_deferred') {
+    outcome = 'deferred';
+  } else if (input.status.status === 'activation_completed' || feedbackClasses.includes('execution_completed')) {
+    outcome = feedbackClasses.includes('execution_started') ? 'partially_completed' : 'completed';
+  } else if (input.status.status === 'activation_active' || feedbackClasses.includes('execution_started')) {
+    outcome = 'active';
+  } else if (input.status.status === 'handoff_submitted' || feedbackClasses.includes('handoff_submitted')) {
+    outcome = 'submitted';
+  }
+
+  return {
+    executionActivationRecordId: input.executionActivationRecordId,
+    outcome,
+    reasonTokens: uniqueSortedStrings([
+      `status:${input.status.status}`,
+      `outcome:${outcome}`,
+      `feedback_count:${String(input.feedbackLinks.length)}`,
+    ]),
+  };
+}

--- a/control-plane/mission-control/execution-activation-record.ts
+++ b/control-plane/mission-control/execution-activation-record.ts
@@ -1,0 +1,83 @@
+import {
+  deriveExecutionActivationRecordId,
+} from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationOutcomeValue,
+  ExecutionActivationRecord,
+  ExecutionActivationRecordState,
+} from './mission-execution-activation-types.ts';
+import type { ExecutionRequestRecord } from './mission-execution-coordination-types.ts';
+
+function stateFromRequestState(requestState: ExecutionRequestRecord['state']): ExecutionActivationRecordState {
+  if (requestState === 'completed') {
+    return 'completed';
+  }
+  if (requestState === 'failed') {
+    return 'failed';
+  }
+  if (requestState === 'deferred') {
+    return 'deferred';
+  }
+  if (requestState === 'active') {
+    return 'active';
+  }
+  if (requestState === 'submitted') {
+    return 'submitted';
+  }
+  if (requestState === 'queued') {
+    return 'queued';
+  }
+  if (requestState === 'inconclusive') {
+    return 'inconclusive';
+  }
+  return 'created';
+}
+
+function outcomeFromState(state: ExecutionActivationRecordState): ExecutionActivationOutcomeValue {
+  if (state === 'completed') {
+    return 'completed';
+  }
+  if (state === 'failed') {
+    return 'failed';
+  }
+  if (state === 'deferred') {
+    return 'deferred';
+  }
+  if (state === 'active') {
+    return 'active';
+  }
+  if (state === 'submitted') {
+    return 'submitted';
+  }
+  if (state === 'inconclusive') {
+    return 'inconclusive';
+  }
+  return 'pending';
+}
+
+export function createExecutionActivationRecord(input: {
+  request: ExecutionRequestRecord;
+}): ExecutionActivationRecord {
+  const state = stateFromRequestState(input.request.state);
+
+  return {
+    executionActivationRecordId: deriveExecutionActivationRecordId({
+      executionRequestRecordId: input.request.executionRequestRecordId,
+      missionExecutionCoordinationPlanId: input.request.missionExecutionCoordinationPlanId,
+      executionIntentId: input.request.executionIntentId,
+      targetExecutionDomain: input.request.targetExecutionDomain,
+      priority: input.request.priority,
+    }),
+    executionRequestRecordId: input.request.executionRequestRecordId,
+    missionExecutionCoordinationPlanId: input.request.missionExecutionCoordinationPlanId,
+    executionIntentId: input.request.executionIntentId,
+    targetExecutionDomain: input.request.targetExecutionDomain,
+    priority: input.request.priority,
+    state,
+    outcome: outcomeFromState(state),
+  };
+}
+
+export function sortExecutionActivationRecords(records: ExecutionActivationRecord[]): ExecutionActivationRecord[] {
+  return [...records].sort((left, right) => left.executionActivationRecordId.localeCompare(right.executionActivationRecordId));
+}

--- a/control-plane/mission-control/execution-activation-status.ts
+++ b/control-plane/mission-control/execution-activation-status.ts
@@ -1,0 +1,63 @@
+import {
+  deriveActivationStatusFromQueueState,
+  uniqueSortedStrings,
+} from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationFeedbackLink,
+  ExecutionActivationHistoryEvent,
+  ExecutionActivationStatusRecord,
+  MissionExecutionActivationQueueEntry,
+} from './mission-execution-activation-types.ts';
+
+export function deriveExecutionActivationStatus(input: {
+  executionActivationRecordId: string;
+  queueEntry: MissionExecutionActivationQueueEntry | null;
+  feedbackLinks: ExecutionActivationFeedbackLink[];
+  historyEntries: ExecutionActivationHistoryEvent[];
+}): ExecutionActivationStatusRecord {
+  const feedbackClasses = input.feedbackLinks.map((entry) => entry.feedbackClass);
+  let status = deriveActivationStatusFromQueueState({
+    queueState: input.queueEntry?.queueState ?? null,
+    hasFeedback: feedbackClasses.length > 0,
+  });
+
+  for (const entry of input.historyEntries) {
+    if (entry.eventType === 'execution_activation_deferred') {
+      status = 'activation_deferred';
+      continue;
+    }
+    if (entry.eventType === 'execution_activation_handoff_submitted') {
+      status = 'handoff_submitted';
+      continue;
+    }
+    if (entry.eventType === 'execution_activation_completed') {
+      status = 'activation_completed';
+      continue;
+    }
+    if (entry.eventType === 'execution_activation_failed') {
+      status = 'activation_failed';
+    }
+  }
+
+  if (feedbackClasses.includes('execution_inconclusive')) {
+    status = 'inconclusive';
+  } else if (feedbackClasses.includes('execution_failed') || feedbackClasses.includes('execution_blocked')) {
+    status = 'activation_failed';
+  } else if (feedbackClasses.includes('execution_completed')) {
+    status = 'activation_completed';
+  } else if (feedbackClasses.includes('execution_started')) {
+    status = 'activation_active';
+  } else if (feedbackClasses.includes('handoff_submitted')) {
+    status = 'handoff_submitted';
+  }
+
+  return {
+    executionActivationRecordId: input.executionActivationRecordId,
+    status,
+    reasonTokens: uniqueSortedStrings([
+      `status:${status}`,
+      `queue_state:${input.queueEntry?.queueState ?? 'none'}`,
+      `feedback_count:${String(input.feedbackLinks.length)}`,
+    ]),
+  };
+}

--- a/control-plane/mission-control/execution-request-activation-mapping.ts
+++ b/control-plane/mission-control/execution-request-activation-mapping.ts
@@ -1,0 +1,62 @@
+import {
+  deriveExecutionRequestActivationMappingId,
+  uniqueSortedStrings,
+} from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationRule,
+  ExecutionRequestActivationMapping,
+} from './mission-execution-activation-types.ts';
+import type { ExecutionActivationRecord } from './mission-execution-activation-types.ts';
+import type { ExecutionRequestRecord } from './mission-execution-coordination-types.ts';
+
+function activationRuleForRequest(request: ExecutionRequestRecord): ExecutionActivationRule {
+  if (request.requestClass === 'monitoring_request') {
+    return 'monitoring_activation';
+  }
+  if (request.requestClass === 'review_execution_request') {
+    return 'review_activation';
+  }
+  if (request.requestClass === 'stabilization_request') {
+    return 'stabilization_followup_activation';
+  }
+  return 'standard_task_activation';
+}
+
+export function deriveExecutionRequestActivationMappings(input: {
+  requests: ExecutionRequestRecord[];
+  activationRecords: ExecutionActivationRecord[];
+}): ExecutionRequestActivationMapping[] {
+  const activationByRequestId = new Map(
+    input.activationRecords.map((entry) => [entry.executionRequestRecordId, entry])
+  );
+
+  return input.requests
+    .map((request) => {
+      const activation = activationByRequestId.get(request.executionRequestRecordId);
+      if (!activation) {
+        return null;
+      }
+
+      const activationRule = activationRuleForRequest(request);
+      const reasonTokens = uniqueSortedStrings([
+        ...request.reasonTokens,
+        `activation_rule:${activationRule}`,
+      ]);
+
+      return {
+        executionRequestActivationMappingId: deriveExecutionRequestActivationMappingId({
+          executionRequestRecordId: request.executionRequestRecordId,
+          executionActivationRecordId: activation.executionActivationRecordId,
+          activationRule,
+          reasonTokens,
+        }),
+        executionRequestRecordId: request.executionRequestRecordId,
+        executionActivationRecordId: activation.executionActivationRecordId,
+        activationRule,
+        reasonTokens,
+        state: 'active',
+      } satisfies ExecutionRequestActivationMapping;
+    })
+    .filter((entry): entry is ExecutionRequestActivationMapping => entry !== null)
+    .sort((left, right) => left.executionRequestActivationMappingId.localeCompare(right.executionRequestActivationMappingId));
+}

--- a/control-plane/mission-control/mission-execution-activation-history-store.ts
+++ b/control-plane/mission-control/mission-execution-activation-history-store.ts
@@ -1,0 +1,238 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+
+import {
+  deriveExecutionActivationHistoryEventDedupeKey,
+  normalizeCanonicalRecord,
+  uniqueSortedStrings,
+} from './mission-execution-activation-identity.ts';
+import {
+  EXECUTION_ACTIVATION_HISTORY_EVENT_TYPES,
+  type ExecutionActivationHistory,
+  type ExecutionActivationHistoryEvent,
+  type ExecutionActivationHistoryEventType,
+} from './mission-execution-activation-types.ts';
+import { resolveMissionControlArtifactsRoot } from './mission-run-history-store.ts';
+
+function normalizeRelativeSegment(value: string, fieldName: string): string {
+  const normalized = value.trim().replace(/\\/g, '/').replace(/^\/+/, '');
+  if (normalized.length === 0 || normalized.includes('..') || normalized.includes('/')) {
+    throw new Error(`INVALID_${fieldName.toUpperCase()}: ${value}`);
+  }
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function parseEventType(value: unknown): ExecutionActivationHistoryEventType | null {
+  const parsed = asString(value);
+  if (!parsed) {
+    return null;
+  }
+
+  return EXECUTION_ACTIVATION_HISTORY_EVENT_TYPES.includes(parsed as ExecutionActivationHistoryEventType)
+    ? (parsed as ExecutionActivationHistoryEventType)
+    : null;
+}
+
+function parseEntry(value: unknown): ExecutionActivationHistoryEvent {
+  if (!isRecord(value)) {
+    throw new Error('MISSION_EXECUTION_ACTIVATION_INVALID_HISTORY_ENTRY');
+  }
+
+  const executionActivationRecordId = asString(value.executionActivationRecordId);
+  const eventType = parseEventType(value.eventType);
+  const eventDedupeKey = asString(value.eventDedupeKey);
+
+  if (!executionActivationRecordId || !eventType || !eventDedupeKey || !isRecord(value.payload)) {
+    throw new Error('MISSION_EXECUTION_ACTIVATION_INVALID_HISTORY_ENTRY');
+  }
+
+  return {
+    executionActivationRecordId,
+    eventType,
+    eventDedupeKey,
+    reasonTokens: uniqueSortedStrings(
+      Array.isArray(value.reasonTokens)
+        ? value.reasonTokens.filter((entry): entry is string => typeof entry === 'string')
+        : []
+    ),
+    payload: normalizeCanonicalRecord(value.payload),
+  };
+}
+
+function compareEntries(left: ExecutionActivationHistoryEvent, right: ExecutionActivationHistoryEvent): number {
+  return left.eventDedupeKey.localeCompare(right.eventDedupeKey);
+}
+
+function readHistoryFile(filePath: string, fallback: ExecutionActivationHistory): ExecutionActivationHistory {
+  if (!fs.existsSync(filePath)) {
+    return fallback;
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('MISSION_EXECUTION_ACTIVATION_INVALID_HISTORY');
+  }
+
+  const executionActivationRecordId = asString(parsed.executionActivationRecordId);
+  if (!executionActivationRecordId) {
+    throw new Error('MISSION_EXECUTION_ACTIVATION_INVALID_HISTORY');
+  }
+
+  const entries = Array.isArray(parsed.entries)
+    ? parsed.entries.map((entry) => parseEntry(entry)).sort(compareEntries)
+    : [];
+
+  return {
+    executionActivationRecordId,
+    entries,
+  };
+}
+
+export function resolveMissionExecutionActivationArtifactDir(input: {
+  executionActivationRecordId: string;
+  rootDir?: string;
+}): string {
+  const executionActivationRecordId = normalizeRelativeSegment(
+    input.executionActivationRecordId,
+    'execution_activation_record_id'
+  );
+  return path.join(path.resolve(input.rootDir ?? resolveMissionControlArtifactsRoot()), 'activation', executionActivationRecordId);
+}
+
+export function ensureMissionExecutionActivationArtifactDir(input: {
+  executionActivationRecordId: string;
+  rootDir?: string;
+}): string {
+  const dirPath = resolveMissionExecutionActivationArtifactDir(input);
+  fs.mkdirSync(dirPath, { recursive: true });
+  return dirPath;
+}
+
+export function resolveMissionExecutionActivationArtifactPaths(input: {
+  executionActivationRecordId: string;
+  rootDir?: string;
+}): {
+  dirPath: string;
+  statusJsonPath: string;
+  mappingJsonPath: string;
+  eligibilityJsonPath: string;
+  queueJsonPath: string;
+  feedbackLinksJsonPath: string;
+  historyJsonPath: string;
+  outcomeJsonPath: string;
+  reportJsonPath: string;
+  reportMarkdownPath: string;
+} {
+  const dirPath = resolveMissionExecutionActivationArtifactDir(input);
+
+  return {
+    dirPath,
+    statusJsonPath: path.join(dirPath, 'mission-execution-activation-status.json'),
+    mappingJsonPath: path.join(dirPath, 'mission-execution-activation-mapping.json'),
+    eligibilityJsonPath: path.join(dirPath, 'mission-execution-activation-eligibility.json'),
+    queueJsonPath: path.join(dirPath, 'mission-execution-activation-queue.json'),
+    feedbackLinksJsonPath: path.join(dirPath, 'mission-execution-activation-feedback-links.json'),
+    historyJsonPath: path.join(dirPath, 'mission-execution-activation-history.json'),
+    outcomeJsonPath: path.join(dirPath, 'mission-execution-activation-outcome.json'),
+    reportJsonPath: path.join(dirPath, 'mission-execution-activation-report.json'),
+    reportMarkdownPath: path.join(dirPath, 'mission-execution-activation-report.md'),
+  };
+}
+
+export function createMissionExecutionActivationHistoryStore(options: { artifactsRoot?: string } = {}) {
+  const artifactsRoot = path.resolve(options.artifactsRoot ?? resolveMissionControlArtifactsRoot());
+
+  function load(input: { executionActivationRecordId: string }): ExecutionActivationHistory {
+    const paths = resolveMissionExecutionActivationArtifactPaths({
+      executionActivationRecordId: input.executionActivationRecordId,
+      rootDir: artifactsRoot,
+    });
+
+    return readHistoryFile(paths.historyJsonPath, {
+      executionActivationRecordId: input.executionActivationRecordId,
+      entries: [],
+    });
+  }
+
+  function appendEvent(input: {
+    executionActivationRecordId: string;
+    eventType: ExecutionActivationHistoryEventType;
+    reasonTokens?: string[];
+    payload: Record<string, unknown>;
+  }): { history: ExecutionActivationHistory; appended: boolean; entry: ExecutionActivationHistoryEvent } {
+    ensureMissionExecutionActivationArtifactDir({
+      executionActivationRecordId: input.executionActivationRecordId,
+      rootDir: artifactsRoot,
+    });
+
+    const entry: ExecutionActivationHistoryEvent = {
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: input.eventType,
+      eventDedupeKey: deriveExecutionActivationHistoryEventDedupeKey(input),
+      reasonTokens: uniqueSortedStrings(input.reasonTokens),
+      payload: normalizeCanonicalRecord(input.payload),
+    };
+
+    const current = load({ executionActivationRecordId: input.executionActivationRecordId });
+    if (current.entries.some((row) => row.eventDedupeKey === entry.eventDedupeKey)) {
+      return { history: current, appended: false, entry };
+    }
+
+    const next: ExecutionActivationHistory = {
+      executionActivationRecordId: input.executionActivationRecordId,
+      entries: [...current.entries, entry].sort(compareEntries),
+    };
+
+    const paths = resolveMissionExecutionActivationArtifactPaths({
+      executionActivationRecordId: input.executionActivationRecordId,
+      rootDir: artifactsRoot,
+    });
+
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(next)}\n`, 'utf8');
+
+    return { history: next, appended: true, entry };
+  }
+
+  function replay(input: { executionActivationRecordId: string }): ExecutionActivationHistoryEvent[] {
+    return [...load(input).entries].sort(compareEntries);
+  }
+
+  function write(history: ExecutionActivationHistory): string {
+    ensureMissionExecutionActivationArtifactDir({
+      executionActivationRecordId: history.executionActivationRecordId,
+      rootDir: artifactsRoot,
+    });
+
+    const normalized: ExecutionActivationHistory = {
+      executionActivationRecordId: history.executionActivationRecordId,
+      entries: [...history.entries].sort(compareEntries),
+    };
+
+    const paths = resolveMissionExecutionActivationArtifactPaths({
+      executionActivationRecordId: history.executionActivationRecordId,
+      rootDir: artifactsRoot,
+    });
+
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(normalized)}\n`, 'utf8');
+    return paths.historyJsonPath;
+  }
+
+  return {
+    appendEvent,
+    load,
+    replay,
+    write,
+  };
+}
+
+export type MissionExecutionActivationHistoryStore = ReturnType<typeof createMissionExecutionActivationHistoryStore>;

--- a/control-plane/mission-control/mission-execution-activation-identity.ts
+++ b/control-plane/mission-control/mission-execution-activation-identity.ts
@@ -1,0 +1,137 @@
+import { canonicalStringify, sha256 } from '../finance/determinism.ts';
+
+import type {
+  ExecutionActivationFeedbackClass,
+  ExecutionActivationHistoryEventType,
+  ExecutionActivationRule,
+  ExecutionActivationStatus,
+  ExecutionActivationEligibilityValue,
+  MissionExecutionActivationQueueState,
+} from './mission-execution-activation-types.ts';
+
+export function uniqueSortedStrings(values: string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).map((value) => value.trim()).filter((value) => value.length > 0)))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function normalizeCanonicalRecord(payload: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(canonicalStringify(payload)) as Record<string, unknown>;
+}
+
+export function deriveExecutionActivationRecordId(input: {
+  executionRequestRecordId: string;
+  missionExecutionCoordinationPlanId: string;
+  executionIntentId: string;
+  targetExecutionDomain: string;
+  priority: string;
+}): string {
+  return sha256(canonicalStringify({
+    executionRequestRecordId: input.executionRequestRecordId,
+    missionExecutionCoordinationPlanId: input.missionExecutionCoordinationPlanId,
+    executionIntentId: input.executionIntentId,
+    targetExecutionDomain: input.targetExecutionDomain,
+    priority: input.priority,
+  }));
+}
+
+export function deriveExecutionRequestActivationMappingId(input: {
+  executionRequestRecordId: string;
+  executionActivationRecordId: string;
+  activationRule: ExecutionActivationRule;
+  reasonTokens?: string[];
+}): string {
+  return sha256(canonicalStringify({
+    executionRequestRecordId: input.executionRequestRecordId,
+    executionActivationRecordId: input.executionActivationRecordId,
+    activationRule: input.activationRule,
+    reasonTokens: uniqueSortedStrings(input.reasonTokens),
+  }));
+}
+
+export function deriveExecutionActivationEligibilityId(input: {
+  executionRequestRecordId: string;
+  eligibilityStatus: ExecutionActivationEligibilityValue;
+  reasonTokens?: string[];
+  blockingConditionTokens?: string[];
+}): string {
+  return sha256(canonicalStringify({
+    executionRequestRecordId: input.executionRequestRecordId,
+    eligibilityStatus: input.eligibilityStatus,
+    reasonTokens: uniqueSortedStrings(input.reasonTokens),
+    blockingConditionTokens: uniqueSortedStrings(input.blockingConditionTokens),
+  }));
+}
+
+export function deriveMissionExecutionActivationQueueEntryId(input: {
+  executionActivationRecordId: string;
+  priority: string;
+  queueState: MissionExecutionActivationQueueState;
+  reasonTokens?: string[];
+}): string {
+  return sha256(canonicalStringify({
+    executionActivationRecordId: input.executionActivationRecordId,
+    priority: input.priority,
+    queueState: input.queueState,
+    reasonTokens: uniqueSortedStrings(input.reasonTokens),
+  }));
+}
+
+export function deriveExecutionActivationFeedbackLinkId(input: {
+  executionActivationRecordId: string;
+  executionRequestRecordId: string;
+  executionAttemptId?: string | null;
+  taskExecutionRunId?: string | null;
+  workerResultId?: string | null;
+  feedbackClass: ExecutionActivationFeedbackClass;
+}): string {
+  return sha256(canonicalStringify({
+    executionActivationRecordId: input.executionActivationRecordId,
+    executionRequestRecordId: input.executionRequestRecordId,
+    executionAttemptId: input.executionAttemptId ?? null,
+    taskExecutionRunId: input.taskExecutionRunId ?? null,
+    workerResultId: input.workerResultId ?? null,
+    feedbackClass: input.feedbackClass,
+  }));
+}
+
+export function deriveExecutionActivationHistoryEventDedupeKey(input: {
+  executionActivationRecordId: string;
+  eventType: ExecutionActivationHistoryEventType;
+  reasonTokens?: string[];
+  payload: Record<string, unknown>;
+}): string {
+  return sha256(canonicalStringify({
+    executionActivationRecordId: input.executionActivationRecordId,
+    eventType: input.eventType,
+    reasonTokens: uniqueSortedStrings(input.reasonTokens),
+    payload: normalizeCanonicalRecord(input.payload),
+  }));
+}
+
+export function deriveActivationStatusFromQueueState(input: {
+  queueState: MissionExecutionActivationQueueState | null;
+  hasFeedback: boolean;
+}): ExecutionActivationStatus {
+  if (input.queueState === 'deferred') {
+    return 'activation_deferred';
+  }
+  if (input.queueState === 'blocked') {
+    return 'activation_failed';
+  }
+  if (input.queueState === 'closed') {
+    return 'activation_completed';
+  }
+  if (input.queueState === 'under_activation') {
+    return 'activation_active';
+  }
+  if (input.queueState === 'handoff_submitted') {
+    return 'handoff_submitted';
+  }
+  if (input.queueState === 'queued' || input.queueState === 'awaiting_handoff') {
+    return 'pending_activation';
+  }
+  if (input.hasFeedback) {
+    return 'pending_activation';
+  }
+  return 'not_started';
+}

--- a/control-plane/mission-control/mission-execution-activation-inspection.ts
+++ b/control-plane/mission-control/mission-execution-activation-inspection.ts
@@ -1,0 +1,100 @@
+import {
+  createMissionExecutionActivationHistoryStore,
+  type MissionExecutionActivationHistoryStore,
+} from './mission-execution-activation-history-store.ts';
+import {
+  createMissionExecutionActivationProjection,
+  type MissionExecutionActivationProjectionEngine,
+} from './mission-execution-activation-projection.ts';
+
+export function createMissionExecutionActivationInspection(options: {
+  projection?: MissionExecutionActivationProjectionEngine;
+  historyStore?: MissionExecutionActivationHistoryStore;
+  missionDefinitionsDir?: string;
+  missionInstancesDir?: string;
+  missionArtifactsRoot?: string;
+  teamDefinitionsDir?: string;
+  compatibilityArtifactsRoot?: string;
+  assignmentArtifactsRoot?: string;
+  activationArtifactsRoot?: string;
+  executionContractArtifactsRoot?: string;
+  runtimeEnvelopeArtifactsRoot?: string;
+  executionAttemptArtifactsRoot?: string;
+  executionJournalArtifactsRoot?: string;
+  executionEngineArtifactsRoot?: string;
+  taskGraphArtifactsRoot?: string;
+  taskExecutionArtifactsRoot?: string;
+  missionControlArtifactsRoot?: string;
+} = {}) {
+  const projection = options.projection ?? createMissionExecutionActivationProjection({
+    missionDefinitionsDir: options.missionDefinitionsDir,
+    missionInstancesDir: options.missionInstancesDir,
+    missionArtifactsRoot: options.missionArtifactsRoot,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    compatibilityArtifactsRoot: options.compatibilityArtifactsRoot,
+    assignmentArtifactsRoot: options.assignmentArtifactsRoot,
+    activationArtifactsRoot: options.activationArtifactsRoot,
+    executionContractArtifactsRoot: options.executionContractArtifactsRoot,
+    runtimeEnvelopeArtifactsRoot: options.runtimeEnvelopeArtifactsRoot,
+    executionAttemptArtifactsRoot: options.executionAttemptArtifactsRoot,
+    executionJournalArtifactsRoot: options.executionJournalArtifactsRoot,
+    executionEngineArtifactsRoot: options.executionEngineArtifactsRoot,
+    taskGraphArtifactsRoot: options.taskGraphArtifactsRoot,
+    taskExecutionArtifactsRoot: options.taskExecutionArtifactsRoot,
+    missionControlArtifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  const historyStore = options.historyStore ?? createMissionExecutionActivationHistoryStore({
+    artifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  function listActivationRecords() {
+    return projection.listActivationRecords();
+  }
+
+  function inspectActivationRecord(input: { executionActivationRecordId: string }) {
+    return projection.projectOne(input);
+  }
+
+  function inspectRequestActivationMappings(input: { executionActivationRecordId: string }) {
+    return inspectActivationRecord(input).mapping;
+  }
+
+  function inspectActivationEligibility(input: { executionActivationRecordId: string }) {
+    return inspectActivationRecord(input).eligibility;
+  }
+
+  function inspectActivationQueue(input: { executionActivationRecordId: string }) {
+    return inspectActivationRecord(input).queueEntry;
+  }
+
+  function inspectActivationFeedbackLinks(input: { executionActivationRecordId: string }) {
+    return inspectActivationRecord(input).feedbackLinkSummaries;
+  }
+
+  function inspectActivationHistory(input: { executionActivationRecordId: string }) {
+    return historyStore.load(input);
+  }
+
+  function inspectActivationStatus(input: { executionActivationRecordId: string }) {
+    return inspectActivationRecord(input).status;
+  }
+
+  function inspectActivationOutcome(input: { executionActivationRecordId: string }) {
+    return inspectActivationRecord(input).outcome;
+  }
+
+  return {
+    listActivationRecords,
+    inspectActivationRecord,
+    inspectRequestActivationMappings,
+    inspectActivationEligibility,
+    inspectActivationQueue,
+    inspectActivationFeedbackLinks,
+    inspectActivationHistory,
+    inspectActivationStatus,
+    inspectActivationOutcome,
+  };
+}
+
+export type MissionExecutionActivationInspection = ReturnType<typeof createMissionExecutionActivationInspection>;

--- a/control-plane/mission-control/mission-execution-activation-manager.ts
+++ b/control-plane/mission-control/mission-execution-activation-manager.ts
@@ -1,0 +1,232 @@
+import {
+  createMissionExecutionActivationHistoryStore,
+  type MissionExecutionActivationHistoryStore,
+} from './mission-execution-activation-history-store.ts';
+import {
+  createMissionExecutionActivationMaterializer,
+  type MissionExecutionActivationMaterializer,
+} from './mission-execution-activation-materializer.ts';
+import {
+  createMissionExecutionActivationProjection,
+  type MissionExecutionActivationProjectionEngine,
+} from './mission-execution-activation-projection.ts';
+import { uniqueSortedStrings } from './mission-execution-activation-identity.ts';
+import type { ExecutionActivationFeedbackClass } from './mission-execution-activation-types.ts';
+
+export function createMissionExecutionActivationManager(options: {
+  projection?: MissionExecutionActivationProjectionEngine;
+  historyStore?: MissionExecutionActivationHistoryStore;
+  materializer?: MissionExecutionActivationMaterializer;
+  missionDefinitionsDir?: string;
+  missionInstancesDir?: string;
+  missionArtifactsRoot?: string;
+  teamDefinitionsDir?: string;
+  compatibilityArtifactsRoot?: string;
+  assignmentArtifactsRoot?: string;
+  activationArtifactsRoot?: string;
+  executionContractArtifactsRoot?: string;
+  runtimeEnvelopeArtifactsRoot?: string;
+  executionAttemptArtifactsRoot?: string;
+  executionJournalArtifactsRoot?: string;
+  executionEngineArtifactsRoot?: string;
+  taskGraphArtifactsRoot?: string;
+  taskExecutionArtifactsRoot?: string;
+  missionControlArtifactsRoot?: string;
+} = {}) {
+  const historyStore = options.historyStore ?? createMissionExecutionActivationHistoryStore({
+    artifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  const projection = options.projection ?? createMissionExecutionActivationProjection({
+    historyStore,
+    missionDefinitionsDir: options.missionDefinitionsDir,
+    missionInstancesDir: options.missionInstancesDir,
+    missionArtifactsRoot: options.missionArtifactsRoot,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    compatibilityArtifactsRoot: options.compatibilityArtifactsRoot,
+    assignmentArtifactsRoot: options.assignmentArtifactsRoot,
+    activationArtifactsRoot: options.activationArtifactsRoot,
+    executionContractArtifactsRoot: options.executionContractArtifactsRoot,
+    runtimeEnvelopeArtifactsRoot: options.runtimeEnvelopeArtifactsRoot,
+    executionAttemptArtifactsRoot: options.executionAttemptArtifactsRoot,
+    executionJournalArtifactsRoot: options.executionJournalArtifactsRoot,
+    executionEngineArtifactsRoot: options.executionEngineArtifactsRoot,
+    taskGraphArtifactsRoot: options.taskGraphArtifactsRoot,
+    taskExecutionArtifactsRoot: options.taskExecutionArtifactsRoot,
+    missionControlArtifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  const materializer = options.materializer ?? createMissionExecutionActivationMaterializer({
+    projection,
+    historyStore,
+    missionDefinitionsDir: options.missionDefinitionsDir,
+    missionInstancesDir: options.missionInstancesDir,
+    missionArtifactsRoot: options.missionArtifactsRoot,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    compatibilityArtifactsRoot: options.compatibilityArtifactsRoot,
+    assignmentArtifactsRoot: options.assignmentArtifactsRoot,
+    activationArtifactsRoot: options.activationArtifactsRoot,
+    executionContractArtifactsRoot: options.executionContractArtifactsRoot,
+    runtimeEnvelopeArtifactsRoot: options.runtimeEnvelopeArtifactsRoot,
+    executionAttemptArtifactsRoot: options.executionAttemptArtifactsRoot,
+    executionJournalArtifactsRoot: options.executionJournalArtifactsRoot,
+    executionEngineArtifactsRoot: options.executionEngineArtifactsRoot,
+    taskGraphArtifactsRoot: options.taskGraphArtifactsRoot,
+    taskExecutionArtifactsRoot: options.taskExecutionArtifactsRoot,
+    missionControlArtifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  function evaluateExecutionActivationRecord(input: { executionActivationRecordId: string }) {
+    const projected = projection.projectOne(input);
+
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'execution_activation_record_created',
+      reasonTokens: uniqueSortedStrings([
+        `state:${projected.activationRecord.state}`,
+        `priority:${projected.activationRecord.priority}`,
+      ]),
+      payload: {
+        activationRecord: projected.activationRecord,
+      },
+    });
+
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'execution_activation_eligibility_evaluated',
+      reasonTokens: projected.eligibility.reasonTokens,
+      payload: {
+        eligibility: projected.eligibility,
+      },
+    });
+
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'execution_activation_queued',
+      reasonTokens: projected.queueEntry?.reasonTokens ?? [],
+      payload: {
+        queueEntry: projected.queueEntry,
+      },
+    });
+
+    for (const feedbackLink of projected.feedbackLinkSummaries) {
+      historyStore.appendEvent({
+        executionActivationRecordId: input.executionActivationRecordId,
+        eventType: 'execution_activation_feedback_linked',
+        reasonTokens: uniqueSortedStrings([
+          `feedback_class:${feedbackLink.feedbackClass}`,
+          `execution_request_record_id:${feedbackLink.executionRequestRecordId}`,
+        ]),
+        payload: feedbackLink as unknown as Record<string, unknown>,
+      });
+    }
+
+    return projection.projectOne(input);
+  }
+
+  function linkActivationFeedback(input: {
+    executionActivationRecordId: string;
+    executionRequestRecordId: string;
+    executionAttemptId?: string | null;
+    taskExecutionRunId?: string | null;
+    workerResultId?: string | null;
+    feedbackClass: ExecutionActivationFeedbackClass;
+    reasonTokens?: string[];
+  }) {
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: input.feedbackClass === 'handoff_submitted'
+        ? 'execution_activation_handoff_submitted'
+        : 'execution_activation_feedback_linked',
+      reasonTokens: uniqueSortedStrings([
+        `feedback_class:${input.feedbackClass}`,
+        ...(input.reasonTokens ?? []),
+      ]),
+      payload: {
+        executionActivationRecordId: input.executionActivationRecordId,
+        executionRequestRecordId: input.executionRequestRecordId,
+        executionAttemptId: input.executionAttemptId ?? null,
+        taskExecutionRunId: input.taskExecutionRunId ?? null,
+        workerResultId: input.workerResultId ?? null,
+        feedbackClass: input.feedbackClass,
+      },
+    });
+
+    return projection.projectOne({ executionActivationRecordId: input.executionActivationRecordId });
+  }
+
+  function deferExecutionActivationRecord(input: {
+    executionActivationRecordId: string;
+    reasonTokens?: string[];
+  }) {
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'execution_activation_deferred',
+      reasonTokens: uniqueSortedStrings(['state:deferred', ...(input.reasonTokens ?? [])]),
+      payload: {
+        executionActivationRecordId: input.executionActivationRecordId,
+      },
+    });
+
+    return projection.projectOne({ executionActivationRecordId: input.executionActivationRecordId });
+  }
+
+  function markExecutionActivationSubmitted(input: {
+    executionActivationRecordId: string;
+    reasonTokens?: string[];
+  }) {
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'execution_activation_handoff_submitted',
+      reasonTokens: uniqueSortedStrings(['status:handoff_submitted', ...(input.reasonTokens ?? [])]),
+      payload: {
+        executionActivationRecordId: input.executionActivationRecordId,
+      },
+    });
+
+    return projection.projectOne({ executionActivationRecordId: input.executionActivationRecordId });
+  }
+
+  function markExecutionActivationComplete(input: {
+    executionActivationRecordId: string;
+    reasonTokens?: string[];
+  }) {
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'execution_activation_completed',
+      reasonTokens: uniqueSortedStrings(['outcome:completed', ...(input.reasonTokens ?? [])]),
+      payload: {
+        executionActivationRecordId: input.executionActivationRecordId,
+      },
+    });
+
+    return projection.projectOne({ executionActivationRecordId: input.executionActivationRecordId });
+  }
+
+  function materializeExecutionActivationRecord(input: { executionActivationRecordId: string }) {
+    evaluateExecutionActivationRecord(input);
+    const materialized = materializer.materializeOne(input);
+
+    historyStore.appendEvent({
+      executionActivationRecordId: input.executionActivationRecordId,
+      eventType: 'mission_execution_activation_materialized',
+      reasonTokens: uniqueSortedStrings([`materialized:${input.executionActivationRecordId}`]),
+      payload: {
+        executionActivationRecordId: input.executionActivationRecordId,
+      },
+    });
+
+    return materialized;
+  }
+
+  return {
+    evaluateExecutionActivationRecord,
+    linkActivationFeedback,
+    deferExecutionActivationRecord,
+    markExecutionActivationSubmitted,
+    markExecutionActivationComplete,
+    materializeExecutionActivationRecord,
+  };
+}
+
+export type MissionExecutionActivationManager = ReturnType<typeof createMissionExecutionActivationManager>;

--- a/control-plane/mission-control/mission-execution-activation-materializer.ts
+++ b/control-plane/mission-control/mission-execution-activation-materializer.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+
+import { canonicalStringify } from '../finance/determinism.ts';
+
+import {
+  createMissionExecutionActivationHistoryStore,
+  ensureMissionExecutionActivationArtifactDir,
+  resolveMissionExecutionActivationArtifactPaths,
+  type MissionExecutionActivationHistoryStore,
+} from './mission-execution-activation-history-store.ts';
+import {
+  createMissionExecutionActivationInspection,
+  type MissionExecutionActivationInspection,
+} from './mission-execution-activation-inspection.ts';
+import {
+  createMissionExecutionActivationProjection,
+  type MissionExecutionActivationProjectionEngine,
+} from './mission-execution-activation-projection.ts';
+
+function toMarkdownReport(input: {
+  executionActivationRecordId: string;
+  status: unknown;
+  mapping: unknown;
+  eligibility: unknown;
+  queue: unknown;
+  feedbackLinks: unknown;
+  history: unknown;
+  outcome: unknown;
+  report: unknown;
+}): string {
+  const sections: Array<{ title: string; value: unknown }> = [
+    { title: 'Mission Execution Activation Status', value: input.status },
+    { title: 'Mission Execution Activation Mapping', value: input.mapping },
+    { title: 'Mission Execution Activation Eligibility', value: input.eligibility },
+    { title: 'Mission Execution Activation Queue', value: input.queue },
+    { title: 'Mission Execution Activation Feedback Links', value: input.feedbackLinks },
+    { title: 'Mission Execution Activation History', value: input.history },
+    { title: 'Mission Execution Activation Outcome', value: input.outcome },
+    { title: 'Mission Execution Activation Report', value: input.report },
+  ];
+
+  const lines = [
+    '# Mission Execution Activation Report',
+    '',
+    `Activation Record: ${input.executionActivationRecordId}`,
+    '',
+  ];
+
+  for (const section of sections) {
+    lines.push(`## ${section.title}`);
+    lines.push('');
+    lines.push(canonicalStringify(section.value));
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export interface MissionExecutionActivationMaterializationSummary {
+  executionActivationRecordId: string;
+  statusPath: string;
+  mappingPath: string;
+  eligibilityPath: string;
+  queuePath: string;
+  feedbackLinksPath: string;
+  historyPath: string;
+  outcomePath: string;
+  reportPath: string;
+  reportMarkdownPath: string;
+}
+
+export function createMissionExecutionActivationMaterializer(options: {
+  inspection?: MissionExecutionActivationInspection;
+  projection?: MissionExecutionActivationProjectionEngine;
+  historyStore?: MissionExecutionActivationHistoryStore;
+  missionDefinitionsDir?: string;
+  missionInstancesDir?: string;
+  missionArtifactsRoot?: string;
+  teamDefinitionsDir?: string;
+  compatibilityArtifactsRoot?: string;
+  assignmentArtifactsRoot?: string;
+  activationArtifactsRoot?: string;
+  executionContractArtifactsRoot?: string;
+  runtimeEnvelopeArtifactsRoot?: string;
+  executionAttemptArtifactsRoot?: string;
+  executionJournalArtifactsRoot?: string;
+  executionEngineArtifactsRoot?: string;
+  taskGraphArtifactsRoot?: string;
+  taskExecutionArtifactsRoot?: string;
+  missionControlArtifactsRoot?: string;
+} = {}) {
+  const projection = options.projection ?? createMissionExecutionActivationProjection({
+    missionDefinitionsDir: options.missionDefinitionsDir,
+    missionInstancesDir: options.missionInstancesDir,
+    missionArtifactsRoot: options.missionArtifactsRoot,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    compatibilityArtifactsRoot: options.compatibilityArtifactsRoot,
+    assignmentArtifactsRoot: options.assignmentArtifactsRoot,
+    activationArtifactsRoot: options.activationArtifactsRoot,
+    executionContractArtifactsRoot: options.executionContractArtifactsRoot,
+    runtimeEnvelopeArtifactsRoot: options.runtimeEnvelopeArtifactsRoot,
+    executionAttemptArtifactsRoot: options.executionAttemptArtifactsRoot,
+    executionJournalArtifactsRoot: options.executionJournalArtifactsRoot,
+    executionEngineArtifactsRoot: options.executionEngineArtifactsRoot,
+    taskGraphArtifactsRoot: options.taskGraphArtifactsRoot,
+    taskExecutionArtifactsRoot: options.taskExecutionArtifactsRoot,
+    missionControlArtifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  const inspection = options.inspection ?? createMissionExecutionActivationInspection({
+    projection,
+    missionControlArtifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  const historyStore = options.historyStore ?? createMissionExecutionActivationHistoryStore({
+    artifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  function materializeOne(input: { executionActivationRecordId: string }): MissionExecutionActivationMaterializationSummary {
+    const projected = projection.projectOne(input);
+
+    ensureMissionExecutionActivationArtifactDir({
+      executionActivationRecordId: input.executionActivationRecordId,
+      rootDir: options.missionControlArtifactsRoot,
+    });
+
+    const paths = resolveMissionExecutionActivationArtifactPaths({
+      executionActivationRecordId: input.executionActivationRecordId,
+      rootDir: options.missionControlArtifactsRoot,
+    });
+
+    const status = inspection.inspectActivationStatus(input);
+    const mapping = inspection.inspectRequestActivationMappings(input);
+    const eligibility = inspection.inspectActivationEligibility(input);
+    const queue = inspection.inspectActivationQueue(input);
+    const feedbackLinks = inspection.inspectActivationFeedbackLinks(input);
+    const history = historyStore.load(input);
+    const outcome = inspection.inspectActivationOutcome(input);
+    const report = projected.reportPreview;
+
+    fs.writeFileSync(paths.statusJsonPath, `${canonicalStringify(status)}\n`, 'utf8');
+    fs.writeFileSync(paths.mappingJsonPath, `${canonicalStringify(mapping)}\n`, 'utf8');
+    fs.writeFileSync(paths.eligibilityJsonPath, `${canonicalStringify(eligibility)}\n`, 'utf8');
+    fs.writeFileSync(paths.queueJsonPath, `${canonicalStringify(queue)}\n`, 'utf8');
+    fs.writeFileSync(paths.feedbackLinksJsonPath, `${canonicalStringify(feedbackLinks)}\n`, 'utf8');
+    fs.writeFileSync(paths.historyJsonPath, `${canonicalStringify(history)}\n`, 'utf8');
+    fs.writeFileSync(paths.outcomeJsonPath, `${canonicalStringify(outcome)}\n`, 'utf8');
+    fs.writeFileSync(paths.reportJsonPath, `${canonicalStringify(report)}\n`, 'utf8');
+    fs.writeFileSync(paths.reportMarkdownPath, toMarkdownReport({
+      executionActivationRecordId: input.executionActivationRecordId,
+      status,
+      mapping,
+      eligibility,
+      queue,
+      feedbackLinks,
+      history,
+      outcome,
+      report,
+    }), 'utf8');
+
+    return {
+      executionActivationRecordId: input.executionActivationRecordId,
+      statusPath: paths.statusJsonPath,
+      mappingPath: paths.mappingJsonPath,
+      eligibilityPath: paths.eligibilityJsonPath,
+      queuePath: paths.queueJsonPath,
+      feedbackLinksPath: paths.feedbackLinksJsonPath,
+      historyPath: paths.historyJsonPath,
+      outcomePath: paths.outcomeJsonPath,
+      reportPath: paths.reportJsonPath,
+      reportMarkdownPath: paths.reportMarkdownPath,
+    };
+  }
+
+  return {
+    materializeOne,
+  };
+}
+
+export type MissionExecutionActivationMaterializer = ReturnType<typeof createMissionExecutionActivationMaterializer>;

--- a/control-plane/mission-control/mission-execution-activation-projection.ts
+++ b/control-plane/mission-control/mission-execution-activation-projection.ts
@@ -1,0 +1,290 @@
+import { createExecutionActivationRecord, sortExecutionActivationRecords } from './execution-activation-record.ts';
+import { deriveExecutionActivationEligibility, type RuntimeCapabilitySurface } from './execution-activation-eligibility.ts';
+import { deriveExecutionActivationFeedbackLinks, summarizeLinkedExecutionAttemptIds } from './execution-activation-feedback-link.ts';
+import { deriveExecutionActivationOutcome } from './execution-activation-outcome.ts';
+import { deriveExecutionActivationStatus } from './execution-activation-status.ts';
+import { deriveExecutionRequestActivationMappings } from './execution-request-activation-mapping.ts';
+import {
+  createMissionExecutionActivationHistoryStore,
+  type MissionExecutionActivationHistoryStore,
+} from './mission-execution-activation-history-store.ts';
+import { deriveMissionExecutionActivationQueueEntry, sortMissionExecutionActivationQueue } from './mission-execution-activation-queue.ts';
+import {
+  createMissionExecutionCoordinationProjection,
+  type MissionExecutionCoordinationProjectionEngine,
+} from './mission-execution-coordination-projection.ts';
+import type {
+  ExecutionActivationFeedbackClass,
+  ExecutionActivationFeedbackLink,
+  MissionExecutionActivationProjection,
+} from './mission-execution-activation-types.ts';
+
+function feedbackLinksFromHistory(input: {
+  executionActivationRecordId: string;
+  executionRequestRecordId: string;
+  historyEntries: ReturnType<MissionExecutionActivationHistoryStore['replay']>;
+}): ExecutionActivationFeedbackLink[] {
+  return input.historyEntries
+    .filter((entry) => entry.eventType === 'execution_activation_feedback_linked')
+    .map((entry) => {
+      const payload = entry.payload;
+      if (
+        typeof payload.executionActivationFeedbackLinkId !== 'string'
+        || typeof payload.executionActivationRecordId !== 'string'
+        || typeof payload.executionRequestRecordId !== 'string'
+        || typeof payload.feedbackClass !== 'string'
+      ) {
+        return null;
+      }
+
+      return {
+        executionActivationFeedbackLinkId: payload.executionActivationFeedbackLinkId,
+        executionActivationRecordId: payload.executionActivationRecordId,
+        executionRequestRecordId: payload.executionRequestRecordId,
+        executionAttemptId: typeof payload.executionAttemptId === 'string' ? payload.executionAttemptId : null,
+        taskExecutionRunId: typeof payload.taskExecutionRunId === 'string' ? payload.taskExecutionRunId : null,
+        workerResultId: typeof payload.workerResultId === 'string' ? payload.workerResultId : null,
+        feedbackClass: payload.feedbackClass as ExecutionActivationFeedbackClass,
+        state: 'linked',
+      } satisfies ExecutionActivationFeedbackLink;
+    })
+    .filter((entry): entry is ExecutionActivationFeedbackLink => entry !== null)
+    .sort((left, right) => left.executionActivationFeedbackLinkId.localeCompare(right.executionActivationFeedbackLinkId));
+}
+
+function projectFromCoordination(input: {
+  coordination: ReturnType<MissionExecutionCoordinationProjectionEngine['projectOne']>;
+  historyStore: MissionExecutionActivationHistoryStore;
+  runtimeCapabilities?: RuntimeCapabilitySurface[];
+  feedbackRecords?: Array<{
+    executionActivationRecordId?: string;
+    executionRequestRecordId: string;
+    executionAttemptId?: string | null;
+    taskExecutionRunId?: string | null;
+    workerResultId?: string | null;
+    feedbackClass: ExecutionActivationFeedbackClass;
+  }>;
+}): MissionExecutionActivationProjection[] {
+  const activationRecords = sortExecutionActivationRecords(
+    input.coordination.executionRequestSummaries.map((request) => createExecutionActivationRecord({ request }))
+  );
+
+  const mappings = deriveExecutionRequestActivationMappings({
+    requests: input.coordination.executionRequestSummaries,
+    activationRecords,
+  });
+
+  const mappingByActivationId = new Map(mappings.map((entry) => [entry.executionActivationRecordId, entry]));
+
+  const feedbackLinksFromRuntime = deriveExecutionActivationFeedbackLinks({
+    activationRecords,
+    feedbackRecords: input.feedbackRecords,
+  });
+
+  return activationRecords
+    .map((activationRecord) => {
+      const request = input.coordination.executionRequestSummaries
+        .find((entry) => entry.executionRequestRecordId === activationRecord.executionRequestRecordId);
+      const mapping = mappingByActivationId.get(activationRecord.executionActivationRecordId);
+
+      if (!request || !mapping) {
+        return null;
+      }
+
+      const activationHistory = input.historyStore.load({
+        executionActivationRecordId: activationRecord.executionActivationRecordId,
+      });
+
+      const eligibility = deriveExecutionActivationEligibility({
+        request,
+        missionExecutionCoordinationProjection: input.coordination,
+        runtimeCapabilities: input.runtimeCapabilities,
+      });
+
+      const runtimeFeedbackLinks = feedbackLinksFromRuntime
+        .filter((entry) => entry.executionActivationRecordId === activationRecord.executionActivationRecordId);
+
+      const replayFeedbackLinks = feedbackLinksFromHistory({
+        executionActivationRecordId: activationRecord.executionActivationRecordId,
+        executionRequestRecordId: activationRecord.executionRequestRecordId,
+        historyEntries: activationHistory.entries,
+      });
+
+      const feedbackById = new Map(
+        [...runtimeFeedbackLinks, ...replayFeedbackLinks].map((entry) => [entry.executionActivationFeedbackLinkId, entry])
+      );
+      const feedbackLinkSummaries = Array.from(feedbackById.values())
+        .sort((left, right) => left.executionActivationFeedbackLinkId.localeCompare(right.executionActivationFeedbackLinkId));
+
+      const queueEntry = deriveMissionExecutionActivationQueueEntry({
+        activationRecord,
+        eligibility,
+        feedbackLinks: feedbackLinkSummaries,
+        historyEntries: activationHistory.entries,
+      });
+
+      const status = deriveExecutionActivationStatus({
+        executionActivationRecordId: activationRecord.executionActivationRecordId,
+        queueEntry,
+        feedbackLinks: feedbackLinkSummaries,
+        historyEntries: activationHistory.entries,
+      });
+
+      const outcome = deriveExecutionActivationOutcome({
+        executionActivationRecordId: activationRecord.executionActivationRecordId,
+        status,
+        feedbackLinks: feedbackLinkSummaries,
+      });
+
+      const statusPreview = {
+        executionActivationRecordId: activationRecord.executionActivationRecordId,
+        executionRequestRecordId: activationRecord.executionRequestRecordId,
+        missionExecutionCoordinationPlanId: activationRecord.missionExecutionCoordinationPlanId,
+        eligibilityStatus: eligibility.eligibilityStatus,
+        queueState: queueEntry.queueState,
+        status: status.status,
+        outcome: outcome.outcome,
+      } as Record<string, unknown>;
+
+      const reportPreview = {
+        activationRecord,
+        mapping,
+        eligibility,
+        queueEntry,
+        feedbackLinkSummaries,
+        activationHistory,
+        status,
+        outcome,
+      } as Record<string, unknown>;
+
+      return {
+        executionActivationRecordId: activationRecord.executionActivationRecordId,
+        executionRequestRecordId: activationRecord.executionRequestRecordId,
+        missionExecutionCoordinationPlanId: activationRecord.missionExecutionCoordinationPlanId,
+        eligibilityStatus: eligibility.eligibilityStatus,
+        queueState: queueEntry.queueState,
+        feedbackLinkSummaries,
+        status,
+        outcome,
+        priority: activationRecord.priority,
+        linkedExecutionAttemptIds: summarizeLinkedExecutionAttemptIds(feedbackLinkSummaries),
+        activationHistory,
+        activationRecord,
+        mapping,
+        eligibility,
+        queueEntry,
+        statusPreview,
+        reportPreview,
+      } satisfies MissionExecutionActivationProjection;
+    })
+    .filter((entry): entry is MissionExecutionActivationProjection => entry !== null)
+    .sort((left, right) => left.executionActivationRecordId.localeCompare(right.executionActivationRecordId));
+}
+
+export function createMissionExecutionActivationProjection(options: {
+  coordinationProjection?: MissionExecutionCoordinationProjectionEngine;
+  historyStore?: MissionExecutionActivationHistoryStore;
+  runtimeCapabilities?: RuntimeCapabilitySurface[];
+  feedbackRecords?: Array<{
+    executionActivationRecordId?: string;
+    executionRequestRecordId: string;
+    executionAttemptId?: string | null;
+    taskExecutionRunId?: string | null;
+    workerResultId?: string | null;
+    feedbackClass: ExecutionActivationFeedbackClass;
+  }>;
+  missionDefinitionsDir?: string;
+  missionInstancesDir?: string;
+  missionArtifactsRoot?: string;
+  teamDefinitionsDir?: string;
+  compatibilityArtifactsRoot?: string;
+  assignmentArtifactsRoot?: string;
+  activationArtifactsRoot?: string;
+  executionContractArtifactsRoot?: string;
+  runtimeEnvelopeArtifactsRoot?: string;
+  executionAttemptArtifactsRoot?: string;
+  executionJournalArtifactsRoot?: string;
+  executionEngineArtifactsRoot?: string;
+  taskGraphArtifactsRoot?: string;
+  taskExecutionArtifactsRoot?: string;
+  missionControlArtifactsRoot?: string;
+} = {}) {
+  const coordinationProjection = options.coordinationProjection ?? createMissionExecutionCoordinationProjection({
+    missionDefinitionsDir: options.missionDefinitionsDir,
+    missionInstancesDir: options.missionInstancesDir,
+    missionArtifactsRoot: options.missionArtifactsRoot,
+    teamDefinitionsDir: options.teamDefinitionsDir,
+    compatibilityArtifactsRoot: options.compatibilityArtifactsRoot,
+    assignmentArtifactsRoot: options.assignmentArtifactsRoot,
+    activationArtifactsRoot: options.activationArtifactsRoot,
+    executionContractArtifactsRoot: options.executionContractArtifactsRoot,
+    runtimeEnvelopeArtifactsRoot: options.runtimeEnvelopeArtifactsRoot,
+    executionAttemptArtifactsRoot: options.executionAttemptArtifactsRoot,
+    executionJournalArtifactsRoot: options.executionJournalArtifactsRoot,
+    executionEngineArtifactsRoot: options.executionEngineArtifactsRoot,
+    taskGraphArtifactsRoot: options.taskGraphArtifactsRoot,
+    taskExecutionArtifactsRoot: options.taskExecutionArtifactsRoot,
+    missionControlArtifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  const historyStore = options.historyStore ?? createMissionExecutionActivationHistoryStore({
+    artifactsRoot: options.missionControlArtifactsRoot,
+  });
+
+  function projectAll(): MissionExecutionActivationProjection[] {
+    const byId = new Map<string, MissionExecutionActivationProjection>();
+
+    for (const coordination of coordinationProjection.projectAll()) {
+      const projections = projectFromCoordination({
+        coordination,
+        historyStore,
+        runtimeCapabilities: options.runtimeCapabilities,
+        feedbackRecords: options.feedbackRecords,
+      });
+
+      for (const projection of projections) {
+        byId.set(projection.executionActivationRecordId, projection);
+      }
+    }
+
+    return Array.from(byId.values())
+      .sort((left, right) => left.executionActivationRecordId.localeCompare(right.executionActivationRecordId));
+  }
+
+  function projectOne(input: { executionActivationRecordId: string }): MissionExecutionActivationProjection {
+    const found = projectAll().find((entry) => entry.executionActivationRecordId === input.executionActivationRecordId);
+    if (!found) {
+      throw new Error('EXECUTION_ACTIVATION_RECORD_NOT_FOUND');
+    }
+    return found;
+  }
+
+  function listActivationRecords() {
+    return projectAll().map((entry) => ({
+      executionActivationRecordId: entry.executionActivationRecordId,
+      executionRequestRecordId: entry.executionRequestRecordId,
+      missionExecutionCoordinationPlanId: entry.missionExecutionCoordinationPlanId,
+      priority: entry.priority,
+      eligibilityStatus: entry.eligibilityStatus,
+      queueState: entry.queueState,
+      status: entry.status.status,
+      outcome: entry.outcome.outcome,
+    }));
+  }
+
+  function listActivationQueue() {
+    return sortMissionExecutionActivationQueue(
+      projectAll().map((entry) => entry.queueEntry)
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    );
+  }
+
+  return {
+    projectAll,
+    projectOne,
+    listActivationRecords,
+    listActivationQueue,
+  };
+}
+
+export type MissionExecutionActivationProjectionEngine = ReturnType<typeof createMissionExecutionActivationProjection>;

--- a/control-plane/mission-control/mission-execution-activation-queue.ts
+++ b/control-plane/mission-control/mission-execution-activation-queue.ts
@@ -1,0 +1,138 @@
+import {
+  deriveMissionExecutionActivationQueueEntryId,
+  uniqueSortedStrings,
+} from './mission-execution-activation-identity.ts';
+import type {
+  ExecutionActivationEligibility,
+  ExecutionActivationFeedbackLink,
+  ExecutionActivationHistoryEvent,
+  ExecutionActivationRecord,
+  MissionExecutionActivationQueueEntry,
+  MissionExecutionActivationQueueState,
+} from './mission-execution-activation-types.ts';
+
+function priorityRank(priority: string): number {
+  if (priority === 'critical') {
+    return 5;
+  }
+  if (priority === 'high') {
+    return 4;
+  }
+  if (priority === 'normal') {
+    return 3;
+  }
+  if (priority === 'low') {
+    return 2;
+  }
+  return 1;
+}
+
+function deriveQueueState(input: {
+  activationRecord: ExecutionActivationRecord;
+  eligibility: ExecutionActivationEligibility;
+  feedbackLinks: ExecutionActivationFeedbackLink[];
+  historyEntries: ExecutionActivationHistoryEvent[];
+}): MissionExecutionActivationQueueState {
+  if (input.eligibility.eligibilityStatus === 'blocked_from_activation') {
+    return 'blocked';
+  }
+
+  let state: MissionExecutionActivationQueueState = input.eligibility.eligibilityStatus === 'not_eligible'
+    ? 'deferred'
+    : (input.eligibility.eligibilityStatus === 'eligible' ? 'awaiting_handoff' : 'queued');
+
+  for (const entry of input.historyEntries) {
+    if (entry.eventType === 'execution_activation_deferred') {
+      state = 'deferred';
+      continue;
+    }
+    if (entry.eventType === 'execution_activation_handoff_submitted') {
+      state = 'handoff_submitted';
+      continue;
+    }
+    if (entry.eventType === 'execution_activation_completed') {
+      state = 'closed';
+      continue;
+    }
+    if (entry.eventType === 'execution_activation_failed') {
+      state = 'blocked';
+    }
+  }
+
+  const feedbackClasses = input.feedbackLinks.map((entry) => entry.feedbackClass);
+  if (feedbackClasses.includes('execution_inconclusive')) {
+    return 'blocked';
+  }
+  if (feedbackClasses.includes('execution_failed') || feedbackClasses.includes('execution_blocked')) {
+    return 'blocked';
+  }
+  if (feedbackClasses.includes('execution_completed')) {
+    return 'closed';
+  }
+  if (feedbackClasses.includes('execution_started')) {
+    return 'under_activation';
+  }
+  if (feedbackClasses.includes('handoff_submitted')) {
+    return 'handoff_submitted';
+  }
+
+  if (input.activationRecord.state === 'deferred') {
+    return 'deferred';
+  }
+  if (input.activationRecord.state === 'completed') {
+    return 'closed';
+  }
+  if (input.activationRecord.state === 'failed') {
+    return 'blocked';
+  }
+  if (input.activationRecord.state === 'active') {
+    return 'under_activation';
+  }
+  if (input.activationRecord.state === 'submitted') {
+    return 'handoff_submitted';
+  }
+  if (state === 'awaiting_handoff') {
+    return 'awaiting_handoff';
+  }
+  return state;
+}
+
+export function deriveMissionExecutionActivationQueueEntry(input: {
+  activationRecord: ExecutionActivationRecord;
+  eligibility: ExecutionActivationEligibility;
+  feedbackLinks: ExecutionActivationFeedbackLink[];
+  historyEntries: ExecutionActivationHistoryEvent[];
+}): MissionExecutionActivationQueueEntry {
+  const queueState = deriveQueueState(input);
+  const reasonTokens = uniqueSortedStrings([
+    `eligibility:${input.eligibility.eligibilityStatus}`,
+    `queue_state:${queueState}`,
+    `feedback_count:${String(input.feedbackLinks.length)}`,
+  ]);
+
+  return {
+    missionExecutionActivationQueueEntryId: deriveMissionExecutionActivationQueueEntryId({
+      executionActivationRecordId: input.activationRecord.executionActivationRecordId,
+      priority: input.activationRecord.priority,
+      queueState,
+      reasonTokens,
+    }),
+    executionActivationRecordId: input.activationRecord.executionActivationRecordId,
+    priority: input.activationRecord.priority,
+    queueState,
+    reasonTokens,
+    state: queueState === 'closed'
+      ? 'resolved'
+      : (queueState === 'blocked' ? 'inconclusive' : 'active'),
+  };
+}
+
+export function sortMissionExecutionActivationQueue(entries: MissionExecutionActivationQueueEntry[]): MissionExecutionActivationQueueEntry[] {
+  return [...entries].sort((left, right) => {
+    const byPriority = priorityRank(right.priority) - priorityRank(left.priority);
+    if (byPriority !== 0) {
+      return byPriority;
+    }
+    return left.executionActivationRecordId.localeCompare(right.executionActivationRecordId);
+  });
+}

--- a/control-plane/mission-control/mission-execution-activation-types.ts
+++ b/control-plane/mission-control/mission-execution-activation-types.ts
@@ -1,0 +1,193 @@
+export const EXECUTION_ACTIVATION_RECORD_STATES = [
+  'created',
+  'queued',
+  'submitted',
+  'active',
+  'deferred',
+  'completed',
+  'failed',
+  'inconclusive',
+] as const;
+
+export const EXECUTION_REQUEST_ACTIVATION_MAPPING_STATES = [
+  'active',
+  'deprecated',
+] as const;
+
+export const EXECUTION_ACTIVATION_ELIGIBILITY_VALUES = [
+  'not_eligible',
+  'conditionally_eligible',
+  'eligible',
+  'blocked_from_activation',
+  'inconclusive',
+] as const;
+
+export const EXECUTION_ACTIVATION_STATUS_VALUES = [
+  'not_started',
+  'pending_activation',
+  'handoff_submitted',
+  'activation_active',
+  'activation_completed',
+  'activation_failed',
+  'activation_deferred',
+  'inconclusive',
+] as const;
+
+export const EXECUTION_ACTIVATION_OUTCOME_VALUES = [
+  'pending',
+  'submitted',
+  'active',
+  'partially_completed',
+  'completed',
+  'failed',
+  'deferred',
+  'inconclusive',
+] as const;
+
+export const MISSION_EXECUTION_ACTIVATION_QUEUE_STATES = [
+  'queued',
+  'awaiting_handoff',
+  'handoff_submitted',
+  'under_activation',
+  'deferred',
+  'closed',
+  'blocked',
+] as const;
+
+export const EXECUTION_ACTIVATION_FEEDBACK_CLASSES = [
+  'handoff_submitted',
+  'execution_started',
+  'execution_completed',
+  'execution_failed',
+  'execution_blocked',
+  'execution_inconclusive',
+] as const;
+
+export const EXECUTION_ACTIVATION_FEEDBACK_STATES = [
+  'linked',
+  'processed',
+] as const;
+
+export const EXECUTION_ACTIVATION_RULES = [
+  'standard_task_activation',
+  'monitoring_activation',
+  'review_activation',
+  'stabilization_followup_activation',
+] as const;
+
+export const EXECUTION_ACTIVATION_HISTORY_EVENT_TYPES = [
+  'execution_activation_record_created',
+  'execution_activation_eligibility_evaluated',
+  'execution_activation_queued',
+  'execution_activation_handoff_submitted',
+  'execution_activation_feedback_linked',
+  'execution_activation_deferred',
+  'execution_activation_completed',
+  'execution_activation_failed',
+  'mission_execution_activation_materialized',
+] as const;
+
+export type ExecutionActivationRecordState = typeof EXECUTION_ACTIVATION_RECORD_STATES[number];
+export type ExecutionRequestActivationMappingState = typeof EXECUTION_REQUEST_ACTIVATION_MAPPING_STATES[number];
+export type ExecutionActivationEligibilityValue = typeof EXECUTION_ACTIVATION_ELIGIBILITY_VALUES[number];
+export type ExecutionActivationStatus = typeof EXECUTION_ACTIVATION_STATUS_VALUES[number];
+export type ExecutionActivationOutcomeValue = typeof EXECUTION_ACTIVATION_OUTCOME_VALUES[number];
+export type MissionExecutionActivationQueueState = typeof MISSION_EXECUTION_ACTIVATION_QUEUE_STATES[number];
+export type ExecutionActivationFeedbackClass = typeof EXECUTION_ACTIVATION_FEEDBACK_CLASSES[number];
+export type ExecutionActivationFeedbackState = typeof EXECUTION_ACTIVATION_FEEDBACK_STATES[number];
+export type ExecutionActivationRule = typeof EXECUTION_ACTIVATION_RULES[number];
+export type ExecutionActivationHistoryEventType = typeof EXECUTION_ACTIVATION_HISTORY_EVENT_TYPES[number];
+
+export interface ExecutionActivationRecord {
+  executionActivationRecordId: string;
+  executionRequestRecordId: string;
+  missionExecutionCoordinationPlanId: string;
+  executionIntentId: string;
+  targetExecutionDomain: string;
+  priority: string;
+  state: ExecutionActivationRecordState;
+  outcome: ExecutionActivationOutcomeValue;
+}
+
+export interface ExecutionRequestActivationMapping {
+  executionRequestActivationMappingId: string;
+  executionRequestRecordId: string;
+  executionActivationRecordId: string;
+  activationRule: ExecutionActivationRule;
+  reasonTokens: string[];
+  state: ExecutionRequestActivationMappingState;
+}
+
+export interface ExecutionActivationEligibility {
+  executionActivationEligibilityId: string;
+  executionRequestRecordId: string;
+  eligibilityStatus: ExecutionActivationEligibilityValue;
+  reasonTokens: string[];
+  blockingConditionTokens: string[];
+  state: 'active' | 'resolved' | 'inconclusive';
+}
+
+export interface MissionExecutionActivationQueueEntry {
+  missionExecutionActivationQueueEntryId: string;
+  executionActivationRecordId: string;
+  priority: string;
+  queueState: MissionExecutionActivationQueueState;
+  reasonTokens: string[];
+  state: 'active' | 'resolved' | 'inconclusive';
+}
+
+export interface ExecutionActivationFeedbackLink {
+  executionActivationFeedbackLinkId: string;
+  executionActivationRecordId: string;
+  executionRequestRecordId: string;
+  executionAttemptId: string | null;
+  taskExecutionRunId: string | null;
+  workerResultId: string | null;
+  feedbackClass: ExecutionActivationFeedbackClass;
+  state: ExecutionActivationFeedbackState;
+}
+
+export interface ExecutionActivationStatusRecord {
+  executionActivationRecordId: string;
+  status: ExecutionActivationStatus;
+  reasonTokens: string[];
+}
+
+export interface ExecutionActivationOutcome {
+  executionActivationRecordId: string;
+  outcome: ExecutionActivationOutcomeValue;
+  reasonTokens: string[];
+}
+
+export interface ExecutionActivationHistoryEvent {
+  executionActivationRecordId: string;
+  eventType: ExecutionActivationHistoryEventType;
+  eventDedupeKey: string;
+  reasonTokens: string[];
+  payload: Record<string, unknown>;
+}
+
+export interface ExecutionActivationHistory {
+  executionActivationRecordId: string;
+  entries: ExecutionActivationHistoryEvent[];
+}
+
+export interface MissionExecutionActivationProjection {
+  executionActivationRecordId: string;
+  executionRequestRecordId: string;
+  missionExecutionCoordinationPlanId: string;
+  eligibilityStatus: ExecutionActivationEligibilityValue;
+  queueState: MissionExecutionActivationQueueState | null;
+  feedbackLinkSummaries: ExecutionActivationFeedbackLink[];
+  status: ExecutionActivationStatusRecord;
+  outcome: ExecutionActivationOutcome;
+  priority: string;
+  linkedExecutionAttemptIds: string[];
+  activationHistory: ExecutionActivationHistory;
+  activationRecord: ExecutionActivationRecord;
+  mapping: ExecutionRequestActivationMapping;
+  eligibility: ExecutionActivationEligibility;
+  queueEntry: MissionExecutionActivationQueueEntry | null;
+  statusPreview: Record<string, unknown>;
+  reportPreview: Record<string, unknown>;
+}

--- a/docs/architecture/controlled-execution-handoff-and-activation.md
+++ b/docs/architecture/controlled-execution-handoff-and-activation.md
@@ -1,0 +1,118 @@
+# Controlled Execution Handoff and Activation
+
+## Purpose
+
+Sprint 8.1 introduces a deterministic control-plane handoff layer between mission execution coordination and runtime execution. The layer converts execution request records into explicit activation records with append-only activation history.
+
+This layer does not change runtime semantics, worker semantics, or mission execution coordination truth.
+
+## Inputs and Truth Model
+
+Activation truth is projection-derived from:
+
+- mission execution coordination projection (execution requests)
+- append-only activation history
+- explicit activation feedback links
+
+No hidden mutable "current activation state" store exists.
+
+## Deterministic Identity
+
+All semantic identifiers are derived with:
+
+- `canonicalStringify(payload)`
+- `sha256(...)`
+
+The identity payloads exclude timestamps, paths, process IDs, and environment metadata.
+
+## Core Models
+
+- `ExecutionActivationRecord`: control-plane handoff object per execution request.
+- `ExecutionRequestActivationMapping`: explainable request-to-activation rule mapping.
+- `ExecutionActivationEligibility`: bounded eligibility assessment per request.
+- `MissionExecutionActivationQueueEntry`: deterministic queue posture.
+- `ExecutionActivationFeedbackLink`: linkage from activation to runtime execution identifiers.
+- `ExecutionActivationStatusRecord`: derived status.
+- `ExecutionActivationOutcome`: derived outcome.
+- `ExecutionActivationHistory`: append-only, replay-safe history.
+
+## State Model
+
+Eligibility:
+
+- `not_eligible`
+- `conditionally_eligible`
+- `eligible`
+- `blocked_from_activation`
+- `inconclusive`
+
+Activation status:
+
+- `not_started`
+- `pending_activation`
+- `handoff_submitted`
+- `activation_active`
+- `activation_completed`
+- `activation_failed`
+- `activation_deferred`
+- `inconclusive`
+
+Activation outcome:
+
+- `pending`
+- `submitted`
+- `active`
+- `partially_completed`
+- `completed`
+- `failed`
+- `deferred`
+- `inconclusive`
+
+Queue state:
+
+- `queued`
+- `awaiting_handoff`
+- `handoff_submitted`
+- `under_activation`
+- `deferred`
+- `closed`
+- `blocked`
+
+## History Events
+
+- `execution_activation_record_created`
+- `execution_activation_eligibility_evaluated`
+- `execution_activation_queued`
+- `execution_activation_handoff_submitted`
+- `execution_activation_feedback_linked`
+- `execution_activation_deferred`
+- `execution_activation_completed`
+- `execution_activation_failed`
+- `mission_execution_activation_materialized`
+
+History dedupe is semantic, using deterministic event payload hashing.
+
+## Projection and Replay
+
+`mission-execution-activation-projection.ts` computes replay-stable activation projections for all activation records. Queue ordering is deterministic:
+
+- priority rank
+- activation record ID
+
+## Materialization
+
+Artifacts are projection outputs only and are written to:
+
+- `artifacts/mission-control/activation/<executionActivationRecordId>/`
+
+Files:
+
+- `mission-execution-activation-status.json`
+- `mission-execution-activation-mapping.json`
+- `mission-execution-activation-eligibility.json`
+- `mission-execution-activation-queue.json`
+- `mission-execution-activation-feedback-links.json`
+- `mission-execution-activation-history.json`
+- `mission-execution-activation-outcome.json`
+- `mission-execution-activation-report.json`
+- `mission-execution-activation-report.md`

--- a/docs/runbooks/controlled-execution-handoff-operations.md
+++ b/docs/runbooks/controlled-execution-handoff-operations.md
@@ -1,0 +1,89 @@
+# Controlled Execution Handoff Operations
+
+## List Activation Records
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-list.ts
+```
+
+## Inspect a Single Activation Record
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-inspect.ts --activation <activation-id>
+```
+
+## Inspect Mapping
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-mappings.ts --activation <activation-id>
+```
+
+## Inspect Eligibility
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-eligibility.ts --activation <activation-id>
+```
+
+## Inspect Queue Posture
+
+Single activation:
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-queue.ts --activation <activation-id>
+```
+
+All queue summaries:
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-queue.ts
+```
+
+## Inspect Feedback Links
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-feedback.ts --activation <activation-id>
+```
+
+## Inspect Status
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-status.ts --activation <activation-id>
+```
+
+## Inspect History
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-history.ts --activation <activation-id>
+```
+
+## Inspect Outcome
+
+Use inspect output and read `outcome`, or use materialized output file.
+
+## Materialize Activation Artifacts
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-materialize.ts --activation <activation-id>
+```
+
+## Bounded Append-Only Actions
+
+Defer activation:
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-defer.ts --activation <activation-id>
+```
+
+Mark handoff submitted:
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-mark-submitted.ts --activation <activation-id>
+```
+
+Mark activation complete:
+
+```bash
+node --experimental-strip-types control-plane/cli/mission-control-activation-mark-complete.ts --activation <activation-id>
+```
+
+All commands return JSON-only output with deterministic key ordering and stable error payloads.


### PR DESCRIPTION
Sprint 8.1 implements the deterministic controlled execution handoff and activation layer between mission execution coordination and runtime activation.

tier-3

## Summary
- add execution activation record, mapping, eligibility, queue, feedback-link, status, outcome, history, projection, inspection, materialization, and manager modules
- add activation CLI inspection/materialization/action commands
- add activation docs and runbook
- add activation unit, projection, integration, and CLI tests

## Validation
- targeted activation tests passed
- full mission-control regression passed
- npm run typecheck passed
- npm run lint passed
- npm run build passed

```evidence
npx vitest run control-plane/__tests__/mission-control/mission-execution-activation-identity.test.ts control-plane/__tests__/mission-control/mission-execution-activation-mapping.test.ts control-plane/__tests__/mission-control/mission-execution-activation-eligibility.test.ts control-plane/__tests__/mission-control/mission-execution-activation-queue.test.ts control-plane/__tests__/mission-control/mission-execution-activation-feedback-link.test.ts control-plane/__tests__/mission-control/mission-execution-activation-projection.test.ts control-plane/__tests__/mission-control/mission-execution-activation.integration.test.ts control-plane/__tests__/mission-control/mission-execution-activation-cli.test.ts
npx vitest run control-plane/__tests__/mission-control/*.test.ts
npm run typecheck
npm run lint
npm run build
```
